### PR TITLE
fix: status=published exclui cursos em accepting_enrollments/scheduled

### DIFF
--- a/internal/repository/curso_repository.go
+++ b/internal/repository/curso_repository.go
@@ -186,9 +186,16 @@ func applyStatusINFilter(db *gorm.DB, statuses []string) *gorm.DB {
 
 	for _, s := range statuses {
 		switch s {
+		case "published":
+			clauses = append(clauses,
+				"(status = 'published'"+
+					" AND (enrollment_start_date IS NULL OR enrollment_start_date <= NOW())"+
+					" AND NOT (enrollment_start_date IS NOT NULL AND enrollment_end_date IS NOT NULL"+
+					"          AND enrollment_start_date <= NOW() AND enrollment_end_date >= NOW()))")
 		case "accepting_enrollments":
 			clauses = append(clauses,
-				"(status = 'published' AND (enrollment_start_date IS NULL OR enrollment_start_date <= NOW()) AND (enrollment_end_date IS NULL OR enrollment_end_date >= NOW()))")
+				"(status = 'published' AND enrollment_start_date IS NOT NULL AND enrollment_end_date IS NOT NULL"+
+					" AND enrollment_start_date <= NOW() AND enrollment_end_date >= NOW())")
 		case "scheduled":
 			clauses = append(clauses,
 				"(status = 'published' AND enrollment_start_date IS NOT NULL AND enrollment_start_date > NOW())")


### PR DESCRIPTION
## Problema

\`?status=published\` retornava cursos com derived status \`accepting_enrollments\` porque o filtro SQL era apenas \`WHERE status = 'published'\` sem restrição de datas — igual ao bug anterior de \`accepting_enrollments\`.

## Root cause

O case \`published\` não existia em \`applyStatusINFilter\`, então caía no \`default\` que faz \`status = ?\`. Isso retorna TODOS os cursos stored como \`published\`, incluindo os que a API retorna como \`accepting_enrollments\` ou \`scheduled\`.

## Fix

Adiciona case \`published\` que aplica as condições de data corretas para o derived status \`published\` (não scheduled, não accepting_enrollments):

\`\`\`sql
status = 'published'
AND (enrollment_start_date IS NULL OR enrollment_start_date <= NOW())       -- exclui scheduled
AND NOT (start IS NOT NULL AND end IS NOT NULL AND start <= NOW <= end)     -- exclui accepting_enrollments
\`\`\`

Também corrige \`accepting_enrollments\` para requerer que ambas as datas sejam NOT NULL (alinhado com \`DeriveStatus\`).