### PR TITLE
fix: cursos com opened legado derivam status dinâmico corretamente (PREF-9)

### DIFF
--- a/internal/db/migrations/064_normalize_opened_to_published.sql
+++ b/internal/db/migrations/064_normalize_opened_to_published.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Courses with legacy "opened" status are semantically equivalent to "published".
+-- DeriveStatus already normalizes "opened" -> "published" at read time, but only
+-- after this migration runs will courses without recent writes show derived statuses
+-- (scheduled, accepting_enrollments, in_progress, finished) correctly.
+UPDATE cursos SET status = 'published' WHERE status = 'opened';
+
+-- +goose Down
+-- Intentionally empty: reverting would incorrectly overwrite legitimately published
+-- courses back to the legacy "opened" value.

--- a/internal/models/curso.go
+++ b/internal/models/curso.go
@@ -259,7 +259,7 @@ func (f FormatoAula) Normalize() FormatoAula {
 // dates. Returns the derived status without mutating the receiver. Non-published courses return
 // their current status unchanged.
 func (c *Curso) DeriveStatus(now time.Time) StatusCurso {
-	if c.Status != StatusCursoPublished {
+	if c.Status.Normalize() != StatusCursoPublished {
 		return c.Status
 	}
 

--- a/internal/models/curso_test.go
+++ b/internal/models/curso_test.go
@@ -264,6 +264,21 @@ func TestCurso_DeriveStatus(t *testing.T) {
 			want:  models.StatusCursoPublished,
 		},
 		{
+			name: "opened (legacy) with past class dates derives finished",
+			curso: models.Curso{
+				Status:              models.StatusCursoOpened,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(past.Add(5 * 24 * time.Hour)),
+				Modalidade:          models.ModalidadePresencial,
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{
+						{ClassStartDate: classStart, ClassEndDate: classEndPast},
+					}},
+				},
+			},
+			want: models.StatusCursoFinished,
+		},
+		{
 			name: "remote class in_progress",
 			curso: models.Curso{
 				Status:              models.StatusCursoPublished,


### PR DESCRIPTION
## Summary

- `DeriveStatus` agora usa `.Normalize()` antes de checar o status, tratando `opened` como alias de `published` também em leituras — sem precisar de um write para acionar a derivação
- Migration `064` converte todos os cursos com `opened` no banco para `published`, resolvendo o caso raiz de uma vez
- Teste novo cobre o cenário: curso `opened` com datas de aula passadas → deriva `finished`

## Contexto

Após o refactor de status (PR #77), cursos publicados antes do refactor continuavam com `opened` no banco. A derivação dinâmica (`scheduled`, `accepting_enrollments`, `in_progress`, `finished`) só era acionada para cursos com `published` no banco. Qualquer write no curso atualizava `opened → published` e a derivação passava a funcionar — mas cursos sem write recente continuavam mostrando `opened` em vez do status derivado.

Reportado pelo Lucas Tavares no PREF-9: https://iplanrio-pcrj.atlassian.net/browse/PREF-9?focusedCommentId=159810

## Test plan

- [ ] Build e unit tests passando (`go build ./...`, `go test ./internal/models/...`)
- [ ] Deploy em staging e validar curso 2258 em https://admin.staging.app.dados.rio/gorio/courses/course/2258 — deve mostrar `finished`
- [ ] Confirmar que cursos com outros status (draft, in_review, closed, etc.) não são afetados pela migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)