### PR TITLE
feat(empregabilidade): retornar titulo nas respostas_info_complementares [PREF-327]

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -10872,6 +10872,9 @@ const docTemplate = `{
                 },
                 "resposta": {
                     "type": "string"
+                },
+                "titulo": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -10870,6 +10870,9 @@
                 },
                 "resposta": {
                     "type": "string"
+                },
+                "titulo": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -398,6 +398,8 @@ definitions:
         type: string
       resposta:
         type: string
+      titulo:
+        type: string
     type: object
   empregabilidade.SituacaoAtual:
     properties:

--- a/internal/handlers/v1/empregabilidade/candidatura_handler.go
+++ b/internal/handlers/v1/empregabilidade/candidatura_handler.go
@@ -158,6 +158,7 @@ func (h *CandidaturaHandler) List(c *gin.Context) {
 		return
 	}
 
+	h.service.EnrichRespostasWithTituloMultiple(entities)
 	h.service.EnrichMultipleWithPersonalInfo(c.Request.Context(), entities)
 	c.JSON(http.StatusOK, gin.H{
 		"data": entities,
@@ -246,6 +247,7 @@ func (h *CandidaturaHandler) ListByCPF(c *gin.Context) {
 		return
 	}
 
+	h.service.EnrichRespostasWithTituloMultiple(entities)
 	h.service.EnrichMultipleWithPersonalInfo(c.Request.Context(), entities)
 	c.JSON(http.StatusOK, gin.H{
 		"data": entities,
@@ -290,6 +292,7 @@ func (h *CandidaturaHandler) GetByID(c *gin.Context) {
 		return
 	}
 
+	h.service.EnrichRespostasWithTitulo(entity)
 	h.service.EnrichWithPersonalInfo(c.Request.Context(), entity)
 	c.JSON(http.StatusOK, entity)
 }

--- a/internal/handlers/v1/empregabilidade/candidatura_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/candidatura_handler_test.go
@@ -2,6 +2,7 @@ package empregabilidade_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -1029,6 +1030,99 @@ func TestCandidaturaHandler_Update_GetByIDError_EdgeCase(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code == http.StatusOK {
 		t.Error("expected error status")
+	}
+}
+
+func TestCandidaturaHandler_GetByID_EnrichRespostasWithTitulo(t *testing.T) {
+	infoID := uuid.New()
+	candID := uuid.MustParse(validUUID)
+
+	candidatura := &empmodels.Candidatura{
+		ID:  candID,
+		CPF: "12345678900",
+		Vaga: &empmodels.Vaga{
+			ID: uuid.New(),
+			InformacoesComplementares: []empmodels.InformacaoComplementar{
+				{ID: infoID, Titulo: "Tem experiência com Go?"},
+			},
+		},
+		RespostasInfoComplementares: []empmodels.RespostaInfoComplementar{
+			{IDInfo: infoID, Resposta: "Sim"},
+		},
+	}
+
+	candRepo := &mockCandidaturaRepoH{entity: candidatura}
+	vagaRepo := &mockVagaForCandidaturaH{}
+	r := setupCandidaturaRouter(candRepo, vagaRepo, "12345678900", false)
+
+	req := httptest.NewRequest(http.MethodGet, "/candidaturas/"+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp empmodels.Candidatura
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(resp.RespostasInfoComplementares) != 1 {
+		t.Fatalf("expected 1 resposta, got %d", len(resp.RespostasInfoComplementares))
+	}
+	if resp.RespostasInfoComplementares[0].Titulo != "Tem experiência com Go?" {
+		t.Errorf("expected titulo %q, got %q", "Tem experiência com Go?", resp.RespostasInfoComplementares[0].Titulo)
+	}
+}
+
+func TestCandidaturaHandler_List_EnrichRespostasWithTitulo(t *testing.T) {
+	infoID := uuid.New()
+
+	candidatura := &empmodels.Candidatura{
+		ID:  uuid.New(),
+		CPF: "12345678900",
+		Vaga: &empmodels.Vaga{
+			ID: uuid.New(),
+			InformacoesComplementares: []empmodels.InformacaoComplementar{
+				{ID: infoID, Titulo: "Nível de escolaridade"},
+			},
+		},
+		RespostasInfoComplementares: []empmodels.RespostaInfoComplementar{
+			{IDInfo: infoID, Resposta: "Superior completo"},
+		},
+	}
+
+	candRepo := &mockCandidaturaRepoH{
+		listItems: []*empmodels.Candidatura{candidatura},
+		listTotal: 1,
+	}
+	vagaRepo := &mockVagaForCandidaturaH{}
+	r := setupCandidaturaRouter(candRepo, vagaRepo, "admin", true)
+
+	req := httptest.NewRequest(http.MethodGet, "/candidaturas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Data []empmodels.Candidatura `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 candidatura, got %d", len(resp.Data))
+	}
+	if len(resp.Data[0].RespostasInfoComplementares) != 1 {
+		t.Fatalf("expected 1 resposta, got %d", len(resp.Data[0].RespostasInfoComplementares))
+	}
+	if resp.Data[0].RespostasInfoComplementares[0].Titulo != "Nível de escolaridade" {
+		t.Errorf("expected titulo %q, got %q", "Nível de escolaridade", resp.Data[0].RespostasInfoComplementares[0].Titulo)
 	}
 }
 

