### PR TITLE
fix: inclui status published no filtro onlyWithCourses

### DIFF
--- a/internal/repository/categoria_repository.go
+++ b/internal/repository/categoria_repository.go
@@ -83,7 +83,7 @@ func (r *CategoriaRepository) List(ctx context.Context, filter map[string]interf
 				SELECT DISTINCT cc.categoria_id
 				FROM cursos_categorias cc
 				INNER JOIN cursos c ON cc.curso_id = c.id
-				WHERE c.status IN ('opened', 'ABERTO')
+				WHERE c.status IN ('published', 'opened', 'ABERTO')
 				AND (c.is_visible = true OR c.is_visible IS NULL)
 			)`)
 		} else {
@@ -91,7 +91,7 @@ func (r *CategoriaRepository) List(ctx context.Context, filter map[string]interf
 				SELECT DISTINCT cc.categoria_id
 				FROM cursos_categorias cc
 				INNER JOIN cursos c ON cc.curso_id = c.id
-				WHERE c.status IN ('opened', 'ABERTO')
+				WHERE c.status IN ('published', 'opened', 'ABERTO')
 			)`)
 		}
 	}


### PR DESCRIPTION
## Problema

`GET /api/v1/categorias?onlyWithCourses=true` continuava retornando array vazio mesmo após o fix anterior.

## Root cause

O banco de produção não tem cursos com status `opened` ou `ABERTO`. O status real para cursos disponíveis ao público é `published` (253 cursos em prod). O filtro nunca casava com nada:

```sql
-- antes
WHERE c.status IN ('opened', 'ABERTO')  -- zero matches em prod
```

```
 draft            │ 353
 published        │ 253  ← estes
 in_review        │  14
 needs_changes    │  11
 canceled         │   4
 pending_deletion │   3
 closed           │   1
```

## Fix

```sql
-- depois
WHERE c.status IN ('published', 'opened', 'ABERTO')
```

Adiciona `published` ao IN clause. Os valores `opened` e `ABERTO` são mantidos para retrocompatibilidade com dados legados.