### PR TITLE
fix: corrige descrição do parâmetro cnpj no Swagger

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4783,7 +4783,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "CNPJ da empresa (com ou sem formatação)",
+                        "description": "CNPJ da empresa (apenas dígitos, 14 caracteres)",
                         "name": "cnpj",
                         "in": "path",
                         "required": true
@@ -11068,7 +11068,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "certificate_url": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 2048
                 }
             }
         },
@@ -11134,6 +11135,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "genero": {
+                    "type": "string"
+                },
+                "nome": {
                     "type": "string"
                 },
                 "nome_social": {
@@ -12272,6 +12276,15 @@ const docTemplate = `{
                 "opened",
                 "closed",
                 "canceled",
+                "in_review",
+                "needs_changes",
+                "approved",
+                "published",
+                "pending_deletion",
+                "scheduled",
+                "accepting_enrollments",
+                "in_progress",
+                "finished",
                 "CRIADO",
                 "ABERTO",
                 "ENCERRADO"
@@ -12281,6 +12294,15 @@ const docTemplate = `{
                 "StatusCursoOpened",
                 "StatusCursoClosed",
                 "StatusCursoCanceled",
+                "StatusCursoInReview",
+                "StatusCursoNeedsChanges",
+                "StatusCursoApproved",
+                "StatusCursoPublished",
+                "StatusCursoPendingDeletion",
+                "StatusCursoScheduled",
+                "StatusCursoAcceptingEnrollments",
+                "StatusCursoInProgress",
+                "StatusCursoFinished",
                 "StatusCursoCriado",
                 "StatusCursoAberto",
                 "StatusCursoEncerrado"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4781,7 +4781,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "CNPJ da empresa (com ou sem formatação)",
+                        "description": "CNPJ da empresa (apenas dígitos, 14 caracteres)",
                         "name": "cnpj",
                         "in": "path",
                         "required": true
@@ -11066,7 +11066,8 @@
             "type": "object",
             "properties": {
                 "certificate_url": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 2048
                 }
             }
         },
@@ -11132,6 +11133,9 @@
                     "type": "string"
                 },
                 "genero": {
+                    "type": "string"
+                },
+                "nome": {
                     "type": "string"
                 },
                 "nome_social": {
@@ -12270,6 +12274,15 @@
                 "opened",
                 "closed",
                 "canceled",
+                "in_review",
+                "needs_changes",
+                "approved",
+                "published",
+                "pending_deletion",
+                "scheduled",
+                "accepting_enrollments",
+                "in_progress",
+                "finished",
                 "CRIADO",
                 "ABERTO",
                 "ENCERRADO"
@@ -12279,6 +12292,15 @@
                 "StatusCursoOpened",
                 "StatusCursoClosed",
                 "StatusCursoCanceled",
+                "StatusCursoInReview",
+                "StatusCursoNeedsChanges",
+                "StatusCursoApproved",
+                "StatusCursoPublished",
+                "StatusCursoPendingDeletion",
+                "StatusCursoScheduled",
+                "StatusCursoAcceptingEnrollments",
+                "StatusCursoInProgress",
+                "StatusCursoFinished",
                 "StatusCursoCriado",
                 "StatusCursoAberto",
                 "StatusCursoEncerrado"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -605,6 +605,7 @@ definitions:
   models.CertificateUpdateRequest:
     properties:
       certificate_url:
+        maxLength: 2048
         type: string
     type: object
   models.CertificateUpdateResponse:
@@ -648,6 +649,8 @@ definitions:
       escolaridade:
         type: string
       genero:
+        type: string
+      nome:
         type: string
       nome_social:
         type: string
@@ -1432,6 +1435,15 @@ definitions:
     - opened
     - closed
     - canceled
+    - in_review
+    - needs_changes
+    - approved
+    - published
+    - pending_deletion
+    - scheduled
+    - accepting_enrollments
+    - in_progress
+    - finished
     - CRIADO
     - ABERTO
     - ENCERRADO
@@ -1441,6 +1453,15 @@ definitions:
     - StatusCursoOpened
     - StatusCursoClosed
     - StatusCursoCanceled
+    - StatusCursoInReview
+    - StatusCursoNeedsChanges
+    - StatusCursoApproved
+    - StatusCursoPublished
+    - StatusCursoPendingDeletion
+    - StatusCursoScheduled
+    - StatusCursoAcceptingEnrollments
+    - StatusCursoInProgress
+    - StatusCursoFinished
     - StatusCursoCriado
     - StatusCursoAberto
     - StatusCursoEncerrado
@@ -4807,7 +4828,7 @@ paths:
       description: Consulta dados de uma empresa pelo CNPJ no RMI (Registro Mercantil
         Integrado)
       parameters:
-      - description: CNPJ da empresa (com ou sem formatação)
+      - description: CNPJ da empresa (apenas dígitos, 14 caracteres)
         in: path
         name: cnpj
         required: true

--- a/internal/handlers/v1/empregabilidade/empresa_handler.go
+++ b/internal/handlers/v1/empregabilidade/empresa_handler.go
@@ -174,7 +174,7 @@ func (h *EmpresaHandler) Delete(c *gin.Context) {
 // @Description  Consulta dados de uma empresa pelo CNPJ no RMI (Registro Mercantil Integrado)
 // @Tags         empregabilidade-empresas
 // @Produce      json
-// @Param        cnpj   path      string  true  "CNPJ da empresa (com ou sem formatação)"
+// @Param        cnpj   path      string  true  "CNPJ da empresa (apenas dígitos, 14 caracteres)"
 // @Success      200    {object}  models.LegalEntityConsultaResponse
 // @Failure      400    {object}  map[string]string
 // @Failure      404    {object}  map[string]string


### PR DESCRIPTION
## Problema

O Swagger documentava o parâmetro `cnpj` como "com ou sem formatação", mas CNPJ com barra (`61.800.993/0001-70`) não funciona como path param: o ingress (nginx/Istio) normaliza `%2F` → `/` antes de rotear, resultando em 404 antes de chegar no Gin.

## Fix

Atualiza a descrição do `@Param` para "apenas dígitos, 14 caracteres" e regenera os docs do Swagger.

Relacionado ao fix de acesso do `app-go-api` ao RMI via service account (prefeitura-rio/app-rmi#55).