### PR TITLE
feat: slug no JSON das vagas e 301 redirect para slug histórico

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -70,7 +70,7 @@ const docTemplate = `{
         },
         "/api/public/empregabilidade/vagas/slug/{slug}": {
             "get": {
-                "description": "Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato \"{titulo-slugificado}-{12-chars-hex-do-uuid}\".",
+                "description": "Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato \"{titulo-slugificado}-{12-chars-hex-do-uuid}\". Se o slug for histórico (título mudou), retorna 301 redirect para o slug atual.",
                 "produces": [
                     "application/json"
                 ],
@@ -92,6 +92,15 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/empregabilidade.Vaga"
+                        }
+                    },
+                    "301": {
+                        "description": "Moved Permanently",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "404": {
@@ -11053,6 +11062,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "responsabilidades": {
+                    "type": "string"
+                },
+                "slug": {
                     "type": "string"
                 },
                 "status": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -68,7 +68,7 @@
         },
         "/api/public/empregabilidade/vagas/slug/{slug}": {
             "get": {
-                "description": "Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato \"{titulo-slugificado}-{12-chars-hex-do-uuid}\".",
+                "description": "Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato \"{titulo-slugificado}-{12-chars-hex-do-uuid}\". Se o slug for histórico (título mudou), retorna 301 redirect para o slug atual.",
                 "produces": [
                     "application/json"
                 ],
@@ -90,6 +90,15 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/empregabilidade.Vaga"
+                        }
+                    },
+                    "301": {
+                        "description": "Moved Permanently",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "404": {
@@ -11051,6 +11060,9 @@
                     "type": "string"
                 },
                 "responsabilidades": {
+                    "type": "string"
+                },
+                "slug": {
                     "type": "string"
                 },
                 "status": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -565,6 +565,8 @@ definitions:
         type: string
       responsabilidades:
         type: string
+      slug:
+        type: string
       status:
         $ref: '#/definitions/empregabilidade.StatusVaga'
       tipos_pcd:
@@ -1632,7 +1634,8 @@ paths:
   /api/public/empregabilidade/vagas/slug/{slug}:
     get:
       description: Retorna uma vaga publicada pelo slug (apenas se estiver ativa).
-        Slug no formato "{titulo-slugificado}-{12-chars-hex-do-uuid}".
+        Slug no formato "{titulo-slugificado}-{12-chars-hex-do-uuid}". Se o slug for
+        histórico (título mudou), retorna 301 redirect para o slug atual.
       parameters:
       - description: 'Slug da vaga (ex: analista-financeiro-jr-b06235c80d2a)'
         in: path
@@ -1646,6 +1649,12 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/empregabilidade.Vaga'
+        "301":
+          description: Moved Permanently
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "404":
           description: Not Found
           schema:

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -498,11 +498,12 @@ func (h *VagaHandler) PublicList(c *gin.Context) {
 }
 
 // @Summary      Buscar vaga pública por slug
-// @Description  Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato "{titulo-slugificado}-{12-chars-hex-do-uuid}".
+// @Description  Retorna uma vaga publicada pelo slug (apenas se estiver ativa). Slug no formato "{titulo-slugificado}-{12-chars-hex-do-uuid}". Se o slug for histórico (título mudou), retorna 301 redirect para o slug atual.
 // @Tags         empregabilidade-vagas-public
 // @Produce      json
 // @Param        slug  path      string  true  "Slug da vaga (ex: analista-financeiro-jr-b06235c80d2a)"
 // @Success      200   {object}  empregabilidade.Vaga
+// @Success      301   {object}  map[string]string
 // @Failure      404   {object}  map[string]string
 // @Failure      500   {object}  map[string]string
 // @Router       /api/public/empregabilidade/vagas/slug/{slug} [get]
@@ -517,6 +518,11 @@ func (h *VagaHandler) PublicGetBySlug(c *gin.Context) {
 
 	if entity == nil || entity.Status != empregabilidade.StatusVagaPublicadoAtivo {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Vaga não encontrada"})
+		return
+	}
+
+	if entity.Slug != vagaSlug {
+		c.Redirect(http.StatusMovedPermanently, "/api/public/empregabilidade/vagas/slug/"+entity.Slug)
 		return
 	}
 

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -1051,13 +1051,15 @@ func TestVagaHandler_Update_PublishedForbiddenForEditorComCuradoria(t *testing.T
 
 func TestVagaHandler_PublicGetBySlug_Success(t *testing.T) {
 	id := uuid.MustParse("f3d23675-97e5-4d57-8892-bff6ba805d6d")
+	slug := "analista-de-ti-f3d2367597e5"
 	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{
 		ID:     id,
 		Titulo: "Analista de TI",
 		Status: empmodels.StatusVagaPublicadoAtivo,
+		Slug:   slug,
 	}}
 	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
-	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/analista-de-ti-f3d2367597e5", nil)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/"+slug, nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -1082,6 +1084,7 @@ func TestVagaHandler_PublicGetBySlug_NaoPublicada(t *testing.T) {
 		ID:     id,
 		Titulo: "Vaga em edição",
 		Status: empmodels.StatusVagaEmEdicao,
+		Slug:   "vaga-em-edicao-f3d2367597e5",
 	}}
 	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
 	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/vaga-em-edicao-f3d2367597e5", nil)
@@ -1089,5 +1092,28 @@ func TestVagaHandler_PublicGetBySlug_NaoPublicada(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for non-published vaga, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetBySlug_RedirectSlugHistorico(t *testing.T) {
+	id := uuid.MustParse("f3d23675-97e5-4d57-8892-bff6ba805d6d")
+	currentSlug := "analista-financeiro-jr-f3d2367597e5"
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{
+		ID:     id,
+		Titulo: "Analista Financeiro Jr",
+		Status: empmodels.StatusVagaPublicadoAtivo,
+		Slug:   currentSlug,
+	}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/analista-jr-f3d2367597e5", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusMovedPermanently {
+		t.Errorf("expected 301 for historical slug, got %d", w.Code)
+	}
+	location := w.Header().Get("Location")
+	expected := "/api/public/empregabilidade/vagas/slug/" + currentSlug
+	if location != expected {
+		t.Errorf("expected Location %q, got %q", expected, location)
 	}
 }

--- a/internal/models/empregabilidade/vaga.go
+++ b/internal/models/empregabilidade/vaga.go
@@ -63,6 +63,7 @@ type Vaga struct {
 	Beneficios          string             `json:"beneficios" gorm:"type:text"`
 	IDOrgaoParceiro     string             `json:"id_orgao_parceiro" gorm:"type:varchar(50)"`
 	Status              StatusVaga         `json:"status" gorm:"type:varchar(50);not null;default:'em_edicao'"`
+	Slug                string             `json:"slug" gorm:"-"`
 	DeletedAt           gorm.DeletedAt     `json:"deleted_at,omitempty" gorm:"index" swaggertype:"string" example:"2024-12-31T23:59:59Z"`
 	CreatedAt           time.Time          `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt           time.Time          `json:"updated_at" gorm:"autoUpdateTime"`