--- a/internal/models/empregabilidade/candidatura.go
+++ b/internal/models/empregabilidade/candidatura.go
@@ -28,6 +28,7 @@ func (s StatusCandidatura) IsValid() bool {
 
 type RespostaInfoComplementar struct {
 	IDInfo   uuid.UUID `json:"id_info"`
+	Titulo   string    `json:"titulo"`
 	Resposta string    `json:"resposta"`
 }
 

--- a/internal/repository/empregabilidade/candidatura_repository.go
+++ b/internal/repository/empregabilidade/candidatura_repository.go
@@ -37,6 +37,7 @@ func (r *CandidaturaRepository) GetByID(ctx context.Context, id uuid.UUID) (*emp
 		Preload("Vaga").
 		Preload("Vaga.Contratante").
 		Preload("Vaga.Etapas").
+		Preload("Vaga.InformacoesComplementares").
 		Preload("EtapaAtual").
 		First(&entity, "id = ?", id)
 	if result.Error != nil {
@@ -101,6 +102,7 @@ func (r *CandidaturaRepository) List(ctx context.Context, filter empregabilidade
 		Preload("Vaga").
 		Preload("Vaga.Contratante").
 		Preload("Vaga.Etapas").
+		Preload("Vaga.InformacoesComplementares").
 		Preload("EtapaAtual").
 		Order("created_at DESC").
 		Limit(limit).

--- a/internal/services/empregabilidade/candidatura_service.go
+++ b/internal/services/empregabilidade/candidatura_service.go
@@ -389,6 +389,30 @@ func (s *CandidaturaService) Reject(ctx context.Context, id uuid.UUID) error {
 	return s.repo.UpdateStatus(ctx, id, empregabilidade.StatusCandidaturaReprovada)
 }
 
+// EnrichRespostasWithTitulo popula o campo Titulo em cada RespostaInfoComplementar
+// a partir das InformacoesComplementares da Vaga associada à candidatura.
+func (s *CandidaturaService) EnrichRespostasWithTitulo(c *empregabilidade.Candidatura) {
+	if c == nil || c.Vaga == nil || len(c.RespostasInfoComplementares) == 0 {
+		return
+	}
+
+	tituloByID := make(map[uuid.UUID]string, len(c.Vaga.InformacoesComplementares))
+	for _, info := range c.Vaga.InformacoesComplementares {
+		tituloByID[info.ID] = info.Titulo
+	}
+
+	for i := range c.RespostasInfoComplementares {
+		c.RespostasInfoComplementares[i].Titulo = tituloByID[c.RespostasInfoComplementares[i].IDInfo]
+	}
+}
+
+// EnrichRespostasWithTituloMultiple popula Titulo em RespostasInfoComplementares de múltiplas candidaturas.
+func (s *CandidaturaService) EnrichRespostasWithTituloMultiple(candidaturas []*empregabilidade.Candidatura) {
+	for _, c := range candidaturas {
+		s.EnrichRespostasWithTitulo(c)
+	}
+}
+
 // EnrichWithPersonalInfo popula PersonalInfo de uma candidatura a partir do citizen_snapshot.
 func (s *CandidaturaService) EnrichWithPersonalInfo(ctx context.Context, c *empregabilidade.Candidatura) {
 	if s.citizenSnapshotRepo == nil || c == nil || c.CPF == "" {

--- a/internal/services/empregabilidade/candidatura_service_test.go
+++ b/internal/services/empregabilidade/candidatura_service_test.go
@@ -1592,3 +1592,76 @@ func TestCandidaturaService_CountByStatus_Success(t *testing.T) {
 		}
 	})
 }
+
+func TestCandidaturaService_EnrichRespostasWithTitulo(t *testing.T) {
+	infoID1 := uuid.New()
+	infoID2 := uuid.New()
+	infoIDOrfao := uuid.New()
+
+	vaga := &empregabilidade.Vaga{
+		ID: uuid.New(),
+		InformacoesComplementares: []empregabilidade.InformacaoComplementar{
+			{ID: infoID1, Titulo: "Tem CNH?"},
+			{ID: infoID2, Titulo: "Anos de experiência"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		candidatura *empregabilidade.Candidatura
+		wantTitulos []string
+	}{
+		{
+			name: "popula titulo a partir da vaga",
+			candidatura: &empregabilidade.Candidatura{
+				Vaga: vaga,
+				RespostasInfoComplementares: []empregabilidade.RespostaInfoComplementar{
+					{IDInfo: infoID1, Resposta: "Sim"},
+					{IDInfo: infoID2, Resposta: "3"},
+				},
+			},
+			wantTitulos: []string{"Tem CNH?", "Anos de experiência"},
+		},
+		{
+			name: "id_info sem correspondencia fica com titulo vazio",
+			candidatura: &empregabilidade.Candidatura{
+				Vaga: vaga,
+				RespostasInfoComplementares: []empregabilidade.RespostaInfoComplementar{
+					{IDInfo: infoIDOrfao, Resposta: "alguma coisa"},
+				},
+			},
+			wantTitulos: []string{""},
+		},
+		{
+			name: "candidatura sem vaga nao panics",
+			candidatura: &empregabilidade.Candidatura{
+				Vaga: nil,
+				RespostasInfoComplementares: []empregabilidade.RespostaInfoComplementar{
+					{IDInfo: infoID1, Resposta: "Sim"},
+				},
+			},
+			wantTitulos: []string{""},
+		},
+		{
+			name:        "candidatura nil nao panics",
+			candidatura: nil,
+			wantTitulos: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := services.NewCandidaturaService(NewMockCandidaturaRepo(), NewMockVagaRepo(), NewMockCurriculoService(), nil, nil)
+			svc.EnrichRespostasWithTitulo(tt.candidatura)
+
+			if tt.candidatura == nil {
+				return
+			}
+			for i, resposta := range tt.candidatura.RespostasInfoComplementares {
+				if resposta.Titulo != tt.wantTitulos[i] {
+					t.Errorf("resposta[%d].Titulo = %q, want %q", i, resposta.Titulo, tt.wantTitulos[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## O que faz

Retorna o campo `titulo` dentro de cada item de `respostas_info_complementares` nas candidaturas.

## Problema

O campo `RespostaInfoComplementar` retornava apenas `id_info` e `resposta`. O frontend precisava do `titulo` da informação complementar para exibir o label correto ao usuário.

## Solução

- **Modelo**: adiciona `Titulo string` em `RespostaInfoComplementar`
- **Repository**: preload de `Vaga.InformacoesComplementares` nos queries de `GetByID` e `List`
- **Service**: `EnrichRespostasWithTitulo` que mapeia `id_info → titulo` a partir das infos complementares da vaga
- **Handlers**: `GetByID`, `List` e `ListByCPF` chamam o enriquecimento

Sem migration — o campo `respostas_info_complementares` é JSONB; apenas o schema de resposta muda.

## Endpoints afetados

- `GET /api/v1/empregabilidade/candidaturas`
- `GET /api/v1/empregabilidade/candidaturas/{id}`
- `GET /api/v1/empregabilidade/candidaturas/usuario/{cpf}`

## Testes

TDD aplicado. 6 novos cenários:
- `TestCandidaturaService_EnrichRespostasWithTitulo` (4 sub-testes)
- `TestCandidaturaHandler_GetByID_EnrichRespostasWithTitulo`
- `TestCandidaturaHandler_List_EnrichRespostasWithTitulo`

Closes [PREF-327](https://iplanrio-pcrj.atlassian.net/browse/PREF-327)