### PR TITLE
fix: onlyWithCourses usa status como critério de curso aberto

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -386,7 +386,7 @@ const docTemplate = `{
         },
         "/api/v1/categorias": {
             "get": {
-                "description": "Retorna lista paginada de categorias. Use onlyWithCourses=true para filtrar apenas categorias com cursos abertos, visíveis e com inscrições dentro do período de tolerância.",
+                "description": "Retorna lista paginada de categorias. Use onlyWithCourses=true para filtrar apenas categorias com cursos com status aberto (opened/ABERTO).",
                 "produces": [
                     "application/json"
                 ],
@@ -11068,7 +11068,8 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "certificate_url": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 2048
                 }
             }
         },
@@ -11134,6 +11135,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "genero": {
+                    "type": "string"
+                },
+                "nome": {
                     "type": "string"
                 },
                 "nome_social": {
@@ -12272,6 +12276,15 @@ const docTemplate = `{
                 "opened",
                 "closed",
                 "canceled",
+                "in_review",
+                "needs_changes",
+                "approved",
+                "published",
+                "pending_deletion",
+                "scheduled",
+                "accepting_enrollments",
+                "in_progress",
+                "finished",
                 "CRIADO",
                 "ABERTO",
                 "ENCERRADO"
@@ -12281,6 +12294,15 @@ const docTemplate = `{
                 "StatusCursoOpened",
                 "StatusCursoClosed",
                 "StatusCursoCanceled",
+                "StatusCursoInReview",
+                "StatusCursoNeedsChanges",
+                "StatusCursoApproved",
+                "StatusCursoPublished",
+                "StatusCursoPendingDeletion",
+                "StatusCursoScheduled",
+                "StatusCursoAcceptingEnrollments",
+                "StatusCursoInProgress",
+                "StatusCursoFinished",
                 "StatusCursoCriado",
                 "StatusCursoAberto",
                 "StatusCursoEncerrado"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -384,7 +384,7 @@
         },
         "/api/v1/categorias": {
             "get": {
-                "description": "Retorna lista paginada de categorias. Use onlyWithCourses=true para filtrar apenas categorias com cursos abertos, visíveis e com inscrições dentro do período de tolerância.",
+                "description": "Retorna lista paginada de categorias. Use onlyWithCourses=true para filtrar apenas categorias com cursos com status aberto (opened/ABERTO).",
                 "produces": [
                     "application/json"
                 ],
@@ -11066,7 +11066,8 @@
             "type": "object",
             "properties": {
                 "certificate_url": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 2048
                 }
             }
         },
@@ -11132,6 +11133,9 @@
                     "type": "string"
                 },
                 "genero": {
+                    "type": "string"
+                },
+                "nome": {
                     "type": "string"
                 },
                 "nome_social": {
@@ -12270,6 +12274,15 @@
                 "opened",
                 "closed",
                 "canceled",
+                "in_review",
+                "needs_changes",
+                "approved",
+                "published",
+                "pending_deletion",
+                "scheduled",
+                "accepting_enrollments",
+                "in_progress",
+                "finished",
                 "CRIADO",
                 "ABERTO",
                 "ENCERRADO"
@@ -12279,6 +12292,15 @@
                 "StatusCursoOpened",
                 "StatusCursoClosed",
                 "StatusCursoCanceled",
+                "StatusCursoInReview",
+                "StatusCursoNeedsChanges",
+                "StatusCursoApproved",
+                "StatusCursoPublished",
+                "StatusCursoPendingDeletion",
+                "StatusCursoScheduled",
+                "StatusCursoAcceptingEnrollments",
+                "StatusCursoInProgress",
+                "StatusCursoFinished",
                 "StatusCursoCriado",
                 "StatusCursoAberto",
                 "StatusCursoEncerrado"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -605,6 +605,7 @@ definitions:
   models.CertificateUpdateRequest:
     properties:
       certificate_url:
+        maxLength: 2048
         type: string
     type: object
   models.CertificateUpdateResponse:
@@ -648,6 +649,8 @@ definitions:
       escolaridade:
         type: string
       genero:
+        type: string
+      nome:
         type: string
       nome_social:
         type: string
@@ -1432,6 +1435,15 @@ definitions:
     - opened
     - closed
     - canceled
+    - in_review
+    - needs_changes
+    - approved
+    - published
+    - pending_deletion
+    - scheduled
+    - accepting_enrollments
+    - in_progress
+    - finished
     - CRIADO
     - ABERTO
     - ENCERRADO
@@ -1441,6 +1453,15 @@ definitions:
     - StatusCursoOpened
     - StatusCursoClosed
     - StatusCursoCanceled
+    - StatusCursoInReview
+    - StatusCursoNeedsChanges
+    - StatusCursoApproved
+    - StatusCursoPublished
+    - StatusCursoPendingDeletion
+    - StatusCursoScheduled
+    - StatusCursoAcceptingEnrollments
+    - StatusCursoInProgress
+    - StatusCursoFinished
     - StatusCursoCriado
     - StatusCursoAberto
     - StatusCursoEncerrado
@@ -1782,8 +1803,7 @@ paths:
   /api/v1/categorias:
     get:
       description: Retorna lista paginada de categorias. Use onlyWithCourses=true
-        para filtrar apenas categorias com cursos abertos, visíveis e com inscrições
-        dentro do período de tolerância.
+        para filtrar apenas categorias com cursos com status aberto (opened/ABERTO).
       parameters:
       - description: 'Número da página (default: 1)'
         in: query

--- a/internal/handlers/v1/categoria_handler.go
+++ b/internal/handlers/v1/categoria_handler.go
@@ -44,7 +44,7 @@ func (h *CategoriaHandler) Create(c *gin.Context) {
 }
 
 // @Summary      Listar categorias
-// @Description  Retorna lista paginada de categorias. Use onlyWithCourses=true para filtrar apenas categorias com cursos abertos, visíveis e com inscrições dentro do período de tolerância.
+// @Description  Retorna lista paginada de categorias. Use onlyWithCourses=true para filtrar apenas categorias com cursos com status aberto (opened/ABERTO).
 // @Tags         categorias
 // @Produce      json
 // @Param        page            query     int   false  "Número da página (default: 1)"

--- a/internal/repository/categoria_repository.go
+++ b/internal/repository/categoria_repository.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"gorm.io/gorm"
 
@@ -70,9 +69,8 @@ func (r *CategoriaRepository) List(ctx context.Context, filter map[string]interf
 
 	db := r.db.WithContext(ctx).Model(&models.Categoria{})
 
-	if daysTolerance, ok := filter["days_tolerance"].(int); ok {
+	if _, ok := filter["days_tolerance"]; ok {
 		delete(filter, "days_tolerance")
-		cutoffDate := time.Now().AddDate(0, 0, -daysTolerance)
 
 		isVisible := true
 		if iv, ok := filter["is_visible"].(bool); ok {
@@ -82,21 +80,19 @@ func (r *CategoriaRepository) List(ctx context.Context, filter map[string]interf
 
 		if isVisible {
 			db = db.Where(`id IN (
-				SELECT DISTINCT cc.categoria_id 
-				FROM cursos_categorias cc 
-				INNER JOIN cursos c ON cc.curso_id = c.id 
+				SELECT DISTINCT cc.categoria_id
+				FROM cursos_categorias cc
+				INNER JOIN cursos c ON cc.curso_id = c.id
 				WHERE c.status IN ('opened', 'ABERTO')
 				AND (c.is_visible = true OR c.is_visible IS NULL)
-				AND c.enrollment_end_date >= ?
-			)`, cutoffDate)
+			)`)
 		} else {
 			db = db.Where(`id IN (
-				SELECT DISTINCT cc.categoria_id 
-				FROM cursos_categorias cc 
-				INNER JOIN cursos c ON cc.curso_id = c.id 
+				SELECT DISTINCT cc.categoria_id
+				FROM cursos_categorias cc
+				INNER JOIN cursos c ON cc.curso_id = c.id
 				WHERE c.status IN ('opened', 'ABERTO')
-				AND c.enrollment_end_date >= ?
-			)`, cutoffDate)
+			)`)
 		}
 	}
 


### PR DESCRIPTION
## Problema

`GET /api/v1/categorias?onlyWithCourses=true` retornava array vazio.

### Root cause

O filtro no repositório aplicava duas condições:
```sql
WHERE c.status IN ('opened', 'ABERTO')
AND c.enrollment_end_date >= ?   -- cutoffDate = now - daysTolerance
```

Cursos novos têm `enrollment_end_date = NULL` (campo não obrigatório). Em PostgreSQL, `NULL >= date` retorna `NULL` (falso), excluindo todos os cursos do resultado.

## Fix

Remove o filtro de `enrollment_end_date` e usa apenas `c.status IN ('opened', 'ABERTO')` como critério de curso aberto — alinhado com os novos status do sistema.

```sql
-- antes
WHERE c.status IN ('opened', 'ABERTO')
AND c.enrollment_end_date >= ?

-- depois
WHERE c.status IN ('opened', 'ABERTO')
```

O parâmetro `daysTolerance` continua aceito na API para retrocompatibilidade, mas não afeta mais a query.