### PR TITLE
fix: invalida cache Redis em transições de status e força orgao_id na criação

### DIFF
--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -247,6 +247,12 @@ func (h *CourseHandler) Create(c *gin.Context) {
 	// Set status to opened for published course
 	curso.Status = models.StatusCursoOpened
 
+	if middlewares.HasRole(c, "go:cursos:editor") && !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
+		if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
+			curso.OrgaoID = orgaoID
+		}
+	}
+
 	id, err := h.cursoService.Create(c.Request.Context(), &curso)
 	if err != nil {
 		// Check if it's a validation error (not a database error)
@@ -304,6 +310,12 @@ func (h *CourseHandler) CreateDraft(c *gin.Context) {
 
 	// Set status to draft
 	curso.Status = models.StatusCursoDraft
+
+	if middlewares.HasRole(c, "go:cursos:editor") && !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
+		if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
+			curso.OrgaoID = orgaoID
+		}
+	}
 
 	id, err := h.cursoService.Create(c.Request.Context(), &curso)
 	if err != nil {
@@ -943,6 +955,9 @@ func (h *CourseHandler) SendToReview(c *gin.Context) {
 		handleCursoTransitionError(c, err)
 		return
 	}
+	if h.courseCache != nil {
+		_ = h.courseCache.InvalidateAll(c.Request.Context())
+	}
 	c.JSON(http.StatusOK, gin.H{"message": "Curso enviado para revisão com sucesso"})
 }
 
@@ -955,6 +970,9 @@ func (h *CourseHandler) Approve(c *gin.Context) {
 	if err := h.cursoService.Approve(c.Request.Context(), id); err != nil {
 		handleCursoTransitionError(c, err)
 		return
+	}
+	if h.courseCache != nil {
+		_ = h.courseCache.InvalidateAll(c.Request.Context())
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "Curso aprovado e publicado com sucesso"})
 }
@@ -969,6 +987,9 @@ func (h *CourseHandler) RequestChanges(c *gin.Context) {
 		handleCursoTransitionError(c, err)
 		return
 	}
+	if h.courseCache != nil {
+		_ = h.courseCache.InvalidateAll(c.Request.Context())
+	}
 	c.JSON(http.StatusOK, gin.H{"message": "Solicitação de edição enviada com sucesso"})
 }
 
@@ -981,6 +1002,9 @@ func (h *CourseHandler) RequestDeletion(c *gin.Context) {
 	if err := h.cursoService.RequestDeletion(c.Request.Context(), id); err != nil {
 		handleCursoTransitionError(c, err)
 		return
+	}
+	if h.courseCache != nil {
+		_ = h.courseCache.InvalidateAll(c.Request.Context())
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "Solicitação de exclusão enviada com sucesso"})
 }


### PR DESCRIPTION
## Problema

Dois bugs identificados no ambiente `admin.staging`:

1. **Delay de 5 minutos nas abas de status** — após `send-to-review`, `approve`, `request-changes` ou `request-deletion`, o curso demorava até 5 minutos para aparecer na nova aba porque o cache Redis não era invalidado nessas operações (TTL = 5 min).

2. **Curso invisível para o editor após criação** — editores podiam criar cursos com `orgao_id` diferente do seu (via request body), mas as listagens filtram por `orgao_id` do JWT. Resultado: o curso existia no banco mas não aparecia para o editor.

## Solução

- `SendToReview`, `Approve`, `RequestChanges` e `RequestDeletion` agora chamam `courseCache.InvalidateAll()` após sucesso — mesmo padrão já aplicado em `Create`, `Update` e `Delete`.
- `Create` e `CreateDraft` sobrescrevem `orgao_id` com o valor extraído do JWT para editores (mesma guarda usada nas listagens: não-admin, não-casa_civil).

## Arquivos modificados

- `internal/handlers/v1/course_handler.go`