### PR TITLE
fix: corrige URL do Prometheus nos manifests K8s

### DIFF
--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -152,7 +152,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://prometheus.istio-system.svc.cluster.local:9090
+        serverAddress: http://prometheus-server.istio-system.svc.cluster.local:9090
         metricName: http_requests_total
         threshold: "100"
         query: sum(rate(istio_requests_total{destination_workload="go"}[30s]))
@@ -200,7 +200,7 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code!~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(1)
     - name: error-rate
@@ -209,6 +209,6 @@ spec:
       failureLimit: 5
       provider:
         prometheus:
-          address: http://prometheus.istio-system.svc.cluster.local:9090
+          address: http://prometheus-server.istio-system.svc.cluster.local:9090
           query: |
             (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}",response_code=~"5.."}[2m])) or vector(0)) / (sum(rate(istio_requests_total{destination_service_name=~"{{args.service-name}}"}[2m])) > 0) or vector(0)

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -127,7 +127,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://prometheus.istio-system.svc.cluster.local:9090
+        serverAddress: http://prometheus-server.istio-system.svc.cluster.local:9090
         metricName: http_requests_total
         threshold: "100"
         query: sum(rate(istio_requests_total{destination_workload="go"}[30s]))


### PR DESCRIPTION
## Problema

O deploy de produção (v0.1.6) estava falhando no passo **Monitor Rollout** porque o Argo Rollouts não conseguia consultar o Prometheus para validar a métrica `success-rate` durante o canary.

**Erro:**
```
Metric "success-rate" assessed Error due to consecutiveErrors (5) > consecutiveErrorLimit (4):
"Error Message: Post "http://prometheus.istio-system.svc.cluster.local:9090/api/v1/query":
dial tcp: lookup prometheus.istio-system.svc.cluster.local on 10.20.0.10:53: no such host"
```

## Causa

O Prometheus foi reinstalado há ~14 dias com o nome de serviço `prometheus-server` (padrão do Helm chart kube-prometheus-stack), mas os manifests K8s ainda referenciavam o nome antigo `prometheus`.

## Solução

Atualiza o endereço do Prometheus de:
`http://prometheus.istio-system.svc.cluster.local:9090`

Para:
`http://prometheus-server.istio-system.svc.cluster.local:9090`

### Arquivos alterados
- `k8s/prod/resources.yaml` — KEDA trigger + 2× AnalysisTemplate (`go-success-rate`)
- `k8s/staging/resources.yaml` — KEDA trigger