### PR TITLE
fix: adiciona transição InReview → NeedsChanges na state machine de cursos

### DIFF
--- a/internal/models/curso.go
+++ b/internal/models/curso.go
@@ -170,7 +170,7 @@ func (s StatusCurso) CanTransitionTo(to StatusCurso) bool {
 	allowed := map[StatusCurso][]StatusCurso{
 		StatusCursoDraft:        {StatusCursoInReview, StatusCursoPendingDeletion},
 		StatusCursoNeedsChanges: {StatusCursoInReview, StatusCursoPendingDeletion},
-		StatusCursoInReview:     {StatusCursoApproved, StatusCursoPendingDeletion},
+		StatusCursoInReview:     {StatusCursoApproved, StatusCursoNeedsChanges, StatusCursoPendingDeletion},
 		StatusCursoApproved:     {StatusCursoPublished, StatusCursoPendingDeletion},
 		StatusCursoPublished:    {StatusCursoNeedsChanges, StatusCursoPendingDeletion, StatusCursoClosed, StatusCursoCanceled},
 		StatusCursoClosed:       {StatusCursoPendingDeletion},

--- a/internal/models/curso_test.go
+++ b/internal/models/curso_test.go
@@ -101,6 +101,68 @@ func TestCourseManagementType_IsValid(t *testing.T) {
 	}
 }
 
+func TestStatusCurso_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name string
+		from models.StatusCurso
+		to   models.StatusCurso
+		want bool
+	}{
+		// draft transitions
+		{"draft → in_review", models.StatusCursoDraft, models.StatusCursoInReview, true},
+		{"draft → pending_deletion", models.StatusCursoDraft, models.StatusCursoPendingDeletion, true},
+		{"draft → approved (invalid)", models.StatusCursoDraft, models.StatusCursoApproved, false},
+		{"draft → published (invalid)", models.StatusCursoDraft, models.StatusCursoPublished, false},
+
+		// in_review transitions
+		{"in_review → approved", models.StatusCursoInReview, models.StatusCursoApproved, true},
+		{"in_review → needs_changes", models.StatusCursoInReview, models.StatusCursoNeedsChanges, true},
+		{"in_review → pending_deletion", models.StatusCursoInReview, models.StatusCursoPendingDeletion, true},
+		{"in_review → published (invalid)", models.StatusCursoInReview, models.StatusCursoPublished, false},
+		{"in_review → draft (invalid)", models.StatusCursoInReview, models.StatusCursoDraft, false},
+
+		// needs_changes transitions
+		{"needs_changes → in_review", models.StatusCursoNeedsChanges, models.StatusCursoInReview, true},
+		{"needs_changes → pending_deletion", models.StatusCursoNeedsChanges, models.StatusCursoPendingDeletion, true},
+		{"needs_changes → approved (invalid)", models.StatusCursoNeedsChanges, models.StatusCursoApproved, false},
+		{"needs_changes → published (invalid)", models.StatusCursoNeedsChanges, models.StatusCursoPublished, false},
+
+		// approved transitions
+		{"approved → published", models.StatusCursoApproved, models.StatusCursoPublished, true},
+		{"approved → pending_deletion", models.StatusCursoApproved, models.StatusCursoPendingDeletion, true},
+		{"approved → in_review (invalid)", models.StatusCursoApproved, models.StatusCursoInReview, false},
+
+		// published transitions
+		{"published → needs_changes", models.StatusCursoPublished, models.StatusCursoNeedsChanges, true},
+		{"published → pending_deletion", models.StatusCursoPublished, models.StatusCursoPendingDeletion, true},
+		{"published → closed", models.StatusCursoPublished, models.StatusCursoClosed, true},
+		{"published → canceled", models.StatusCursoPublished, models.StatusCursoCanceled, true},
+		{"published → draft (invalid)", models.StatusCursoPublished, models.StatusCursoDraft, false},
+
+		// closed transitions
+		{"closed → pending_deletion", models.StatusCursoClosed, models.StatusCursoPendingDeletion, true},
+		{"closed → published (invalid)", models.StatusCursoClosed, models.StatusCursoPublished, false},
+
+		// canceled transitions
+		{"canceled → pending_deletion", models.StatusCursoCanceled, models.StatusCursoPendingDeletion, true},
+		{"canceled → published (invalid)", models.StatusCursoCanceled, models.StatusCursoPublished, false},
+
+		// legacy status normalization
+		{"CRIADO (draft) → in_review", models.StatusCursoCriado, models.StatusCursoInReview, true},
+		{"ABERTO (published) → needs_changes", models.StatusCursoAberto, models.StatusCursoNeedsChanges, true},
+		{"ENCERRADO (closed) → pending_deletion", models.StatusCursoEncerrado, models.StatusCursoPendingDeletion, true},
+		{"ABERTO (published) → draft (invalid)", models.StatusCursoAberto, models.StatusCursoDraft, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.from.CanTransitionTo(tt.to); got != tt.want {
+				t.Errorf("StatusCurso(%q).CanTransitionTo(%q) = %v, want %v", tt.from, tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCurso_TableName(t *testing.T) {
 	curso := &models.Curso{}
 	if got := curso.TableName(); got != "cursos" {


### PR DESCRIPTION
## Summary

- O endpoint `request-changes` retornava **409 Conflict** com a mensagem _"curso não está em estado válido para solicitação de edição"_
- A causa era a ausência da transição `StatusCursoInReview → StatusCursoNeedsChanges` no mapa `CanTransitionTo` em `internal/models/curso.go`
- Fix: adicionado `StatusCursoNeedsChanges` no slice de transições permitidas para `StatusCursoInReview`

## Test plan

- [ ] `just build` passa sem erros
- [ ] `just test` passa sem falhas
- [ ] Testar manualmente o endpoint `request-changes` em staging com um curso no estado `in_review` — deve retornar 200 ao invés de 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)