@@ -81,8 +82,13 @@ func (Vaga) TableName() string {
 	return "emp_vagas"
 }
 
-func (v *Vaga) Slug() string {
-	return slug.Make(v.Titulo) + "-" + strings.ReplaceAll(v.ID.String(), "-", "")[:12]
+func BuildVagaSlug(titulo string, id uuid.UUID) string {
+	return slug.Make(titulo) + "-" + strings.ReplaceAll(id.String(), "-", "")[:12]
+}
+
+func (v *Vaga) AfterFind(_ *gorm.DB) error {
+	v.Slug = BuildVagaSlug(v.Titulo, v.ID)
+	return nil
 }
 
 type VagaFilter struct {

--- a/internal/models/empregabilidade/vaga_slug_test.go
+++ b/internal/models/empregabilidade/vaga_slug_test.go
@@ -9,16 +9,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func populateSlug(v *empregabilidade.Vaga) {
+	_ = v.AfterFind(nil)
+}
+
 func TestVaga_Slug_FormatoCorreto(t *testing.T) {
 	id := uuid.MustParse("f3d23675-97e5-4d57-8892-bff6ba805d6d")
 	v := &empregabilidade.Vaga{ID: id, Titulo: "Analista de TI Júnior"}
-	assert.Equal(t, "analista-de-ti-junior-f3d2367597e5", v.Slug())
+	populateSlug(v)
+	assert.Equal(t, "analista-de-ti-junior-f3d2367597e5", v.Slug)
 }
 
 func TestVaga_Slug_TerminaComDozeCharsHexSemDash(t *testing.T) {
 	id := uuid.New()
 	v := &empregabilidade.Vaga{ID: id, Titulo: "Desenvolvedor Go"}
-	parts := strings.Split(v.Slug(), "-")
+	populateSlug(v)
+	parts := strings.Split(v.Slug, "-")
 	suffix := parts[len(parts)-1]
 	noDash := strings.ReplaceAll(id.String(), "-", "")
 	assert.Equal(t, noDash[:12], suffix)
@@ -27,12 +33,15 @@ func TestVaga_Slug_TerminaComDozeCharsHexSemDash(t *testing.T) {
 func TestVaga_Slug_RemoveAcentos(t *testing.T) {
 	id := uuid.MustParse("aaaabbbb-0000-0000-0000-000000000000")
 	v := &empregabilidade.Vaga{ID: id, Titulo: "Técnico em Administração"}
-	assert.Equal(t, "tecnico-em-administracao-aaaabbbb0000", v.Slug())
+	populateSlug(v)
+	assert.Equal(t, "tecnico-em-administracao-aaaabbbb0000", v.Slug)
 }
 
 func TestVaga_Slug_UnicoPorUUID(t *testing.T) {
 	titulo := "Mesmo Título"
 	v1 := &empregabilidade.Vaga{ID: uuid.New(), Titulo: titulo}
 	v2 := &empregabilidade.Vaga{ID: uuid.New(), Titulo: titulo}
-	assert.NotEqual(t, v1.Slug(), v2.Slug())
+	populateSlug(v1)
+	populateSlug(v2)
+	assert.NotEqual(t, v1.Slug, v2.Slug)
 }


### PR DESCRIPTION
## O que muda

### 1. Campo `slug` em todas as respostas de vagas

O campo `slug` agora aparece no JSON de qualquer endpoint que retorne uma `Vaga`:

```json
{
  "id": "b06235c8-0d2a-443e-ab57-f8af3de76757",
  "titulo": "Analista Financeiro Jr",
  "slug": "analista-financeiro-jr-b06235c80d2a",
  ...
}
```

Implementado via **GORM `AfterFind` hook** — sem migration, sem backfill. O slug é derivado deterministicamente de `slugify(titulo) + primeiros-12-chars-hex-do-uuid`.

### 2. 301 redirect para slug histórico

`GET /api/public/empregabilidade/vagas/slug/:slug`

Se o título da vaga mudou desde que o slug foi gerado, o endpoint retorna **HTTP 301** para o slug atual:

```
GET /vagas/slug/analista-jr-b06235c80d2a        (slug antigo)
→ 301 Location: /api/public/.../analista-financeiro-jr-b06235c80d2a
```

Funciona sem armazenar histórico no banco — o UUID no slug sempre encontra a vaga, e a comparação com o slug atual decide se redireciona.

## Testes

- `TestVagaHandler_PublicGetBySlug_RedirectSlugHistorico` — valida 301 com Location correto
- Testes existentes atualizados para popular `Slug` no mock entity