### PR TITLE
fix(ci): liberar gh pr create/edit/ready no claude-agent

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -48,3 +48,4 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
           model: "claude-sonnet-4-6@default"
+          allowed_tools: "Bash(gh pr create),Bash(gh pr edit),Bash(gh pr ready)"


### PR DESCRIPTION
## Problema

O agente Claude conseguia implementar código e fazer push de branches, mas não conseguia abrir PRs automaticamente. No log do Actions aparecia:

> _"The `gh pr create` command requires approval."_

O `claude-code-action@beta` bloqueia certos comandos Bash por padrão. Sem `allowed_tools` explícito, o agente caía no fallback de postar um link manual no comentário da issue.

## Solução

Adicionado `allowed_tools` com os três comandos necessários para o fluxo completo issue → PR:

- `gh pr create` — abre o PR automaticamente
- `gh pr edit` — atualiza título/descrição depois de criado
- `gh pr ready` — converte draft em ready for review

## Impacto

Nenhuma mudança de comportamento além de liberar esses três comandos específicos no contexto do workflow `claude-agent.yml`.