### PR TITLE
docs: atualizar Swagger com endpoint de slug de vagas

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -68,6 +68,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/public/empregabilidade/vagas/slug/{slug}": {
+            "get": {
+                "description": "Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato \"{titulo-slugificado}-{12-chars-hex-do-uuid}\".",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-vagas-public"
+                ],
+                "summary": "Buscar vaga pública por slug",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Slug da vaga (ex: analista-financeiro-jr-b06235c80d2a)",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Vaga"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/public/empregabilidade/vagas/{id}": {
             "get": {
                 "description": "Retorna uma vaga publicada pelo ID (apenas se estiver ativa)",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -66,6 +66,53 @@
                 }
             }
         },
+        "/api/public/empregabilidade/vagas/slug/{slug}": {
+            "get": {
+                "description": "Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato \"{titulo-slugificado}-{12-chars-hex-do-uuid}\".",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-vagas-public"
+                ],
+                "summary": "Buscar vaga pública por slug",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Slug da vaga (ex: analista-financeiro-jr-b06235c80d2a)",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Vaga"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/public/empregabilidade/vagas/{id}": {
             "get": {
                 "description": "Retorna uma vaga publicada pelo ID (apenas se estiver ativa)",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1629,6 +1629,38 @@ paths:
       summary: Buscar vaga pública
       tags:
       - empregabilidade-vagas-public
+  /api/public/empregabilidade/vagas/slug/{slug}:
+    get:
+      description: Retorna uma vaga publicada pelo slug (apenas se estiver ativa).
+        Slug no formato "{titulo-slugificado}-{12-chars-hex-do-uuid}".
+      parameters:
+      - description: 'Slug da vaga (ex: analista-financeiro-jr-b06235c80d2a)'
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/empregabilidade.Vaga'
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Buscar vaga pública por slug
+      tags:
+      - empregabilidade-vagas-public
   /api/v1/acessibilidades:
     get:
       description: Retorna lista paginada de opções de acessibilidade

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -498,10 +498,10 @@ func (h *VagaHandler) PublicList(c *gin.Context) {
 }
 
 // @Summary      Buscar vaga pública por slug
-// @Description  Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato "{titulo-slugificado}-{8-chars-do-uuid}".
+// @Description  Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato "{titulo-slugificado}-{12-chars-hex-do-uuid}".
 // @Tags         empregabilidade-vagas-public
 // @Produce      json
-// @Param        slug  path      string  true  "Slug da vaga (ex: analista-de-ti-junior-f3d23675)"
+// @Param        slug  path      string  true  "Slug da vaga (ex: analista-financeiro-jr-b06235c80d2a)"
 // @Success      200   {object}  empregabilidade.Vaga
 // @Failure      404   {object}  map[string]string
 // @Failure      500   {object}  map[string]string


### PR DESCRIPTION
Swagger não havia sido regenerado antes do merge do PR #99.

Adiciona o endpoint `GET /api/public/empregabilidade/vagas/slug/{slug}` à documentação com descrição e exemplo corretos (sufixo de 12 chars hex).