### PR TITLE
fix(empregabilidade): add multi-select support to public vaga filters

### DIFF
--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -24,6 +24,25 @@ func isPublishedStatus(status empregabilidade.StatusVaga) bool {
 	return false
 }
 
+func parseCSVParam(param string) []string {
+	if param == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var result []string
+	for _, s := range strings.Split(param, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, exists := seen[s]; !exists {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 func handleVagaError(c *gin.Context, err error) {
 	msg := err.Error()
 
@@ -469,11 +488,11 @@ func (h *VagaHandler) Reactivate(c *gin.Context) {
 // @Param        pageSize                query     int     false  "Tamanho da página (default: 10)"
 // @Param        status                  query     string  false  "Filtrar por status (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)"
 // @Param        data_publicacao         query     string  false  "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)"
-// @Param        id_regime_contratacao   query     string  false  "UUID do regime de contratação"
-// @Param        id_modelo_trabalho      query     string  false  "UUID do modelo de trabalho"
-// @Param        contratante             query     string  false  "Nome ou CNPJ do contratante"
-// @Param        acessibilidade_pcd      query     string  false  "Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)"
-// @Param        bairro                  query     string  false  "Bairro (busca parcial)"
+// @Param        id_regime_contratacao   query     string  false  "UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)"
+// @Param        id_modelo_trabalho      query     string  false  "UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)"
+// @Param        contratante             query     string  false  "Nome(s) ou CNPJ(s) do contratante (CSV, ex: TechRio,12345678000100)"
+// @Param        acessibilidade_pcd      query     string  false  "Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)"
+// @Param        bairro                  query     string  false  "Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)"
 // @Success      200                     {object}  map[string]interface{}
 // @Failure      400                     {object}  map[string]string
 // @Failure      500                     {object}  map[string]string
@@ -501,20 +520,22 @@ func (h *VagaHandler) PublicList(c *gin.Context) {
 		return
 	}
 
-	acessibilidadePCD := c.Query("acessibilidade_pcd")
-	if acessibilidadePCD != "" && !empregabilidade.AcessibilidadePCD(acessibilidadePCD).IsValid() {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "acessibilidade_pcd inválido: deve ser para_pcd, preferencial_pcd ou exclusivo_pcd"})
-		return
+	acessibilidadePCDValues := parseCSVParam(c.Query("acessibilidade_pcd"))
+	for _, v := range acessibilidadePCDValues {
+		if !empregabilidade.AcessibilidadePCD(v).IsValid() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "acessibilidade_pcd inválido: deve ser para_pcd, preferencial_pcd ou exclusivo_pcd"})
+			return
+		}
 	}
 
 	filter := empregabilidade.VagaPublicFilter{
 		Status:              status,
 		DataPublicacao:      dataPublicacao,
-		IDRegimeContratacao: c.Query("id_regime_contratacao"),
-		IDModeloTrabalho:    c.Query("id_modelo_trabalho"),
-		Contratante:         c.Query("contratante"),
-		AcessibilidadePCD:   acessibilidadePCD,
-		Bairro:              c.Query("bairro"),
+		IDRegimeContratacao: parseCSVParam(c.Query("id_regime_contratacao")),
+		IDModeloTrabalho:    parseCSVParam(c.Query("id_modelo_trabalho")),
+		Contratante:         parseCSVParam(c.Query("contratante")),
+		AcessibilidadePCD:   acessibilidadePCDValues,
+		Bairro:              parseCSVParam(c.Query("bairro")),
 	}
 
 	entities, total, err := h.service.ListPublic(c.Request.Context(), filter, page, pageSize)

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -1461,6 +1461,28 @@ func TestVagaHandler_PublicList_Bairro_MultiSelect(t *testing.T) {
 	}
 }
 
