### PR TITLE
fix(ci): adicionar wildcard :* nos allowed_tools do claude-agent

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -48,4 +48,4 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           use_vertex: "true"
           model: "claude-sonnet-4-6@default"
-          allowed_tools: "Bash(gh pr create),Bash(gh pr edit),Bash(gh pr ready)"
+          allowed_tools: "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr ready:*)"


### PR DESCRIPTION
## Problema

O PR #106 liberou `gh pr create`, `gh pr edit` e `gh pr ready` no `allowed_tools`, mas mesmo assim o agente continuou falhando. No log do run **25922335401** (que já tinha o fix do #106 no main), a mensagem foi a mesma:

> _"This command requires approval"_

## Causa raiz

Os tools padrão do action usam o formato `Bash(git add:*)` — o `:\*` é o wildcard que autoriza qualquer combinação de argumentos após o prefixo. Sem ele, `Bash(gh pr create)` só casa com o comando **exato** `gh pr create` (sem argumentos), bloqueando `gh pr create --title "..." --body "..."`.

Evidência nos logs — tools padrão do action:
```
Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git rm:*)
```
Vs o que tinha no #106 (sem wildcard):
```
Bash(gh pr create),Bash(gh pr edit),Bash(gh pr ready)
```

## Solução

Adicionar `:\*` para seguir o mesmo padrão dos tools padrão:
```
Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr ready:*)
```