### PR TITLE
fix: onlyWithCourses filtra por datas de inscrição (derived status)

### DIFF
--- a/internal/repository/categoria_repository.go
+++ b/internal/repository/categoria_repository.go
@@ -84,6 +84,8 @@ func (r *CategoriaRepository) List(ctx context.Context, filter map[string]interf
 				FROM cursos_categorias cc
 				INNER JOIN cursos c ON cc.curso_id = c.id
 				WHERE c.status IN ('published', 'opened', 'ABERTO')
+				AND (c.enrollment_start_date IS NULL OR c.enrollment_start_date <= NOW())
+				AND (c.enrollment_end_date IS NULL OR c.enrollment_end_date >= NOW())
 				AND (c.is_visible = true OR c.is_visible IS NULL)
 			)`)
 		} else {
@@ -92,6 +94,8 @@ func (r *CategoriaRepository) List(ctx context.Context, filter map[string]interf
 				FROM cursos_categorias cc
 				INNER JOIN cursos c ON cc.curso_id = c.id
 				WHERE c.status IN ('published', 'opened', 'ABERTO')
+				AND (c.enrollment_start_date IS NULL OR c.enrollment_start_date <= NOW())
+				AND (c.enrollment_end_date IS NULL OR c.enrollment_end_date >= NOW())
 			)`)
 		}
 	}


### PR DESCRIPTION
## Problema

`GET /api/v1/categorias?onlyWithCourses=true` retornava categorias com cursos encerrados (ex: categoria 18 - Carreira).

### Root cause

O modelo de status tem dois layers:
- **Stored** (persistido no DB): `published`, `draft`, `in_review`, etc.
- **Derived** (calculado em runtime pela `DeriveStatus()`): `accepting_enrollments`, `scheduled`, `in_progress`, `finished`

O filtro SQL comparava apenas o status stored, ignorando datas. Um curso `published` com `enrollment_end_date` no passado tem derived status `finished` — mas passava no filtro e sua categoria aparecia indevidamente.

**Reprodução (staging):**
```
GET /api/v1/categorias?onlyWithCourses=true&isVisible=true
→ retornava categoria 18 (Carreira)

GET /api/v1/courses?categoria_id=18
→ todos os cursos com status finished (enrollment encerrado)
```

## Fix

Adiciona condições de data ao subquery para mapear o derived status `accepting_enrollments` no SQL:

```sql
-- antes
WHERE c.status IN ('published', 'opened', 'ABERTO')

-- depois
WHERE c.status IN ('published', 'opened', 'ABERTO')
AND (c.enrollment_start_date IS NULL OR c.enrollment_start_date <= NOW())
AND (c.enrollment_end_date IS NULL OR c.enrollment_end_date >= NOW())
```

Cursos sem datas de inscrição (NULL) são tratados como abertos indefinidamente.