### PR TITLE
fix(empregabilidade): corrigir filtro ?contratante= por nome [PREF-323]

### DIFF
--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -321,8 +321,9 @@ func (r *VagaRepository) ListPublic(ctx context.Context, filter empregabilidade.
 			if len(digits) >= 11 {
 				db = db.Where("id_contratante = ?", digits)
 			} else {
-				db = db.Joins("JOIN emp_empresas ON emp_empresas.cnpj = emp_vagas.id_contratante").
-					Where("emp_empresas.nome ILIKE ?", "%"+filter.Contratante+"%")
+			db = db.Joins("JOIN emp_empresas ON emp_empresas.cnpj = emp_vagas.id_contratante").
+				Where("emp_empresas.razao_social ILIKE ? OR emp_empresas.nome_fantasia ILIKE ?",
+					"%"+filter.Contratante+"%", "%"+filter.Contratante+"%")
 			}
 		}
 


### PR DESCRIPTION
## Bug

`GET /api/public/empregabilidade/vagas?contratante=<nome>` retornava **HTTP 500** em staging.

```
ERROR: column emp_empresas.nome does not exist (SQLSTATE 42703)
```

## Causa

A query de JOIN com `emp_empresas` referenciava a coluna `nome`, que não existe. A tabela usa `razao_social` e `nome_fantasia`.

## Fix

```go
// Antes (bugado)
Where("emp_empresas.nome ILIKE ?", "%"+filter.Contratante+"%")

// Depois (correto)
Where("emp_empresas.razao_social ILIKE ? OR emp_empresas.nome_fantasia ILIKE ?",
    "%"+filter.Contratante+"%", "%"+filter.Contratante+"%")
```

Filtro por CNPJ (dígitos) não era afetado — continua funcionando normalmente.

## Detectado via

Teste de staging pós-deploy do PREF-323.

Refs: PREF-323