### PR TITLE
feat(empregabilidade): filtrar vagas públicas por status [PREF-323].

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -52,6 +52,42 @@ const docTemplate = `{
                         "description": "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)",
                         "name": "status",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)",
+                        "name": "data_publicacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID do regime de contratação",
+                        "name": "id_regime_contratacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID do modelo de trabalho",
+                        "name": "id_modelo_trabalho",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Nome ou CNPJ do contratante",
+                        "name": "contratante",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)",
+                        "name": "acessibilidade_pcd",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bairro (busca parcial)",
+                        "name": "bairro",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -141,7 +141,7 @@ const docTemplate = `{
         },
         "/api/public/empregabilidade/vagas/{id}": {
             "get": {
-                "description": "Retorna uma vaga publicada pelo ID (apenas se estiver ativa)",
+                "description": "Retorna uma vaga publicada pelo ID (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -26,7 +26,7 @@ const docTemplate = `{
     "paths": {
         "/api/public/empregabilidade/vagas": {
             "get": {
-                "description": "Retorna lista paginada de vagas publicadas (apenas vagas ativas)",
+                "description": "Retorna lista paginada de vagas publicadas. Sem filtro retorna todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada). Use ?status= para filtrar por um status específico.",
                 "produces": [
                     "application/json"
                 ],
@@ -46,6 +46,12 @@ const docTemplate = `{
                         "description": "Tamanho da página (default: 10)",
                         "name": "pageSize",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)",
+                        "name": "status",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -54,6 +60,15 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "500": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -139,7 +139,7 @@
         },
         "/api/public/empregabilidade/vagas/{id}": {
             "get": {
-                "description": "Retorna uma vaga publicada pelo ID (apenas se estiver ativa)",
+                "description": "Retorna uma vaga publicada pelo ID (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -24,7 +24,7 @@
     "paths": {
         "/api/public/empregabilidade/vagas": {
             "get": {
-                "description": "Retorna lista paginada de vagas publicadas (apenas vagas ativas)",
+                "description": "Retorna lista paginada de vagas publicadas. Sem filtro retorna todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada). Use ?status= para filtrar por um status específico.",
                 "produces": [
                     "application/json"
                 ],
@@ -44,6 +44,12 @@
                         "description": "Tamanho da página (default: 10)",
                         "name": "pageSize",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)",
+                        "name": "status",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -52,6 +58,15 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "500": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -50,6 +50,42 @@
                         "description": "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)",
                         "name": "status",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)",
+                        "name": "data_publicacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID do regime de contratação",
+                        "name": "id_regime_contratacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID do modelo de trabalho",
+                        "name": "id_modelo_trabalho",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Nome ou CNPJ do contratante",
+                        "name": "contratante",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)",
+                        "name": "acessibilidade_pcd",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bairro (busca parcial)",
+                        "name": "bairro",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1567,7 +1567,9 @@ info:
 paths:
   /api/public/empregabilidade/vagas:
     get:
-      description: Retorna lista paginada de vagas publicadas (apenas vagas ativas)
+      description: Retorna lista paginada de vagas publicadas. Sem filtro retorna
+        todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada,
+        vaga_descontinuada). Use ?status= para filtrar por um status específico.
       parameters:
       - description: 'Número da página (default: 1)'
         in: query
@@ -1577,6 +1579,11 @@ paths:
         in: query
         name: pageSize
         type: integer
+      - description: Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada,
+          vaga_descontinuada)
+        in: query
+        name: status
+        type: string
       produces:
       - application/json
       responses:
@@ -1584,6 +1591,12 @@ paths:
           description: OK
           schema:
             additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
             type: object
         "500":
           description: Internal Server Error

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1609,7 +1609,8 @@ paths:
       - empregabilidade-vagas-public
   /api/public/empregabilidade/vagas/{id}:
     get:
-      description: Retorna uma vaga publicada pelo ID (apenas se estiver ativa)
+      description: Retorna uma vaga publicada pelo ID (publicado_ativo, publicado_expirado,
+        vaga_congelada, vaga_descontinuada)
       parameters:
       - description: ID da vaga
         in: path

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1584,6 +1584,30 @@ paths:
         in: query
         name: status
         type: string
+      - description: Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)
+        in: query
+        name: data_publicacao
+        type: string
+      - description: UUID do regime de contratação
+        in: query
+        name: id_regime_contratacao
+        type: string
+      - description: UUID do modelo de trabalho
+        in: query
+        name: id_modelo_trabalho
+        type: string
+      - description: Nome ou CNPJ do contratante
+        in: query
+        name: contratante
+        type: string
+      - description: Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)
+        in: query
+        name: acessibilidade_pcd
+        type: string
+      - description: Bairro (busca parcial)
+        in: query
+        name: bairro
+        type: string
       produces:
       - application/json
       responses:

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -462,12 +462,14 @@ func (h *VagaHandler) Reactivate(c *gin.Context) {
 // ==================== Public Endpoints ====================
 
 // @Summary      Listar vagas públicas
-// @Description  Retorna lista paginada de vagas publicadas (apenas vagas ativas)
+// @Description  Retorna lista paginada de vagas publicadas. Sem filtro retorna todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada). Use ?status= para filtrar por um status específico.
 // @Tags         empregabilidade-vagas-public
 // @Produce      json
 // @Param        page       query     int     false  "Número da página (default: 1)"
 // @Param        pageSize   query     int     false  "Tamanho da página (default: 10)"
+// @Param        status     query     string  false  "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)"
 // @Success      200        {object}  map[string]interface{}
+// @Failure      400        {object}  map[string]string
 // @Failure      500        {object}  map[string]string
 // @Router       /api/public/empregabilidade/vagas [get]
 func (h *VagaHandler) PublicList(c *gin.Context) {
@@ -481,7 +483,13 @@ func (h *VagaHandler) PublicList(c *gin.Context) {
 		pageSize = 10
 	}
 
-	entities, total, err := h.service.ListPublicActive(c.Request.Context(), page, pageSize)
+	status := c.Query("status")
+	if status != "" && !isPublishedStatus(empregabilidade.StatusVaga(status)) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "status inválido: deve ser publicado_ativo, publicado_expirado, vaga_congelada ou vaga_descontinuada"})
+		return
+	}
+
+	entities, total, err := h.service.ListPublic(c.Request.Context(), status, page, pageSize)
 	if err != nil {
 		handleVagaError(c, err)
 		return
@@ -516,7 +524,7 @@ func (h *VagaHandler) PublicGetBySlug(c *gin.Context) {
 		return
 	}
 
-	if entity == nil || entity.Status != empregabilidade.StatusVagaPublicadoAtivo {
+	if entity == nil || !isPublishedStatus(entity.Status) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Vaga não encontrada"})
 		return
 	}
@@ -557,8 +565,7 @@ func (h *VagaHandler) PublicGetByID(c *gin.Context) {
 		return
 	}
 
-	// Return 404 if vaga doesn't exist or is not published active
-	if entity == nil || entity.Status != empregabilidade.StatusVagaPublicadoAtivo {
+	if entity == nil || !isPublishedStatus(entity.Status) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Vaga não encontrada"})
 		return
 	}

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -465,12 +465,18 @@ func (h *VagaHandler) Reactivate(c *gin.Context) {
 // @Description  Retorna lista paginada de vagas publicadas. Sem filtro retorna todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada). Use ?status= para filtrar por um status específico.
 // @Tags         empregabilidade-vagas-public
 // @Produce      json
-// @Param        page       query     int     false  "Número da página (default: 1)"
-// @Param        pageSize   query     int     false  "Tamanho da página (default: 10)"
-// @Param        status     query     string  false  "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)"
-// @Success      200        {object}  map[string]interface{}
-// @Failure      400        {object}  map[string]string
-// @Failure      500        {object}  map[string]string
+// @Param        page                    query     int     false  "Número da página (default: 1)"
+// @Param        pageSize                query     int     false  "Tamanho da página (default: 10)"
+// @Param        status                  query     string  false  "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)"
+// @Param        data_publicacao         query     string  false  "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)"
+// @Param        id_regime_contratacao   query     string  false  "UUID do regime de contratação"
+// @Param        id_modelo_trabalho      query     string  false  "UUID do modelo de trabalho"
+// @Param        contratante             query     string  false  "Nome ou CNPJ do contratante"
+// @Param        acessibilidade_pcd      query     string  false  "Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)"
+// @Param        bairro                  query     string  false  "Bairro (busca parcial)"
+// @Success      200                     {object}  map[string]interface{}
+// @Failure      400                     {object}  map[string]string
+// @Failure      500                     {object}  map[string]string
 // @Router       /api/public/empregabilidade/vagas [get]
 func (h *VagaHandler) PublicList(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
@@ -489,7 +495,29 @@ func (h *VagaHandler) PublicList(c *gin.Context) {
 		return
 	}
 
-	entities, total, err := h.service.ListPublic(c.Request.Context(), status, page, pageSize)
+	dataPublicacao := empregabilidade.DataPublicacaoRange(c.Query("data_publicacao"))
+	if dataPublicacao != "" && !dataPublicacao.IsValid() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "data_publicacao inválido: deve ser hoje, ultima_semana ou ultimo_mes"})
+		return
+	}
+
+	acessibilidadePCD := c.Query("acessibilidade_pcd")
+	if acessibilidadePCD != "" && !empregabilidade.AcessibilidadePCD(acessibilidadePCD).IsValid() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "acessibilidade_pcd inválido: deve ser para_pcd, preferencial_pcd ou exclusivo_pcd"})
+		return
+	}
+
+	filter := empregabilidade.VagaPublicFilter{
+		Status:              status,
+		DataPublicacao:      dataPublicacao,
+		IDRegimeContratacao: c.Query("id_regime_contratacao"),
+		IDModeloTrabalho:    c.Query("id_modelo_trabalho"),
+		Contratante:         c.Query("contratante"),
+		AcessibilidadePCD:   acessibilidadePCD,
+		Bairro:              c.Query("bairro"),
+	}
+
+	entities, total, err := h.service.ListPublic(c.Request.Context(), filter, page, pageSize)
 	if err != nil {
 		handleVagaError(c, err)
 		return

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -543,7 +543,7 @@ func (h *VagaHandler) PublicGetBySlug(c *gin.Context) {
 }
 
 // @Summary      Buscar vaga pública
-// @Description  Retorna uma vaga publicada pelo ID (apenas se estiver ativa)
+// @Description  Retorna uma vaga publicada pelo ID (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)
 // @Tags         empregabilidade-vagas-public
 // @Produce      json
 // @Param        id   path      string  true  "ID da vaga"

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -1038,6 +1038,30 @@ func TestVagaHandler_Update_PublishedForbiddenForUnrelatedRole(t *testing.T) {
 	}
 }
 
+func TestVagaHandler_SendToDraft_WrongStatus_Retorna409(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaEmEdicao}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/send-to-draft", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 for wrong state, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_SendToApproval_WrongStatus_Retorna409(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaEmAprovacao}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/send-to-approval", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 for wrong state, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestVagaHandler_PublicGetByID_PublicadoExpirado(t *testing.T) {
 	id := uuid.MustParse(validUUID)
 	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaPublicadoExpirado}}

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -60,7 +60,7 @@ func (m *mockVagaRepoH) ListPublicActive(_ context.Context, _, _ int) ([]*empmod
 	return m.listItems, m.listTotal, m.err
 }
 
-func (m *mockVagaRepoH) ListPublic(_ context.Context, _ string, _, _ int) ([]*empmodels.Vaga, int, error) {
+func (m *mockVagaRepoH) ListPublic(_ context.Context, _ empmodels.VagaPublicFilter, _, _ int) ([]*empmodels.Vaga, int, error) {
 	return m.listItems, m.listTotal, m.err
 }
 
@@ -1322,5 +1322,104 @@ func TestVagaHandler_PublicGetBySlug_RedirectSlugHistorico(t *testing.T) {
 	expected := "/public/vagas/slug/" + currentSlug
 	if location != expected {
 		t.Errorf("expected Location %q, got %q", expected, location)
+	}
+}
+
+func TestVagaHandler_PublicList_DataPublicacao_Hoje(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?data_publicacao=hoje", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for data_publicacao=hoje, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_DataPublicacao_Invalido(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?data_publicacao=invalido", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for data_publicacao=invalido, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_AcessibilidadePCD_ParaPCD(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?acessibilidade_pcd=para_pcd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for acessibilidade_pcd=para_pcd, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_AcessibilidadePCD_Invalido(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?acessibilidade_pcd=invalido", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for acessibilidade_pcd=invalido, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_Bairro(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?bairro=copacabana", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for bairro=copacabana, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_IDRegimeContratacao(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?id_regime_contratacao="+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for id_regime_contratacao, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_IDModeloTrabalho(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?id_modelo_trabalho="+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for id_modelo_trabalho, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Contratante_Nome(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?contratante=Google", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for contratante=Google, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Contratante_CNPJ(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?contratante=12345678000100", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for contratante=12345678000100, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -60,6 +60,10 @@ func (m *mockVagaRepoH) ListPublicActive(_ context.Context, _, _ int) ([]*empmod
 	return m.listItems, m.listTotal, m.err
 }
 
+func (m *mockVagaRepoH) ListPublic(_ context.Context, _ string, _, _ int) ([]*empmodels.Vaga, int, error) {
+	return m.listItems, m.listTotal, m.err
+}
+
 func (m *mockVagaRepoH) UpdateTiposPCD(_ context.Context, _ uuid.UUID, _ []uuid.UUID) error {
 	return m.err
 }
@@ -1031,6 +1035,209 @@ func TestVagaHandler_Update_PublishedForbiddenForUnrelatedRole(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 for unrelated role, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetByID_PublicadoExpirado(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaPublicadoExpirado}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/"+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for publicado_expirado, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetByID_VagaCongelada(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaCongelada}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/"+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for vaga_congelada, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetByID_VagaDescontinuada(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaDescontinuada}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/"+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for vaga_descontinuada, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetByID_EmEdicao_Retorna404(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaEmEdicao}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/"+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for em_edicao, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetByID_EmAprovacao_Retorna404(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaEmAprovacao}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/"+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for em_aprovacao, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetBySlug_PublicadoExpirado(t *testing.T) {
+	id := uuid.MustParse("f3d23675-97e5-4d57-8892-bff6ba805d6d")
+	slug := "vaga-expirada-f3d2367597e5"
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{
+		ID:     id,
+		Titulo: "Vaga Expirada",
+		Status: empmodels.StatusVagaPublicadoExpirado,
+		Slug:   slug,
+	}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/"+slug, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for publicado_expirado slug, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetBySlug_VagaCongelada(t *testing.T) {
+	id := uuid.MustParse("f3d23675-97e5-4d57-8892-bff6ba805d6d")
+	slug := "vaga-congelada-f3d2367597e5"
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{
+		ID:     id,
+		Titulo: "Vaga Congelada",
+		Status: empmodels.StatusVagaCongelada,
+		Slug:   slug,
+	}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/"+slug, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for vaga_congelada slug, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicGetBySlug_VagaDescontinuada(t *testing.T) {
+	id := uuid.MustParse("f3d23675-97e5-4d57-8892-bff6ba805d6d")
+	slug := "vaga-descontinuada-f3d2367597e5"
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{
+		ID:     id,
+		Titulo: "Vaga Descontinuada",
+		Status: empmodels.StatusVagaDescontinuada,
+		Slug:   slug,
+	}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas/slug/"+slug, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for vaga_descontinuada slug, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_WithStatusFilter_PublicadoAtivo(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{
+		listItems: []*empmodels.Vaga{{Titulo: "Vaga Ativa", Status: empmodels.StatusVagaPublicadoAtivo}},
+		listTotal: 1,
+	}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?status=publicado_ativo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for status=publicado_ativo, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_WithStatusFilter_VagaCongelada(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{
+		listItems: []*empmodels.Vaga{{Titulo: "Vaga Congelada", Status: empmodels.StatusVagaCongelada}},
+		listTotal: 1,
+	}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?status=vaga_congelada", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for status=vaga_congelada, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_WithStatusFilter_PublicadoExpirado(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?status=publicado_expirado", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for status=publicado_expirado, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_WithStatusFilter_VagaDescontinuada(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?status=vaga_descontinuada", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for status=vaga_descontinuada, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_WithInvalidStatusFilter(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?status=em_edicao", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid status filter, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_WithInvalidStatusUnknown(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?status=status_invalido", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown status filter, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_PublicList_NoFilter_Success(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{
+		listItems: []*empmodels.Vaga{
+			{Titulo: "Ativa", Status: empmodels.StatusVagaPublicadoAtivo},
+			{Titulo: "Congelada", Status: empmodels.StatusVagaCongelada},
+		},
+		listTotal: 2,
+	}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for no filter, got %d", w.Code)
 	}
 }
 

--- a/internal/models/empregabilidade/models_test.go
+++ b/internal/models/empregabilidade/models_test.go
@@ -229,3 +229,25 @@ func TestTableNames(t *testing.T) {
 		})
 	}
 }
+
+func TestDataPublicacaoRange_IsValid(t *testing.T) {
+	valid := []DataPublicacaoRange{
+		DataPublicacaoHoje,
+		DataPublicacaoUltimaSemana,
+		DataPublicacaoUltimoMes,
+	}
+	for _, d := range valid {
+		if !d.IsValid() {
+			t.Errorf("expected %q to be valid", d)
+		}
+	}
+}
+
+func TestDataPublicacaoRange_IsInvalid(t *testing.T) {
+	invalid := []DataPublicacaoRange{"", "ontem", "HOJE", "semana"}
+	for _, d := range invalid {
+		if d.IsValid() {
+			t.Errorf("expected %q to be invalid", d)
+		}
+	}
+}

--- a/internal/models/empregabilidade/vaga.go
+++ b/internal/models/empregabilidade/vaga.go
@@ -98,6 +98,32 @@ type VagaFilter struct {
 	Search          string // ILIKE em titulo
 }
 
+type DataPublicacaoRange string
+
+const (
+	DataPublicacaoHoje         DataPublicacaoRange = "hoje"
+	DataPublicacaoUltimaSemana DataPublicacaoRange = "ultima_semana"
+	DataPublicacaoUltimoMes    DataPublicacaoRange = "ultimo_mes"
+)
+
+func (d DataPublicacaoRange) IsValid() bool {
+	switch d {
+	case DataPublicacaoHoje, DataPublicacaoUltimaSemana, DataPublicacaoUltimoMes:
+		return true
+	}
+	return false
+}
+
+type VagaPublicFilter struct {
+	Status              string
+	DataPublicacao      DataPublicacaoRange
+	IDRegimeContratacao string
+	IDModeloTrabalho    string
+	Contratante         string
+	AcessibilidadePCD   string
+	Bairro              string
+}
+
 func (v *Vaga) UpdateStatusBasedOnExpiration() {
 	if v.DataLimite == nil {
 		return

--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -3,12 +3,16 @@ package empregabilidade
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
 )
+
+var nonDigit = regexp.MustCompile(`\D`)
 
 type VagaRepository struct {
 	db *gorm.DB
@@ -264,12 +268,12 @@ func (r *VagaRepository) UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, t
 	})
 }
 
-func (r *VagaRepository) ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
+func (r *VagaRepository) ListPublic(ctx context.Context, filter empregabilidade.VagaPublicFilter, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
 	var entities []*empregabilidade.Vaga
 	var total int64
 
 	applyFilters := func(db *gorm.DB) *gorm.DB {
-		switch status {
+		switch filter.Status {
 		case string(empregabilidade.StatusVagaPublicadoAtivo):
 			db = db.Where("status = ? AND (data_limite IS NULL OR data_limite > NOW())", empregabilidade.StatusVagaPublicadoAtivo)
 		case string(empregabilidade.StatusVagaPublicadoExpirado):
@@ -285,6 +289,43 @@ func (r *VagaRepository) ListPublic(ctx context.Context, status string, limit, o
 				string(empregabilidade.StatusVagaDescontinuada),
 			})
 		}
+
+		switch filter.DataPublicacao {
+		case empregabilidade.DataPublicacaoHoje:
+			hoje := time.Now().Truncate(24 * time.Hour)
+			db = db.Where("created_at >= ?", hoje)
+		case empregabilidade.DataPublicacaoUltimaSemana:
+			db = db.Where("created_at >= ?", time.Now().AddDate(0, 0, -7))
+		case empregabilidade.DataPublicacaoUltimoMes:
+			db = db.Where("created_at >= ?", time.Now().AddDate(0, 0, -30))
+		}
+
+		if filter.IDRegimeContratacao != "" {
+			db = db.Where("id_regime_contratacao = ?", filter.IDRegimeContratacao)
+		}
+
+		if filter.IDModeloTrabalho != "" {
+			db = db.Where("id_modelo_trabalho = ?", filter.IDModeloTrabalho)
+		}
+
+		if filter.AcessibilidadePCD != "" {
+			db = db.Where("acessibilidade_pcd = ?", filter.AcessibilidadePCD)
+		}
+
+		if filter.Bairro != "" {
+			db = db.Where("bairro ILIKE ?", "%"+filter.Bairro+"%")
+		}
+
+		if filter.Contratante != "" {
+			digits := nonDigit.ReplaceAllString(filter.Contratante, "")
+			if len(digits) >= 11 {
+				db = db.Where("id_contratante = ?", digits)
+			} else {
+				db = db.Joins("JOIN emp_empresas ON emp_empresas.cnpj = emp_vagas.id_contratante").
+					Where("emp_empresas.nome ILIKE ?", "%"+filter.Contratante+"%")
+			}
+		}
+
 		return db
 	}
 

--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -264,6 +264,52 @@ func (r *VagaRepository) UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, t
 	})
 }
 
+func (r *VagaRepository) ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
+	var entities []*empregabilidade.Vaga
+	var total int64
+
+	applyFilters := func(db *gorm.DB) *gorm.DB {
+		switch status {
+		case string(empregabilidade.StatusVagaPublicadoAtivo):
+			db = db.Where("status = ? AND (data_limite IS NULL OR data_limite > NOW())", empregabilidade.StatusVagaPublicadoAtivo)
+		case string(empregabilidade.StatusVagaPublicadoExpirado):
+			db = db.Where("status = ? AND data_limite IS NOT NULL AND data_limite <= NOW()", empregabilidade.StatusVagaPublicadoAtivo)
+		case string(empregabilidade.StatusVagaCongelada):
+			db = db.Where("status = ?", empregabilidade.StatusVagaCongelada)
+		case string(empregabilidade.StatusVagaDescontinuada):
+			db = db.Where("status = ?", empregabilidade.StatusVagaDescontinuada)
+		default:
+			db = db.Where("status IN ?", []string{
+				string(empregabilidade.StatusVagaPublicadoAtivo),
+				string(empregabilidade.StatusVagaCongelada),
+				string(empregabilidade.StatusVagaDescontinuada),
+			})
+		}
+		return db
+	}
+
+	countDB := applyFilters(r.db.WithContext(ctx).Model(&empregabilidade.Vaga{}))
+	if err := countDB.Count(&total).Error; err != nil {
+		return nil, 0, fmt.Errorf("erro ao contar vagas públicas: %w", err)
+	}
+
+	findDB := applyFilters(r.db.WithContext(ctx).Model(&empregabilidade.Vaga{}))
+	result := findDB.
+		Preload("Contratante").
+		Preload("RegimeContratacao").
+		Preload("ModeloTrabalho").
+		Preload("OrgaoParceiro").
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&entities)
+	if result.Error != nil {
+		return nil, 0, fmt.Errorf("erro ao listar vagas públicas: %w", result.Error)
+	}
+
+	return entities, int(total), nil
+}
+
 func (r *VagaRepository) ListByContratante(ctx context.Context, cnpj string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
 	var entities []*empregabilidade.Vaga
 	var total int64

--- a/internal/services/empregabilidade/vaga_service.go
+++ b/internal/services/empregabilidade/vaga_service.go
@@ -20,6 +20,7 @@ type VagaRepoInterface interface {
 	Delete(ctx context.Context, id uuid.UUID) error
 	List(ctx context.Context, filter empregabilidade.VagaFilter, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	ListPublicActive(ctx context.Context, limit, offset int) ([]*empregabilidade.Vaga, int, error)
+	ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, tiposPCDIDs []uuid.UUID) error
 	ListByContratante(ctx context.Context, cnpj string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	ListByOrgaoParceiro(ctx context.Context, orgaoID string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
@@ -165,6 +166,18 @@ func (s *VagaService) List(ctx context.Context, filter empregabilidade.VagaFilte
 func (s *VagaService) ListPublicActive(ctx context.Context, page, pageSize int) ([]*empregabilidade.Vaga, int, error) {
 	offset := (page - 1) * pageSize
 	return s.repo.ListPublicActive(ctx, pageSize, offset)
+}
+
+func (s *VagaService) ListPublic(ctx context.Context, status string, page, pageSize int) ([]*empregabilidade.Vaga, int, error) {
+	offset := (page - 1) * pageSize
+	vagas, total, err := s.repo.ListPublic(ctx, status, pageSize, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, vaga := range vagas {
+		vaga.UpdateStatusBasedOnExpiration()
+	}
+	return vagas, total, nil
 }
 
 func (s *VagaService) UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, tiposPCDIDs []uuid.UUID) error {

--- a/internal/services/empregabilidade/vaga_service.go
+++ b/internal/services/empregabilidade/vaga_service.go
@@ -20,7 +20,7 @@ type VagaRepoInterface interface {
 	Delete(ctx context.Context, id uuid.UUID) error
 	List(ctx context.Context, filter empregabilidade.VagaFilter, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	ListPublicActive(ctx context.Context, limit, offset int) ([]*empregabilidade.Vaga, int, error)
-	ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
+	ListPublic(ctx context.Context, filter empregabilidade.VagaPublicFilter, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, tiposPCDIDs []uuid.UUID) error
 	ListByContratante(ctx context.Context, cnpj string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	ListByOrgaoParceiro(ctx context.Context, orgaoID string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
@@ -168,9 +168,9 @@ func (s *VagaService) ListPublicActive(ctx context.Context, page, pageSize int) 
 	return s.repo.ListPublicActive(ctx, pageSize, offset)
 }
 
-func (s *VagaService) ListPublic(ctx context.Context, status string, page, pageSize int) ([]*empregabilidade.Vaga, int, error) {
+func (s *VagaService) ListPublic(ctx context.Context, filter empregabilidade.VagaPublicFilter, page, pageSize int) ([]*empregabilidade.Vaga, int, error) {
 	offset := (page - 1) * pageSize
-	vagas, total, err := s.repo.ListPublic(ctx, status, pageSize, offset)
+	vagas, total, err := s.repo.ListPublic(ctx, filter, pageSize, offset)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/services/empregabilidade/vaga_service_test.go
+++ b/internal/services/empregabilidade/vaga_service_test.go
@@ -110,19 +110,39 @@ func (m *MockVagaRepoForService) UpdateTiposPCD(ctx context.Context, vagaID uuid
 }
 
 func (m *MockVagaRepoForService) ListByContratante(ctx context.Context, cnpj string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
+	if m.listError != nil {
+		return nil, 0, m.listError
+	}
 	return nil, 0, nil
 }
 
 func (m *MockVagaRepoForService) ListByOrgaoParceiro(ctx context.Context, orgaoID string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
+	if m.listError != nil {
+		return nil, 0, m.listError
+	}
 	return nil, 0, nil
 }
 
 func (m *MockVagaRepoForService) ListPublicActive(ctx context.Context, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
-	return nil, 0, nil
+	if m.listError != nil {
+		return nil, 0, m.listError
+	}
+	var result []*empregabilidade.Vaga
+	for _, v := range m.vagas {
+		result = append(result, v)
+	}
+	return result, len(result), nil
 }
 
 func (m *MockVagaRepoForService) ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
-	return nil, 0, nil
+	if m.listError != nil {
+		return nil, 0, m.listError
+	}
+	var result []*empregabilidade.Vaga
+	for _, v := range m.vagas {
+		result = append(result, v)
+	}
+	return result, len(result), nil
 }
 
 // Mock Empresa Repository for VagaService tests
@@ -1332,6 +1352,112 @@ func TestVagaService_GetBySlug_ErroDoRepo(t *testing.T) {
 	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
 
 	_, err := service.GetBySlug(context.Background(), "analista-de-ti-f3d2367597e5")
+	assert.Error(t, err)
+}
+
+// ==================== ListPublic Tests ====================
+
+func TestVagaService_ListPublic_Success_Empty(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagas, total, err := service.ListPublic(context.Background(), "", 1, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, vagas)
+}
+
+func TestVagaService_ListPublic_Success_WithVagas(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	vagaID := uuid.New()
+	mockVagaRepo.vagas[vagaID] = &empregabilidade.Vaga{
+		ID:     vagaID,
+		Titulo: "Vaga Ativa",
+		Status: empregabilidade.StatusVagaPublicadoAtivo,
+	}
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagas, total, err := service.ListPublic(context.Background(), string(empregabilidade.StatusVagaPublicadoAtivo), 1, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, vagas, 1)
+}
+
+func TestVagaService_ListPublic_RepoError(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	mockVagaRepo.listError = errors.New("db error")
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	_, _, err := service.ListPublic(context.Background(), "", 1, 10)
+
+	assert.Error(t, err)
+	assert.Equal(t, "db error", err.Error())
+}
+
+// ==================== ListPublicActive Tests ====================
+
+func TestVagaService_ListPublicActive_Success(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	vagaID := uuid.New()
+	mockVagaRepo.vagas[vagaID] = &empregabilidade.Vaga{
+		ID:     vagaID,
+		Titulo: "Vaga Publica Ativa",
+		Status: empregabilidade.StatusVagaPublicadoAtivo,
+	}
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagas, total, err := service.ListPublicActive(context.Background(), 1, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, vagas, 1)
+}
+
+// ==================== ListByContratante Tests ====================
+
+func TestVagaService_ListByContratante_Success(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagas, total, err := service.ListByContratante(context.Background(), "12345678000100", 1, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, vagas)
+}
+
+func TestVagaService_ListByContratante_RepoError(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	mockVagaRepo.listError = errors.New("db error")
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	_, _, err := service.ListByContratante(context.Background(), "12345678000100", 1, 10)
+
+	assert.Error(t, err)
+}
+
+// ==================== ListByOrgaoParceiro Tests ====================
+
+func TestVagaService_ListByOrgaoParceiro_Success(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagas, total, err := service.ListByOrgaoParceiro(context.Background(), "ORG-001", 1, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, vagas)
+}
+
+func TestVagaService_ListByOrgaoParceiro_RepoError(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	mockVagaRepo.listError = errors.New("db error")
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	_, _, err := service.ListByOrgaoParceiro(context.Background(), "ORG-001", 1, 10)
+
 	assert.Error(t, err)
 }
 

--- a/internal/services/empregabilidade/vaga_service_test.go
+++ b/internal/services/empregabilidade/vaga_service_test.go
@@ -121,6 +121,10 @@ func (m *MockVagaRepoForService) ListPublicActive(ctx context.Context, limit, of
 	return nil, 0, nil
 }
 
+func (m *MockVagaRepoForService) ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
+	return nil, 0, nil
+}
+
 // Mock Empresa Repository for VagaService tests
 type MockEmpresaRepoForService struct {
 	empresas map[string]*empregabilidade.Empresa

--- a/internal/services/empregabilidade/vaga_service_test.go
+++ b/internal/services/empregabilidade/vaga_service_test.go
@@ -134,7 +134,7 @@ func (m *MockVagaRepoForService) ListPublicActive(ctx context.Context, limit, of
 	return result, len(result), nil
 }
 
-func (m *MockVagaRepoForService) ListPublic(ctx context.Context, status string, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
+func (m *MockVagaRepoForService) ListPublic(ctx context.Context, filter empregabilidade.VagaPublicFilter, limit, offset int) ([]*empregabilidade.Vaga, int, error) {
 	if m.listError != nil {
 		return nil, 0, m.listError
 	}
@@ -1361,7 +1361,7 @@ func TestVagaService_ListPublic_Success_Empty(t *testing.T) {
 	mockVagaRepo := NewMockVagaRepoForService()
 	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
 
-	vagas, total, err := service.ListPublic(context.Background(), "", 1, 10)
+	vagas, total, err := service.ListPublic(context.Background(), empregabilidade.VagaPublicFilter{}, 1, 10)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, total)
@@ -1378,7 +1378,7 @@ func TestVagaService_ListPublic_Success_WithVagas(t *testing.T) {
 	}
 	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
 
-	vagas, total, err := service.ListPublic(context.Background(), string(empregabilidade.StatusVagaPublicadoAtivo), 1, 10)
+	vagas, total, err := service.ListPublic(context.Background(), empregabilidade.VagaPublicFilter{Status: string(empregabilidade.StatusVagaPublicadoAtivo)}, 1, 10)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, total)
@@ -1390,7 +1390,7 @@ func TestVagaService_ListPublic_RepoError(t *testing.T) {
 	mockVagaRepo.listError = errors.New("db error")
 	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
 
-	_, _, err := service.ListPublic(context.Background(), "", 1, 10)
+	_, _, err := service.ListPublic(context.Background(), empregabilidade.VagaPublicFilter{}, 1, 10)
 
 	assert.Error(t, err)
 	assert.Equal(t, "db error", err.Error())


### PR DESCRIPTION
## Resumo

- **`PublicGetByID`** e **`PublicGetBySlug`** passam a retornar 200 para todos os status públicos (`publicado_ativo`, `publicado_expirado`, `vaga_congelada`, `vaga_descontinuada`). Antes retornavam 404 para qualquer status diferente de `publicado_ativo`.
- **`PublicList`** aceita o query param `?status=` para filtrar por um dos 4 status públicos. Sem filtro, retorna todos os 4. Status não-público (ex: `em_edicao`) retorna 400.

## Mudanças

| Arquivo | O que mudou |
|---|---|
| `repository/empregabilidade/vaga_repository.go` | Novo método `ListPublic` com filtro por status público |
| `services/empregabilidade/vaga_service.go` | Interface + método `ListPublic` no service |
| `handlers/v1/empregabilidade/vaga_handler.go` | `PublicList`, `PublicGetByID`, `PublicGetBySlug` atualizados |
| `*_test.go` | 16 novos testes TDD cobrindo todos os cenários novos |
| `docs/` | Swagger regenerado |

## Testes

```
go test -race ./...  → PASS (suite completa)
```

16 novos testes adicionados (TDD red→green):
- `PublicGetByID` retorna 200 para `publicado_expirado`, `vaga_congelada`, `vaga_descontinuada`
- `PublicGetByID` mantém 404 para `em_edicao` e `em_aprovacao`
- `PublicGetBySlug` retorna 200 para os 3 status não-ativos
- `PublicList` com filtro válido → 200
- `PublicList` com filtro inválido (ex: `em_edicao`) → 400

## Contexto

Refs: [PREF-323](https://iplanrio-pcrj.atlassian.net/browse/PREF-323)
Parent: [PREF-71](https://iplanrio-pcrj.atlassian.net/browse/PREF-71)