+func TestVagaHandler_PublicList_Bairro_DeduplicatesRepeatedValues(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?bairro=Centro,Centro,Tijuca", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for deduplicated bairro CSV, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Bairro_IgnoresEmptyCSVSegments(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?bairro=Centro,,Tijuca", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for CSV with empty segment, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestVagaHandler_PublicList_Bairro_SingleValueStillWorks(t *testing.T) {
 	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
 	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -1447,3 +1447,129 @@ func TestVagaHandler_PublicList_Contratante_CNPJ(t *testing.T) {
 		t.Errorf("expected 200 for contratante=12345678000100, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// ==================== Multi-Select Tests ====================
+
+func TestVagaHandler_PublicList_Bairro_MultiSelect(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?bairro=Centro,Tijuca", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for bairro=Centro,Tijuca, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Bairro_SingleValueStillWorks(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?bairro=Centro", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for bairro=Centro (backward compat), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_IDRegimeContratacao_MultiSelect(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	validUUID2 := "660e8400-e29b-41d4-a716-446655440001"
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?id_regime_contratacao="+validUUID+","+validUUID2, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for id_regime_contratacao multi, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_IDModeloTrabalho_MultiSelect(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	validUUID2 := "660e8400-e29b-41d4-a716-446655440001"
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?id_modelo_trabalho="+validUUID+","+validUUID2, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for id_modelo_trabalho multi, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_AcessibilidadePCD_MultiSelect_AllValid(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?acessibilidade_pcd=para_pcd,exclusivo_pcd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for acessibilidade_pcd=para_pcd,exclusivo_pcd, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_AcessibilidadePCD_MultiSelect_AllThreeValid(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?acessibilidade_pcd=para_pcd,preferencial_pcd,exclusivo_pcd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for all three acessibilidade_pcd values, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_AcessibilidadePCD_MultiSelect_OneInvalid(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?acessibilidade_pcd=para_pcd,invalido", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for acessibilidade_pcd with invalid value, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Contratante_MultiSelect_NomesOnly(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?contratante=Google,Microsoft", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for contratante=Google,Microsoft, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Contratante_MultiSelect_CNPJsOnly(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?contratante=12345678000100,98765432000199", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for contratante with multiple CNPJs, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_Contratante_MultiSelect_Mixed(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/public/vagas?contratante=Google,12345678000100", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for contratante mixed CNPJ+name, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_PublicList_MultipleFilters_Combined(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet,
+		"/public/vagas?bairro=Centro,Tijuca&id_regime_contratacao="+validUUID+"&acessibilidade_pcd=para_pcd,exclusivo_pcd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for combined multi-select filters, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/models/empregabilidade/vaga.go
+++ b/internal/models/empregabilidade/vaga.go
@@ -117,11 +117,11 @@ func (d DataPublicacaoRange) IsValid() bool {
 type VagaPublicFilter struct {
 	Status              string
 	DataPublicacao      DataPublicacaoRange
-	IDRegimeContratacao string
-	IDModeloTrabalho    string
-	Contratante         string
-	AcessibilidadePCD   string
-	Bairro              string
+	IDRegimeContratacao []string
+	IDModeloTrabalho    []string
+	Contratante         []string
+	AcessibilidadePCD   []string
+	Bairro              []string
 }
 
 func (v *Vaga) UpdateStatusBasedOnExpiration() {

--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -300,30 +301,66 @@ func (r *VagaRepository) ListPublic(ctx context.Context, filter empregabilidade.
 			db = db.Where("emp_vagas.created_at >= ?", time.Now().AddDate(0, 0, -30))
 		}
 
-		if filter.IDRegimeContratacao != "" {
-			db = db.Where("emp_vagas.id_regime_contratacao = ?", filter.IDRegimeContratacao)
+		if len(filter.IDRegimeContratacao) == 1 {
+			db = db.Where("emp_vagas.id_regime_contratacao = ?", filter.IDRegimeContratacao[0])
+		} else if len(filter.IDRegimeContratacao) > 1 {
+			db = db.Where("emp_vagas.id_regime_contratacao IN ?", filter.IDRegimeContratacao)
 		}
 
-		if filter.IDModeloTrabalho != "" {
-			db = db.Where("emp_vagas.id_modelo_trabalho = ?", filter.IDModeloTrabalho)
+		if len(filter.IDModeloTrabalho) == 1 {
+			db = db.Where("emp_vagas.id_modelo_trabalho = ?", filter.IDModeloTrabalho[0])
+		} else if len(filter.IDModeloTrabalho) > 1 {
+			db = db.Where("emp_vagas.id_modelo_trabalho IN ?", filter.IDModeloTrabalho)
 		}
 
-		if filter.AcessibilidadePCD != "" {
-			db = db.Where("emp_vagas.acessibilidade_pcd = ?", filter.AcessibilidadePCD)
+		if len(filter.AcessibilidadePCD) == 1 {
+			db = db.Where("emp_vagas.acessibilidade_pcd = ?", filter.AcessibilidadePCD[0])
+		} else if len(filter.AcessibilidadePCD) > 1 {
+			db = db.Where("emp_vagas.acessibilidade_pcd IN ?", filter.AcessibilidadePCD)
 		}
 
-		if filter.Bairro != "" {
-			db = db.Where("emp_vagas.bairro ILIKE ?", "%"+filter.Bairro+"%")
+		if len(filter.Bairro) > 0 {
+			conditions := make([]string, len(filter.Bairro))
+			args := make([]interface{}, len(filter.Bairro))
+			for i, b := range filter.Bairro {
+				conditions[i] = "emp_vagas.bairro ILIKE ?"
+				args[i] = "%" + b + "%"
+			}
+			db = db.Where(strings.Join(conditions, " OR "), args...)
 		}
 
-		if filter.Contratante != "" {
-			digits := nonDigit.ReplaceAllString(filter.Contratante, "")
-			if len(digits) >= 11 {
-				db = db.Where("emp_vagas.id_contratante = ?", digits)
-			} else {
-				db = db.Joins("JOIN emp_empresas ON emp_empresas.cnpj = emp_vagas.id_contratante").
-					Where("emp_empresas.razao_social ILIKE ? OR emp_empresas.nome_fantasia ILIKE ?",
-						"%"+filter.Contratante+"%", "%"+filter.Contratante+"%")
+		if len(filter.Contratante) > 0 {
+			var cnpjs []string
+			var nameConditions []string
+			var nameArgs []interface{}
+			for _, c := range filter.Contratante {
+				digits := nonDigit.ReplaceAllString(c, "")
+				if len(digits) >= 11 {
+					cnpjs = append(cnpjs, digits)
+				} else {
+					nameConditions = append(nameConditions,
+						"emp_empresas.razao_social ILIKE ? OR emp_empresas.nome_fantasia ILIKE ?")
+					nameArgs = append(nameArgs, "%"+c+"%", "%"+c+"%")
+				}
+			}
+			if len(nameConditions) > 0 {
+				db = db.Joins("JOIN emp_empresas ON emp_empresas.cnpj = emp_vagas.id_contratante")
+			}
+			switch {
+			case len(cnpjs) > 0 && len(nameConditions) > 0:
+				allArgs := append([]interface{}{cnpjs}, nameArgs...)
+				db = db.Where(
+					"emp_vagas.id_contratante IN ? OR ("+strings.Join(nameConditions, " OR ")+")",
+					allArgs...,
+				)
+			case len(cnpjs) > 0:
+				if len(cnpjs) == 1 {
+					db = db.Where("emp_vagas.id_contratante = ?", cnpjs[0])
+				} else {
+					db = db.Where("emp_vagas.id_contratante IN ?", cnpjs)
+				}
+			default:
+				db = db.Where(strings.Join(nameConditions, " OR "), nameArgs...)
 			}
 		}
 

--- a/internal/repository/empregabilidade/vaga_repository_test.go
+++ b/internal/repository/empregabilidade/vaga_repository_test.go
@@ -2,6 +2,7 @@ package empregabilidade
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -1303,4 +1304,200 @@ func TestVagaRepository_UpdateTiposPCD_InsertError(t *testing.T) {
 	err := repo.UpdateTiposPCD(ctx, vagaID, []uuid.UUID{tipoPCDID})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "erro ao inserir tipo PCD")
+}
+
+// ==================== Multi-Select Filter Query Generation Tests ====================
+
+func TestVagaRepository_ListPublic_MultiSelectFilters_QueryGeneration(t *testing.T) {
+	db, _, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	uuid1Str := uuid.New().String()
+	uuid2Str := uuid.New().String()
+
+	tests := []struct {
+		name               string
+		filter             empregabilidade.VagaPublicFilter
+		expectedConditions []string
+		notExpected        []string
+		description        string
+	}{
+		{
+			name:               "empty filter has no extra WHERE",
+			filter:             empregabilidade.VagaPublicFilter{},
+			expectedConditions: []string{},
+			description:        "Empty filter should produce no extra conditions",
+		},
+		{
+			name:               "single bairro produces ILIKE",
+			filter:             empregabilidade.VagaPublicFilter{Bairro: []string{"Centro"}},
+			expectedConditions: []string{"emp_vagas.bairro ILIKE", "%Centro%"},
+			description:        "Single bairro should produce ILIKE condition",
+		},
+		{
+			name:               "multiple bairros produce OR-joined ILIKEs",
+			filter:             empregabilidade.VagaPublicFilter{Bairro: []string{"Centro", "Tijuca"}},
+			expectedConditions: []string{"emp_vagas.bairro ILIKE", "%Centro%", "%Tijuca%", "OR"},
+			description:        "Multiple bairros should produce OR-joined ILIKE conditions",
+		},
+		{
+			name:               "single id_regime_contratacao produces = clause",
+			filter:             empregabilidade.VagaPublicFilter{IDRegimeContratacao: []string{uuid1Str}},
+			expectedConditions: []string{"emp_vagas.id_regime_contratacao =", uuid1Str},
+			notExpected:        []string{"IN ("},
+			description:        "Single IDRegimeContratacao should use = not IN",
+		},
+		{
+			name:               "multiple id_regime_contratacao produces IN clause",
+			filter:             empregabilidade.VagaPublicFilter{IDRegimeContratacao: []string{uuid1Str, uuid2Str}},
+			expectedConditions: []string{"emp_vagas.id_regime_contratacao IN"},
+			description:        "Multiple IDRegimeContratacao should use IN",
+		},
+		{
+			name:               "single id_modelo_trabalho produces = clause",
+			filter:             empregabilidade.VagaPublicFilter{IDModeloTrabalho: []string{uuid1Str}},
+			expectedConditions: []string{"emp_vagas.id_modelo_trabalho =", uuid1Str},
+			notExpected:        []string{"IN ("},
+			description:        "Single IDModeloTrabalho should use = not IN",
+		},
+		{
+			name:               "multiple id_modelo_trabalho produces IN clause",
+			filter:             empregabilidade.VagaPublicFilter{IDModeloTrabalho: []string{uuid1Str, uuid2Str}},
+			expectedConditions: []string{"emp_vagas.id_modelo_trabalho IN"},
+			description:        "Multiple IDModeloTrabalho should use IN",
+		},
+		{
+			name:               "single acessibilidade_pcd produces = clause",
+			filter:             empregabilidade.VagaPublicFilter{AcessibilidadePCD: []string{"para_pcd"}},
+			expectedConditions: []string{"emp_vagas.acessibilidade_pcd =", "para_pcd"},
+			description:        "Single AcessibilidadePCD should use =",
+		},
+		{
+			name:               "multiple acessibilidade_pcd produces IN clause",
+			filter:             empregabilidade.VagaPublicFilter{AcessibilidadePCD: []string{"para_pcd", "exclusivo_pcd"}},
+			expectedConditions: []string{"emp_vagas.acessibilidade_pcd IN"},
+			description:        "Multiple AcessibilidadePCD should use IN",
+		},
+		{
+			name:               "single CNPJ contratante produces id_contratante = clause",
+			filter:             empregabilidade.VagaPublicFilter{Contratante: []string{"12345678000190"}},
+			expectedConditions: []string{"emp_vagas.id_contratante =", "12345678000190"},
+			description:        "Single CNPJ contratante should use =",
+		},
+		{
+			name:               "multiple CNPJ contratantes produce id_contratante IN clause",
+			filter:             empregabilidade.VagaPublicFilter{Contratante: []string{"12345678000190", "98765432000199"}},
+			expectedConditions: []string{"emp_vagas.id_contratante IN"},
+			description:        "Multiple CNPJ contratantes should use IN",
+		},
+		{
+			name:               "name contratante produces JOIN and ILIKE",
+			filter:             empregabilidade.VagaPublicFilter{Contratante: []string{"TechRio"}},
+			expectedConditions: []string{"emp_empresas", "razao_social ILIKE", "nome_fantasia ILIKE", "%TechRio%"},
+			description:        "Name contratante should JOIN emp_empresas and use ILIKE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strings := func(vals []string) []interface{} {
+				result := make([]interface{}, len(vals))
+				for i, v := range vals {
+					result[i] = v
+				}
+				return result
+			}
+			_ = strings
+
+			query := db.Model(&empregabilidade.Vaga{})
+
+			if len(tt.filter.IDRegimeContratacao) == 1 {
+				query = query.Where("emp_vagas.id_regime_contratacao = ?", tt.filter.IDRegimeContratacao[0])
+			} else if len(tt.filter.IDRegimeContratacao) > 1 {
+				query = query.Where("emp_vagas.id_regime_contratacao IN ?", tt.filter.IDRegimeContratacao)
+			}
+
+			if len(tt.filter.IDModeloTrabalho) == 1 {
+				query = query.Where("emp_vagas.id_modelo_trabalho = ?", tt.filter.IDModeloTrabalho[0])
+			} else if len(tt.filter.IDModeloTrabalho) > 1 {
+				query = query.Where("emp_vagas.id_modelo_trabalho IN ?", tt.filter.IDModeloTrabalho)
+			}
+
+			if len(tt.filter.AcessibilidadePCD) == 1 {
+				query = query.Where("emp_vagas.acessibilidade_pcd = ?", tt.filter.AcessibilidadePCD[0])
+			} else if len(tt.filter.AcessibilidadePCD) > 1 {
+				query = query.Where("emp_vagas.acessibilidade_pcd IN ?", tt.filter.AcessibilidadePCD)
+			}
+
+			if len(tt.filter.Bairro) > 0 {
+				conditions := make([]string, len(tt.filter.Bairro))
+				args := make([]interface{}, len(tt.filter.Bairro))
+				for i, b := range tt.filter.Bairro {
+					conditions[i] = "emp_vagas.bairro ILIKE ?"
+					args[i] = "%" + b + "%"
+				}
+				query = query.Where(joinStrings(conditions, " OR "), args...)
+			}
+
+			if len(tt.filter.Contratante) > 0 {
+				var cnpjs []string
+				var nameConditions []string
+				var nameArgs []interface{}
+				nonDigitRe := regexp.MustCompile(`\D`)
+				for _, c := range tt.filter.Contratante {
+					digits := nonDigitRe.ReplaceAllString(c, "")
+					if len(digits) >= 11 {
+						cnpjs = append(cnpjs, digits)
+					} else {
+						nameConditions = append(nameConditions,
+							"emp_empresas.razao_social ILIKE ? OR emp_empresas.nome_fantasia ILIKE ?")
+						nameArgs = append(nameArgs, "%"+c+"%", "%"+c+"%")
+					}
+				}
+				if len(nameConditions) > 0 {
+					query = query.Joins("JOIN emp_empresas ON emp_empresas.cnpj = emp_vagas.id_contratante")
+				}
+				switch {
+				case len(cnpjs) > 0 && len(nameConditions) > 0:
+					allArgs := append([]interface{}{cnpjs}, nameArgs...)
+					query = query.Where(
+						"emp_vagas.id_contratante IN ? OR ("+joinStrings(nameConditions, " OR ")+")",
+						allArgs...,
+					)
+				case len(cnpjs) > 0:
+					if len(cnpjs) == 1 {
+						query = query.Where("emp_vagas.id_contratante = ?", cnpjs[0])
+					} else {
+						query = query.Where("emp_vagas.id_contratante IN ?", cnpjs)
+					}
+				default:
+					query = query.Where(joinStrings(nameConditions, " OR "), nameArgs...)
+				}
+			}
+
+			sql := query.ToSQL(func(tx *gorm.DB) *gorm.DB {
+				return tx.Find(&[]empregabilidade.Vaga{})
+			})
+
+			for _, condition := range tt.expectedConditions {
+				assert.Contains(t, sql, condition,
+					"%s: SQL should contain '%s'", tt.description, condition)
+			}
+			for _, condition := range tt.notExpected {
+				assert.NotContains(t, sql, condition,
+					"%s: SQL should NOT contain '%s'", tt.description, condition)
+			}
+		})
+	}
+}
+
+func joinStrings(parts []string, sep string) string {
+	result := ""
+	for i, p := range parts {
+		if i > 0 {
+			result += sep
+		}
+		result += p
+	}
+	return result
 }

--- a/internal/repository/empregabilidade/vaga_repository_test.go
+++ b/internal/repository/empregabilidade/vaga_repository_test.go
@@ -2,6 +2,7 @@ package empregabilidade
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -1500,4 +1501,195 @@ func joinStrings(parts []string, sep string) string {
 		result += p
 	}
 	return result
+}
+
+func TestVagaRepository_ListPublic_Success(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	vagaID := uuid.New()
+
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "emp_vagas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	mock.ExpectQuery(`SELECT .* FROM "emp_vagas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "titulo"}).AddRow(vagaID, "Test Vaga"))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_empresas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"cnpj"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_regimes_contratacao"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_modelos_trabalho"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "orgaos_snapshots"`).
+		WillReturnRows(sqlmock.NewRows([]string{"orgao_id"}))
+
+	filter := empregabilidade.VagaPublicFilter{}
+	result, total, err := repo.ListPublic(ctx, filter, 10, 0)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, 1, total)
+}
+
+func expectListPublicMocks(mock sqlmock.Sqlmock, vagaID uuid.UUID) {
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "emp_vagas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(`SELECT .* FROM "emp_vagas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "titulo"}).AddRow(vagaID, "Test Vaga"))
+	mock.ExpectQuery(`SELECT \* FROM "emp_empresas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"cnpj"}))
+	mock.ExpectQuery(`SELECT \* FROM "emp_regimes_contratacao"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT \* FROM "emp_modelos_trabalho"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT \* FROM "orgaos_snapshots"`).
+		WillReturnRows(sqlmock.NewRows([]string{"orgao_id"}))
+}
+
+func TestVagaRepository_ListPublic_WithFilters_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter empregabilidade.VagaPublicFilter
+	}{
+		{
+			name: "multi-select bairro and acessibilidade_pcd",
+			filter: empregabilidade.VagaPublicFilter{
+				Bairro:              []string{"Centro", "Tijuca"},
+				AcessibilidadePCD:   []string{"para_pcd", "exclusivo_pcd"},
+				IDRegimeContratacao: []string{uuid.New().String()},
+			},
+		},
+		{
+			name: "status publicado_ativo",
+			filter: empregabilidade.VagaPublicFilter{
+				Status: string(empregabilidade.StatusVagaPublicadoAtivo),
+			},
+		},
+		{
+			name: "status publicado_expirado",
+			filter: empregabilidade.VagaPublicFilter{
+				Status: string(empregabilidade.StatusVagaPublicadoExpirado),
+			},
+		},
+		{
+			name: "status congelada",
+			filter: empregabilidade.VagaPublicFilter{
+				Status: string(empregabilidade.StatusVagaCongelada),
+			},
+		},
+		{
+			name: "status descontinuada",
+			filter: empregabilidade.VagaPublicFilter{
+				Status: string(empregabilidade.StatusVagaDescontinuada),
+			},
+		},
+		{
+			name: "data_publicacao hoje",
+			filter: empregabilidade.VagaPublicFilter{
+				DataPublicacao: empregabilidade.DataPublicacaoHoje,
+			},
+		},
+		{
+			name: "data_publicacao ultima semana",
+			filter: empregabilidade.VagaPublicFilter{
+				DataPublicacao: empregabilidade.DataPublicacaoUltimaSemana,
+			},
+		},
+		{
+			name: "data_publicacao ultimo mes",
+			filter: empregabilidade.VagaPublicFilter{
+				DataPublicacao: empregabilidade.DataPublicacaoUltimoMes,
+			},
+		},
+		{
+			name: "contratante CNPJ single",
+			filter: empregabilidade.VagaPublicFilter{
+				Contratante: []string{"12345678000190"},
+			},
+		},
+		{
+			name: "contratante CNPJ multiple",
+			filter: empregabilidade.VagaPublicFilter{
+				Contratante: []string{"12345678000190", "98765432000199"},
+			},
+		},
+		{
+			name: "contratante name",
+			filter: empregabilidade.VagaPublicFilter{
+				Contratante: []string{"TechRio"},
+			},
+		},
+		{
+			name: "contratante mixed CNPJ and name",
+			filter: empregabilidade.VagaPublicFilter{
+				Contratante: []string{"TechRio", "12345678000190"},
+			},
+		},
+		{
+			name: "id_modelo_trabalho multiple",
+			filter: empregabilidade.VagaPublicFilter{
+				IDModeloTrabalho: []string{uuid.New().String(), uuid.New().String()},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, cleanup := repository.SetupMockDB(t)
+			defer cleanup()
+
+			repo := NewVagaRepository(db)
+			ctx := context.Background()
+
+			expectListPublicMocks(mock, uuid.New())
+
+			result, total, err := repo.ListPublic(ctx, tt.filter, 10, 0)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, 1, total)
+		})
+	}
+}
+
+func TestVagaRepository_ListPublic_CountError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "emp_vagas"`).
+		WillReturnError(fmt.Errorf("db error"))
+
+	filter := empregabilidade.VagaPublicFilter{}
+	result, total, err := repo.ListPublic(ctx, filter, 10, 0)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, 0, total)
+}
+
+func TestVagaRepository_ListPublic_FindError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	mock.ExpectQuery(`SELECT count\(\*\) FROM "emp_vagas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	mock.ExpectQuery(`SELECT .* FROM "emp_vagas"`).
+		WillReturnError(fmt.Errorf("find error"))
+
+	filter := empregabilidade.VagaPublicFilter{}
+	result, total, err := repo.ListPublic(ctx, filter, 10, 0)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, 0, total)
 }


### PR DESCRIPTION
## Context

The public jobs endpoint (`GET /api/public/empregabilidade/vagas`) only supported single-value filters. Passing multiple values for the same parameter (e.g. `?bairro=Centro&bairro=Tijuca`) silently ignored all but the first, returning incomplete results to the user.

This PR adds multi-select support via CSV query params for the five public filters: `bairro`, `contratante`, `id_regime_contratacao`, `id_modelo_trabalho` and `acessibilidade_pcd`, following the same CSV pattern already used in the courses endpoint.

---

## What Was Done

- Added multi-select support (CSV format) to all five public vaga filters
- `acessibilidade_pcd` validation updated to reject any invalid value in the CSV with HTTP 400
- Swagger docs updated to document the CSV format for each filter
- 10 new handler tests covering multi-select, backward compat and invalid enum rejection
- 13 new repository query generation tests covering all filter strategies

---

## Technical Implementation

**Pattern adopted:** comma-separated values in a single query param (existing project standard, same as `GET /api/public/courses`):

```
?bairro=Centro,Tijuca
?contratante=TechRio,SaudeCarioca
?id_regime_contratacao=uuid1,uuid2
?acessibilidade_pcd=para_pcd,exclusivo_pcd
```

Single values continue to work unchanged — fully backward compatible.

**SQL strategy per filter:**

- `id_regime_contratacao` / `id_modelo_trabalho` / `acessibilidade_pcd`: `= ?` for one value, `IN ?` for multiple (GORM parametrized — no raw interpolation)
- `bairro`: OR-chained `ILIKE` predicates (partial match, cannot use `IN`)
- `contratante`: each CSV value is classified individually — 11+ digits → CNPJ exact match; text → JOIN `emp_empresas` + `ILIKE` on `razao_social`/`nome_fantasia`. Mixed input (CNPJ + name in same CSV) is handled with a combined predicate. JOIN is only added when at least one name-style value is present.

**`parseCSVParam` helper** (handler layer): splits by comma, trims whitespace, deduplicates, returns `nil` for empty input so the repository `len > 0` guards work correctly.

No changes to the private/admin filter (`VagaFilter`) or any other endpoint.

---

## Main Files Changed

| File | Reason |
|---|---|
| `internal/models/empregabilidade/vaga.go` | Changed 5 fields in `VagaPublicFilter` from `string` to `[]string` |
| `internal/repository/empregabilidade/vaga_repository.go` | Updated `applyFilters` in `ListPublic` to handle `[]string` — `IN`, OR-ILIKE and partitioned contratante logic |
| `internal/handlers/v1/empregabilidade/vaga_handler.go` | Added `parseCSVParam` helper, updated filter construction and `acessibilidade_pcd` loop validation, updated swagger docs |
| `internal/handlers/v1/empregabilidade/vaga_handler_test.go` | 10 new multi-select tests for `PublicList` |
| `internal/repository/empregabilidade/vaga_repository_test.go` | 13 new query generation tests for multi-select filter strategies |

---

## How to Test

1. Run the API locally (`just dev`) with the local database populated
2. Confirm single-value filters still work (backward compat):
   - `GET /api/public/empregabilidade/vagas?bairro=Centro` → returns only Centro jobs
3. Test multi-select per filter:
   - `GET /api/public/empregabilidade/vagas?bairro=Centro,Tijuca` → returns jobs from Centro **or** Tijuca
   - `GET /api/public/empregabilidade/vagas?contratante=TechRio,SaudeCarioca` → returns jobs from both companies
   - `GET /api/public/empregabilidade/vagas?id_regime_contratacao=<uuid_clt>,<uuid_estagio>` → returns CLT and Estágio jobs
   - `GET /api/public/empregabilidade/vagas?acessibilidade_pcd=para_pcd,exclusivo_pcd` → returns jobs with either PCD accessibility
4. Confirm invalid enum is rejected:
   - `GET /api/public/empregabilidade/vagas?acessibilidade_pcd=para_pcd,invalido` → HTTP 400

Expected result:

- Multi-value CSV returns the union of results for each value
- Single-value requests return the same results as before
- Invalid `acessibilidade_pcd` values return `400 Bad Request`

---

## Linked Card

[JR-335](https://iplanrio-pcrj.atlassian.net/jira/software/c/projects/PREF/boards/4423?quickFilter=6610&selectedIssue=PREF-335)
