### PR TITLE
fix: filtro por derived status aplica condições de data corretas no repositório

### DIFF
--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -482,30 +482,20 @@ func (h *CourseHandler) Update(c *gin.Context) {
 }
 
 func parseStatusFilter(param string) []string {
-	derivedToStored := map[string]string{
-		"scheduled":             "published",
-		"accepting_enrollments": "published",
-		"in_progress":           "published",
-		"finished":              "published",
-	}
-	validStored := map[string]bool{
+	validStatuses := map[string]bool{
 		"draft": true, "opened": true, "closed": true, "canceled": true,
 		"in_review": true, "needs_changes": true, "approved": true,
 		"published": true, "pending_deletion": true,
 		"CRIADO": true, "ABERTO": true, "ENCERRADO": true,
+		"scheduled": true, "accepting_enrollments": true,
+		"in_progress": true, "finished": true,
 	}
 
 	seen := map[string]bool{}
 	var result []string
 	for _, s := range strings.Split(param, ",") {
 		s = strings.TrimSpace(s)
-		if s == "" {
-			continue
-		}
-		if stored, ok := derivedToStored[s]; ok {
-			s = stored
-		}
-		if validStored[s] && !seen[s] {
+		if validStatuses[s] && !seen[s] {
 			seen[s] = true
 			result = append(result, s)
 		}

--- a/internal/handlers/v1/course_handler_test.go
+++ b/internal/handlers/v1/course_handler_test.go
@@ -2979,11 +2979,21 @@ func TestCourseHandler_List_StatusFilter(t *testing.T) {
 		svc.AssertExpectations(t)
 	})
 
-	t.Run("derived statuses map to published", func(t *testing.T) {
+	t.Run("derived statuses passed through for date-based SQL in repository", func(t *testing.T) {
 		svc, _, r := setup()
 		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
 			statuses, _ := f["status IN"].([]string)
-			return len(statuses) == 1 && statuses[0] == "published"
+			has := func(s string) bool {
+				for _, v := range statuses {
+					if v == s {
+						return true
+					}
+				}
+				return false
+			}
+			return len(statuses) == 4 &&
+				has("accepting_enrollments") && has("scheduled") &&
+				has("in_progress") && has("finished")
 		}), 1, 10).Return([]*models.Curso{}, 0, nil)
 
 		w := httptest.NewRecorder()
@@ -3010,7 +3020,15 @@ func TestCourseHandler_List_StatusFilter(t *testing.T) {
 		svc, _, r := setup()
 		svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
 			statuses, _ := f["status IN"].([]string)
-			return len(statuses) == 1 && statuses[0] == "published"
+			has := func(s string) bool {
+				for _, v := range statuses {
+					if v == s {
+						return true
+					}
+				}
+				return false
+			}
+			return len(statuses) == 2 && has("published") && has("finished")
 		}), 1, 10).Return([]*models.Curso{}, 0, nil)
 
 		w := httptest.NewRecorder()

--- a/internal/repository/curso_repository.go
+++ b/internal/repository/curso_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -162,7 +163,7 @@ func (r *CursoRepository) applyFilters(db *gorm.DB, filter map[string]interface{
 			db = db.Where("status != ?", value)
 		case "status IN":
 			if statuses, ok := value.([]string); ok && len(statuses) > 0 {
-				db = db.Where("status IN ?", statuses)
+				db = applyStatusINFilter(db, statuses)
 			}
 		case "title ILIKE":
 			db = db.Where("titulo ILIKE ?", value)
@@ -177,6 +178,33 @@ func (r *CursoRepository) applyFilters(db *gorm.DB, filter map[string]interface{
 		}
 	}
 	return db
+}
+
+func applyStatusINFilter(db *gorm.DB, statuses []string) *gorm.DB {
+	var clauses []string
+	var params []interface{}
+
+	for _, s := range statuses {
+		switch s {
+		case "accepting_enrollments":
+			clauses = append(clauses,
+				"(status = 'published' AND (enrollment_start_date IS NULL OR enrollment_start_date <= NOW()) AND (enrollment_end_date IS NULL OR enrollment_end_date >= NOW()))")
+		case "scheduled":
+			clauses = append(clauses,
+				"(status = 'published' AND enrollment_start_date IS NOT NULL AND enrollment_start_date > NOW())")
+		case "in_progress":
+			clauses = append(clauses,
+				"(status = 'published' AND enrollment_end_date IS NOT NULL AND enrollment_end_date < NOW())")
+		case "finished":
+			clauses = append(clauses,
+				"(status = 'published' AND enrollment_end_date IS NOT NULL AND enrollment_end_date < NOW())")
+		default:
+			clauses = append(clauses, "(status = ?)")
+			params = append(params, s)
+		}
+	}
+
+	return db.Where("("+strings.Join(clauses, " OR ")+")", params...)
 }
 
 // Métodos auxiliares para manipulação dos relacionamentos


### PR DESCRIPTION
## Problema

`?status=accepting_enrollments` retornava 253 cursos (todos `published`), incluindo cursos com inscrições encerradas.

**Reprodução:**
```bash
curl 'https://services.staging.app.dados.rio/go/api/v1/courses?status=accepting_enrollments'
# retornava status=finished e status=published junto com accepting_enrollments
```

### Root cause

O handler normalizava derived statuses (`accepting_enrollments`, `scheduled`, `in_progress`, `finished`) para `published` antes de passar ao repositório. O repositório então fazia `WHERE status IN ('published')` — sem nenhuma condição de data.

## Fix

Remove a normalização no handler. Os derived statuses passam como estão para o repositório, que constrói condições OR com a semântica correta para cada um:

| Status | SQL gerado |
|---|---|
| `accepting_enrollments` | `status = 'published' AND enrollment_start_date <= NOW() AND enrollment_end_date >= NOW()` |
| `scheduled` | `status = 'published' AND enrollment_start_date > NOW()` |
| `in_progress` | `status = 'published' AND enrollment_end_date < NOW()` |
| `finished` | `status = 'published' AND enrollment_end_date < NOW()` |
| stored (ex: `draft`) | `status = 'draft'` |

**Combinações funcionam corretamente:**
```
?status=published,accepting_enrollments
→ (status = 'published') OR (status = 'published' AND enrollment ativo)
```