### PR TITLE
fix: rejeitar troca de turma quando curso possui apenas uma turma (PREF-60)

### DIFF
--- a/internal/services/inscricao_service.go
+++ b/internal/services/inscricao_service.go
@@ -488,6 +488,18 @@ func (s *InscricaoService) UpdateInscricao(ctx context.Context, id uuid.UUID, cu
 	return s.repo.Update(ctx, inscricao)
 }
 
+// countCourseSchedules returns the total number of schedules across all location classes and remote class
+func countCourseSchedules(curso *models.Curso) int {
+	count := 0
+	for _, loc := range curso.LocationClasses {
+		count += len(loc.Schedules)
+	}
+	if curso.RemoteClass != nil {
+		count += len(curso.RemoteClass.Schedules)
+	}
+	return count
+}
+
 // findScheduleVacancies returns the vacancy limit for a schedule within a course
 func (s *InscricaoService) findScheduleVacancies(scheduleID uuid.UUID, curso *models.Curso) int {
 	for _, location := range curso.LocationClasses {
@@ -669,6 +681,18 @@ func (s *InscricaoService) ChangeSchedule(ctx context.Context, inscricaoID uuid.
 	// Validate status - cannot change if cancelled or concluded
 	if inscricao.Status == models.StatusInscricaoCancelled || inscricao.Status == models.StatusInscricaoConcluded {
 		return nil, fmt.Errorf("não é possível trocar de turma para inscrições com status '%s'", inscricao.Status)
+	}
+
+	// Validate that the course has more than one schedule
+	curso, err := s.cursoRepo.GetByID(ctx, inscricao.CursoID)
+	if err != nil {
+		return nil, fmt.Errorf("erro ao buscar curso: %w", err)
+	}
+	if curso == nil {
+		return nil, fmt.Errorf("curso não encontrado")
+	}
+	if countCourseSchedules(curso) <= 1 {
+		return nil, fmt.Errorf("não é possível trocar de turma: este curso possui apenas uma turma disponível")
 	}
 
 	// Get schedule deadline hours from config (default 48)

--- a/internal/services/inscricao_service_test.go
+++ b/internal/services/inscricao_service_test.go
@@ -1842,6 +1842,14 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{
 					newScheduleID: 5, // 5 enrolled, has space
@@ -1966,7 +1974,16 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 			},
 		}
 
-		cursoRepo := &MockCursoRepository{}
+		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
+		}
 
 		// Class starts in 24 hours, but deadline is 48 hours
 		nearFutureDate := time.Now().Add(24 * time.Hour)
@@ -2006,6 +2023,14 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{
 					newScheduleID: 10, // Full
@@ -2062,6 +2087,14 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					RemoteClass: &models.RemoteClass{
+						Schedules: []models.RemoteSchedule{{}, {}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{
 					remoteScheduleID: 3,
@@ -2118,6 +2151,14 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{scheduleID: 0}, nil
 			},
@@ -2167,7 +2208,16 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 			},
 		}
 
-		cursoRepo := &MockCursoRepository{}
+		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
+		}
 
 		request := &models.ScheduleChangeRequest{
 			EnrolledUnit: &models.EnrolledUnit{
@@ -2204,6 +2254,14 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{scheduleID: 0}, nil
 			},
@@ -2233,6 +2291,51 @@ func TestInscricaoService_ChangeSchedule(t *testing.T) {
 		_, err := svc.ChangeSchedule(ctx, inscricaoID, "12345678900", request)
 		if err != nil {
 			t.Fatalf("ChangeSchedule should use default 48h deadline: %v", err)
+		}
+	})
+
+	t.Run("ChangeSchedule fails when course has only one schedule", func(t *testing.T) {
+		inscricaoID := uuid.New()
+
+		inscricaoRepo := &MockInscricaoRepository{
+			GetByIDFunc: func(ctx context.Context, id uuid.UUID) (*models.Inscricao, error) {
+				return &models.Inscricao{
+					ID:      inscricaoID,
+					CPF:     "12345678900",
+					CursoID: 1,
+					Status:  models.StatusInscricaoApproved,
+				}, nil
+			},
+		}
+
+		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}}},
+					},
+				}, nil
+			},
+		}
+
+		futureDate := time.Now().Add(72 * time.Hour)
+		request := &models.ScheduleChangeRequest{
+			EnrolledUnit: &models.EnrolledUnit{
+				Schedules: []models.EnrolledUnitSchedule{
+					{ClassStartDate: futureDate.Format(time.RFC3339)},
+				},
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		_, err := svc.ChangeSchedule(ctx, inscricaoID, "12345678900", request)
+		if err == nil {
+			t.Error("Expected error when course has only one schedule")
+		}
+		if err != nil && !strings.Contains(err.Error(), "apenas uma turma") {
+			t.Errorf("Expected 'apenas uma turma' error, got: %v", err)
 		}
 	})
 }
@@ -3188,6 +3291,14 @@ func TestInscricaoService_ChangeSchedule_AdditionalCases(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{scheduleID: 5}, nil
 			},
@@ -3242,6 +3353,14 @@ func TestInscricaoService_ChangeSchedule_AdditionalCases(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					RemoteClass: &models.RemoteClass{
+						Schedules: []models.RemoteSchedule{{}, {}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{scheduleID: 3}, nil
 			},
@@ -3336,6 +3455,14 @@ func TestInscricaoService_ChangeSchedule_AdditionalCases(t *testing.T) {
 		}
 
 		cursoRepo := &MockCursoRepository{
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{
+					ID: id,
+					LocationClasses: []models.LocationClass{
+						{Schedules: []models.CourseSchedule{{}, {}}},
+					},
+				}, nil
+			},
 			CountEnrollmentsByScheduleIDsFunc: func(ctx context.Context, scheduleIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
 				return map[uuid.UUID]int64{scheduleID: 5}, nil
 			},


### PR DESCRIPTION
## Summary

- Adiciona validação em `ChangeSchedule` que verifica o número total de schedules do curso (somando `LocationClasses` e `RemoteClass`) antes de permitir a troca
- Se o curso tiver apenas 1 turma, retorna erro `"não é possível trocar de turma: este curso possui apenas uma turma disponível"`
- Atualiza testes existentes de `ChangeSchedule` com `GetByIDFunc` (agora necessário na validação antecipada)
- Adiciona novo caso de teste `"ChangeSchedule fails when course has only one schedule"`

Resolve: [PREF-60](https://iplanrio-pcrj.atlassian.net/browse/PREF-60) / [PREF-30](https://iplanrio-pcrj.atlassian.net/browse/PREF-30)

## Test plan

- [ ] `just test` passa sem erros
- [ ] `just build` compila sem erros
- [ ] Testar em staging: inscrever cidadão em curso com 1 turma e tentar trocar → deve retornar 400 com mensagem de erro
- [ ] Testar em staging: inscrever cidadão em curso com 2+ turmas e trocar → deve continuar funcionando normalmente