### PR TITLE
feat: filtro por múltiplos status no endpoint GET /api/v1/courses.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -664,7 +664,7 @@ const docTemplate = `{
         },
         "/api/v1/courses": {
             "get": {
-                "description": "Retorna lista paginada de cursos criados (status: \"opened\", \"closed\", \"canceled\")",
+                "description": "Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
                 "produces": [
                     "application/json"
                 ],
@@ -687,7 +687,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filtrar por status",
+                        "description": "Filtrar por status (CSV, ex: draft,published,in_review)",
                         "name": "status",
                         "in": "query"
                     },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -662,7 +662,7 @@
         },
         "/api/v1/courses": {
             "get": {
-                "description": "Retorna lista paginada de cursos criados (status: \"opened\", \"closed\", \"canceled\")",
+                "description": "Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
                 "produces": [
                     "application/json"
                 ],
@@ -685,7 +685,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filtrar por status",
+                        "description": "Filtrar por status (CSV, ex: draft,published,in_review)",
                         "name": "status",
                         "in": "query"
                     },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1986,8 +1986,9 @@ paths:
       - categorias
   /api/v1/courses:
     get:
-      description: 'Retorna lista paginada de cursos criados (status: "opened", "closed",
-        "canceled")'
+      description: 'Retorna lista paginada de cursos. Sem status: exclui rascunhos.
+        Com status: filtra pelos status informados (CSV). Derived statuses (scheduled,
+        accepting_enrollments, in_progress, finished) são mapeados para published.'
       parameters:
       - description: 'Número da página (default: 1)'
         in: query
@@ -1997,7 +1998,7 @@ paths:
         in: query
         name: limit
         type: integer
-      - description: Filtrar por status
+      - description: 'Filtrar por status (CSV, ex: draft,published,in_review)'
         in: query
         name: status
         type: string

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -481,13 +481,45 @@ func (h *CourseHandler) Update(c *gin.Context) {
 	})
 }
 
+func parseStatusFilter(param string) []string {
+	derivedToStored := map[string]string{
+		"scheduled":             "published",
+		"accepting_enrollments": "published",
+		"in_progress":           "published",
+		"finished":              "published",
+	}
+	validStored := map[string]bool{
+		"draft": true, "opened": true, "closed": true, "canceled": true,
+		"in_review": true, "needs_changes": true, "approved": true,
+		"published": true, "pending_deletion": true,
+		"CRIADO": true, "ABERTO": true, "ENCERRADO": true,
+	}
+
+	seen := map[string]bool{}
+	var result []string
+	for _, s := range strings.Split(param, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if stored, ok := derivedToStored[s]; ok {
+			s = stored
+		}
+		if validStored[s] && !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 // @Summary      Listar cursos criados
-// @Description  Retorna lista paginada de cursos criados (status: "opened", "closed", "canceled")
+// @Description  Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.
 // @Tags         courses
 // @Produce      json
 // @Param        page              query     int     false  "Número da página (default: 1)"
 // @Param        limit             query     int     false  "Tamanho da página (default: 10)"
-// @Param        status            query     string  false  "Filtrar por status"
+// @Param        status            query     string  false  "Filtrar por status (CSV, ex: draft,published,in_review)"
 // @Param        modalidade        query     string  false  "Filtrar por modalidade"
 // @Param        organization      query     string  false  "Filtrar por organização (provedor do curso)"
 // @Param        search            query     string  false  "Buscar no título"
@@ -509,9 +541,16 @@ func (h *CourseHandler) List(c *gin.Context) {
 		limit = 10
 	}
 
-	// Build filters - exclude drafts
-	filter := map[string]interface{}{
-		"status NOT": models.StatusCursoDraft,
+	filter := map[string]interface{}{}
+
+	if statusParam := c.Query("status"); statusParam != "" {
+		if statuses := parseStatusFilter(statusParam); len(statuses) > 0 {
+			filter["status IN"] = statuses
+		} else {
+			filter["status NOT"] = models.StatusCursoDraft
+		}
+	} else {
+		filter["status NOT"] = models.StatusCursoDraft
 	}
 
 	// Secretaria-level filter: go:cursos:editor sees only their own orgao
@@ -519,11 +558,6 @@ func (h *CourseHandler) List(c *gin.Context) {
 		if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
 			filter["orgao_id"] = orgaoID
 		}
-	}
-
-	// Add additional filters
-	if status := c.Query("status"); status != "" {
-		filter["status"] = status
 	}
 
 	if modalidade := c.Query("modalidade"); modalidade != "" {

--- a/internal/handlers/v1/course_handler_test.go
+++ b/internal/handlers/v1/course_handler_test.go
@@ -1158,10 +1158,10 @@ func TestCourseHandler_List_WithFilters(t *testing.T) {
 	}
 
 	mockService.On("List", mock.Anything, mock.MatchedBy(func(filter map[string]interface{}) bool {
-		// Handler automatically adds "status NOT": draft to exclude drafts
 		_, hasStatusNot := filter["status NOT"]
-		statusVal, hasStatus := filter["status"]
-		return hasStatus && hasStatusNot && statusVal == "opened"
+		statusIn, hasStatusIn := filter["status IN"]
+		statuses, _ := statusIn.([]string)
+		return hasStatusIn && !hasStatusNot && len(statuses) == 1 && statuses[0] == "opened"
 	}), 1, 10).Return(cursos, 1, nil)
 	mockRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).Return(make(map[uuid.UUID]int64), nil)
 
@@ -2037,9 +2037,10 @@ func TestCourseHandler_List_MultipleFilters(t *testing.T) {
 	}
 
 	mockService.On("List", mock.Anything, mock.MatchedBy(func(filter map[string]interface{}) bool {
+		statusIn, _ := filter["status IN"].([]string)
 		return filter["modalidade"] == "presencial" &&
 			filter["organization"] == "test-org" &&
-			filter["status"] == "opened" &&
+			len(statusIn) == 1 && statusIn[0] == "opened" &&
 			filter["categoria_id"] == 5 &&
 			filter["acessibilidade_id"] == 3 &&
 			filter["neighborhood_zone"] == "norte"
@@ -2918,6 +2919,104 @@ func TestCourseHandler_RequestChanges(t *testing.T) {
 		r.ServeHTTP(w, httptest.NewRequest("PUT", "/courses/4/request-changes", nil))
 		assert.Equal(t, http.StatusConflict, w.Code)
 		mockService.AssertExpectations(t)
+	})
+}
+
+func TestCourseHandler_List_StatusFilter(t *testing.T) {
+	setup := func() (*MockCursoService, *MockCursoRepositoryForCourseHandler, *gin.Engine) {
+		gin.SetMode(gin.TestMode)
+		svc := new(MockCursoService)
+		repo := new(MockCursoRepositoryForCourseHandler)
+		h := v1.NewCourseHandler(svc, new(MockInscricaoServiceForCourse), repo)
+		r := gin.New()
+		r.GET("/api/v1/courses", h.List)
+		repo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).Return(make(map[uuid.UUID]int64), nil)
+		return svc, repo, r
+	}
+
+	t.Run("no status param uses default exclude-draft filter", func(t *testing.T) {
+		svc, _, r := setup()
+		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
+			_, hasNot := f["status NOT"]
+			_, hasIn := f["status IN"]
+			return hasNot && !hasIn
+		}), 1, 10).Return([]*models.Curso{}, 0, nil)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/courses", nil))
+		assert.Equal(t, http.StatusOK, w.Code)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("single stored status uses status IN without status NOT", func(t *testing.T) {
+		svc, _, r := setup()
+		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
+			statuses, _ := f["status IN"].([]string)
+			_, hasNot := f["status NOT"]
+			return len(statuses) == 1 && statuses[0] == "draft" && !hasNot
+		}), 1, 10).Return([]*models.Curso{}, 0, nil)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/courses?status=draft", nil))
+		assert.Equal(t, http.StatusOK, w.Code)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("multiple stored statuses produce IN with all values", func(t *testing.T) {
+		svc, _, r := setup()
+		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
+			statuses, _ := f["status IN"].([]string)
+			has := func(s string) bool {
+				for _, v := range statuses { if v == s { return true } }
+				return false
+			}
+			return len(statuses) == 2 && has("draft") && has("in_review")
+		}), 1, 10).Return([]*models.Curso{}, 0, nil)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/courses?status=draft,in_review", nil))
+		assert.Equal(t, http.StatusOK, w.Code)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("derived statuses map to published", func(t *testing.T) {
+		svc, _, r := setup()
+		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
+			statuses, _ := f["status IN"].([]string)
+			return len(statuses) == 1 && statuses[0] == "published"
+		}), 1, 10).Return([]*models.Curso{}, 0, nil)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/courses?status=accepting_enrollments,scheduled,in_progress,finished", nil))
+		assert.Equal(t, http.StatusOK, w.Code)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("all invalid statuses fall back to default exclude-draft", func(t *testing.T) {
+		svc, _, r := setup()
+		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
+			_, hasNot := f["status NOT"]
+			_, hasIn := f["status IN"]
+			return hasNot && !hasIn
+		}), 1, 10).Return([]*models.Curso{}, 0, nil)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/courses?status=invalid1,invalid2", nil))
+		assert.Equal(t, http.StatusOK, w.Code)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("duplicates are deduplicated", func(t *testing.T) {
+		svc, _, r := setup()
+		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
+			statuses, _ := f["status IN"].([]string)
+			return len(statuses) == 1 && statuses[0] == "published"
+		}), 1, 10).Return([]*models.Curso{}, 0, nil)
+
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/courses?status=published,published,finished", nil))
+		assert.Equal(t, http.StatusOK, w.Code)
+		svc.AssertExpectations(t)
 	})
 }
 

--- a/internal/repository/curso_repository.go
+++ b/internal/repository/curso_repository.go
@@ -160,6 +160,10 @@ func (r *CursoRepository) applyFilters(db *gorm.DB, filter map[string]interface{
 		switch key {
 		case "status NOT":
 			db = db.Where("status != ?", value)
+		case "status IN":
+			if statuses, ok := value.([]string); ok && len(statuses) > 0 {
+				db = db.Where("status IN ?", statuses)
+			}
 		case "title ILIKE":
 			db = db.Where("titulo ILIKE ?", value)
 		case "categoria_id":


### PR DESCRIPTION
## Problema

O portal interno lista cursos em abas separadas que requerem filtros por conjuntos específicos de status. Sem suporte a múltiplos status, o frontend fazia até **9 requests paralelos** por aba, o que quebrava a paginação real (sempre mostrava só 1 página).

## Solução

Suporte a `?status=s1,s2,...` (CSV) no endpoint `GET /api/v1/courses`.

### Comportamento

| Cenário | Resultado |
|---|---|
| Sem `status` | Comportamento atual mantido (exclui drafts) |
| `?status=draft` | `WHERE status IN ('draft')` — sem exclude-draft default |
| `?status=draft,in_review` | `WHERE status IN ('draft', 'in_review')` |
| `?status=accepting_enrollments` | Mapeado para `published` (derived → stored) |
| `?status=invalid` | Ignorado silenciosamente, cai no default |
| `?status=published,published` | Deduplicado → `IN ('published')` |

### Mapeamento de derived statuses

Derived statuses nunca são persistidos no DB — são computados de `published` + datas. O filtro os normaliza para `published`:

| Derived | Stored |
|---|---|
| `scheduled` | `published` |
| `accepting_enrollments` | `published` |
| `in_progress` | `published` |
| `finished` | `published` |

### Exemplos de uso (spec do portal)

```
# Aba "Em aprovação"
GET /api/v1/courses?status=in_review&page=1&limit=10

# Aba "Em edição"
GET /api/v1/courses?status=needs_changes&page=1&limit=10

# Aba "Rascunhos"
GET /api/v1/courses?status=draft&page=1&limit=10

# Aba "Cursos Criados"
GET /api/v1/courses?status=published,opened,closed,canceled,approved,pending_deletion,accepting_enrollments,scheduled,in_progress,finished&page=2&limit=10
```

## Arquivos alterados

- `internal/handlers/v1/course_handler.go` — `parseStatusFilter()` + nova lógica no `List`
- `internal/repository/curso_repository.go` — case `"status IN"` no `applyFilters`
- `docs/` — Swagger regenerado

## Testes

- 6 novos sub-testes em `TestCourseHandler_List_StatusFilter`
- 2 testes existentes atualizados para o novo contrato do filtro