### PR TITLE
fix(k8s): align prod manifests with rmi gold standard

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -19,7 +19,6 @@ spec:
         istio:
           virtualService:
             name: go-virtual-service
-            namespace: istio-system
             routes:
               - primary
       analysis:
@@ -56,7 +55,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: go
-          image: ghcr.io/prefeitura-rio/app-go-api:stable
+          image: ghcr.io/prefeitura-rio/app-go-api:v0.1.3
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
## Summary

- Remove \`namespace: istio-system\` from VirtualService reference in the Rollout canary config — this was causing persistent ArgoCD OutOfSync on the \`go\` application
- Update base image from floating \`:stable\` tag to versioned \`v0.1.3\` — consistent with how \`app-rmi\` (gold standard) manages its base image

## Context

Investigation against \`app-rmi\` as gold standard revealed two divergences in \`k8s/prod/resources.yaml\`:

1. The \`virtualService.namespace: istio-system\` field caused ArgoCD to track the VS as a resource outside the destination namespace (\`go\`), creating namespace tracking conflicts and keeping the app permanently OutOfSync despite successful syncs.

2. The \`:stable\` base image is a floating tag that doesn't match any release pushed by the workflow (which pushes \`:v{VERSION}\` and \`:latest-release\`). \`app-rmi\` uses a pinned versioned tag as the base.

Note: The ArgoCD Image Updater annotations have been separately removed from the IaC repo (\`iac-superapp\`) — that change is already merged and live.