### PR TITLE
Fix/jr 347/courses adjusts bulk enrollment

### DIFF
--- a/internal/handlers/v1/course_handler_test.go
+++ b/internal/handlers/v1/course_handler_test.go
@@ -84,6 +84,11 @@ func (m *MockInscricaoServiceForCourse) Create(ctx context.Context, inscricao *m
 	return args.Error(0)
 }
 
+func (m *MockInscricaoServiceForCourse) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
+	args := m.Called(ctx, inscricao)
+	return args.Error(0)
+}
+
 func (m *MockInscricaoServiceForCourse) CreateManual(ctx context.Context, inscricao *models.Inscricao) error {
 	args := m.Called(ctx, inscricao)
 	return args.Error(0)

--- a/internal/handlers/v1/inscricao_handler_list_test.go
+++ b/internal/handlers/v1/inscricao_handler_list_test.go
@@ -28,6 +28,10 @@ func (m *mockInscricaoServiceForList) Create(ctx context.Context, inscricao *mod
 	return nil
 }
 
+func (m *mockInscricaoServiceForList) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
+	return nil
+}
+
 func (m *mockInscricaoServiceForList) CreateManual(ctx context.Context, inscricao *models.Inscricao) error {
 	return nil
 }

--- a/internal/handlers/v1/inscricao_handler_mock_test.go
+++ b/internal/handlers/v1/inscricao_handler_mock_test.go
@@ -30,6 +30,11 @@ func (m *MockInscricaoService) Create(ctx context.Context, inscricao *models.Ins
 	return args.Error(0)
 }
 
+func (m *MockInscricaoService) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
+	args := m.Called(ctx, inscricao)
+	return args.Error(0)
+}
+
 func (m *MockInscricaoService) CreateManual(ctx context.Context, inscricao *models.Inscricao) error {
 	args := m.Called(ctx, inscricao)
 	return args.Error(0)

--- a/internal/handlers/v1/inscricao_handler_test.go
+++ b/internal/handlers/v1/inscricao_handler_test.go
@@ -388,6 +388,9 @@ func (m *mockInscricaoService) CreateManual(ctx context.Context, inscricao *mode
 func (m *mockInscricaoService) Create(ctx context.Context, inscricao *models.Inscricao) error {
 	return nil
 }
+func (m *mockInscricaoService) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
+	return nil
+}
 func (m *mockInscricaoService) GetByID(ctx context.Context, id uuid.UUID) (*models.Inscricao, error) {
 	return nil, nil
 }

--- a/internal/jobs/enrollment_import_job.go
+++ b/internal/jobs/enrollment_import_job.go
@@ -724,7 +724,7 @@ func (p *EnrollmentImportProcessor) processRow(ctx context.Context, cursoID int,
 		EnrolledUnit:     enrolledUnit,
 	}
 
-	if err := p.inscricaoService.Create(ctx, inscricao); err != nil {
+	if err := p.inscricaoService.CreateByAdmin(ctx, inscricao); err != nil {
 		return nil, err
 	}
 

--- a/internal/jobs/enrollment_import_job_test.go
+++ b/internal/jobs/enrollment_import_job_test.go
@@ -1233,6 +1233,11 @@ func (m *MockInscricaoService) Create(ctx context.Context, inscricao *models.Ins
 	return args.Error(0)
 }
 
+func (m *MockInscricaoService) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
+	args := m.Called(ctx, inscricao)
+	return args.Error(0)
+}
+
 func (m *MockInscricaoService) CreateManual(ctx context.Context, inscricao *models.Inscricao) error {
 	args := m.Called(ctx, inscricao)
 	return args.Error(0)

--- a/internal/services/inscricao_service.go
+++ b/internal/services/inscricao_service.go
@@ -82,7 +82,6 @@ func (s *InscricaoService) Create(ctx context.Context, inscricao *models.Inscric
 		return err
 	}
 
-	// Check if enrollment is open
 	normalizedStatus := models.StatusCurso(status).Normalize()
 	if normalizedStatus != models.StatusCursoOpened && normalizedStatus != models.StatusCursoPublished {
 		return fmt.Errorf("curso não está aberto para inscrições")
@@ -193,22 +192,112 @@ func (s *InscricaoService) Create(ctx context.Context, inscricao *models.Inscric
 	return nil
 }
 
-// CreateManual creates an enrollment bypassing date restrictions and citizen data override.
-// Used by admins to manually enroll someone regardless of the enrollment period.
-func (s *InscricaoService) CreateManual(ctx context.Context, inscricao *models.Inscricao) error {
-	// Validate course exists and can accept enrollments
-	status, _, _, autoApprove, err := s.cursoRepo.ValidateForEnrollment(ctx, inscricao.CursoID)
+// CreateByAdmin creates an enrollment bypassing course status validation.
+// Used by internal flows (CSV import) where an admin is enrolling participants
+// in courses that may be closed. All other validations still apply.
+func (s *InscricaoService) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
+	_, enrollmentStart, enrollmentEnd, autoApprove, err := s.cursoRepo.ValidateForEnrollment(ctx, inscricao.CursoID)
 	if err != nil {
 		return err
 	}
 
-	// Course must still be in opened status
-	normalizedStatus := models.StatusCurso(status).Normalize()
-	if normalizedStatus != models.StatusCursoOpened && normalizedStatus != models.StatusCursoPublished {
-		return fmt.Errorf("curso não está aberto para inscrições")
+	now := time.Now()
+	if enrollmentStart != nil && now.Before(*enrollmentStart) {
+		return fmt.Errorf("período de inscrições ainda não iniciou")
+	}
+	if enrollmentEnd != nil && now.After(*enrollmentEnd) {
+		return fmt.Errorf("período de inscrições já encerrou")
 	}
 
-	// NOTE: enrollment date validation is intentionally skipped for manual admin enrollments
+	exists, err := s.repo.ExistsByCPFAndCurso(ctx, inscricao.CPF, inscricao.CursoID)
+	if err != nil {
+		return fmt.Errorf("erro ao verificar inscrição existente: %w", err)
+	}
+	if exists {
+		return fmt.Errorf("CPF já inscrito neste curso")
+	}
+
+	if inscricao.ScheduleID != nil {
+		curso, err := s.cursoRepo.GetByID(ctx, inscricao.CursoID)
+		if err != nil {
+			return fmt.Errorf("erro ao verificar curso para validação de schedule: %w", err)
+		}
+		if curso == nil {
+			return fmt.Errorf("curso não encontrado")
+		}
+		if err := s.validateScheduleID(ctx, *inscricao.ScheduleID, curso); err != nil {
+			return err
+		}
+		if autoApprove {
+			vacancies := s.findScheduleVacancies(*inscricao.ScheduleID, curso)
+			if vacancies > 0 {
+				enrolledCount, err := s.cursoRepo.CountEnrollmentsByScheduleID(ctx, *inscricao.ScheduleID)
+				if err != nil || int(enrolledCount) >= vacancies {
+					autoApprove = false
+				}
+			}
+		}
+	}
+
+	if s.citizenDataFetcher != nil && inscricao.CPF != "" {
+		citizenSnapshot, err := s.citizenDataFetcher.SyncCitizenOnDemand(ctx, inscricao.CPF)
+		if err != nil {
+			fmt.Printf("[InscricaoService] Failed to fetch citizen data for CPF %s: %v\n", maskCPFForLog(inscricao.CPF), err)
+		} else if citizenSnapshot != nil {
+			if citizenSnapshot.Email != "" {
+				inscricao.Email = models.SanitizeEmail(citizenSnapshot.Email)
+			}
+			if citizenSnapshot.Celular != "" {
+				inscricao.Phone = citizenSnapshot.Celular
+			}
+			if citizenSnapshot.Nome != "" && inscricao.Name == "" {
+				inscricao.Name = citizenSnapshot.Nome
+			}
+		}
+	}
+
+	if autoApprove {
+		inscricao.Status = models.StatusInscricaoApproved
+	} else {
+		inscricao.Status = models.StatusInscricaoPending
+	}
+	inscricao.EnrolledAt = time.Now()
+	inscricao.UpdatedAt = time.Now()
+
+	if err := s.repo.Create(ctx, inscricao); err != nil {
+		return err
+	}
+
+	if s.emailNotificationService != nil {
+		curso, err := s.cursoRepo.GetByID(ctx, inscricao.CursoID)
+		if err == nil && curso != nil {
+			go func() {
+				var emailErr error
+				if autoApprove {
+					emailErr = s.emailNotificationService.SendEnrollmentApprovedEmail(context.Background(), inscricao, curso)
+				} else {
+					emailErr = s.emailNotificationService.SendEnrollmentCreatedEmail(context.Background(), inscricao, curso)
+				}
+				if emailErr != nil {
+					log.Printf("[InscricaoService] falha ao enviar email de inscrição: %v", emailErr)
+				}
+			}()
+		}
+	}
+
+	return nil
+}
+
+// CreateManual creates an enrollment bypassing date restrictions and citizen data override.
+// Used by admins to manually enroll someone regardless of the enrollment period or course status.
+func (s *InscricaoService) CreateManual(ctx context.Context, inscricao *models.Inscricao) error {
+	// Validate course exists
+	_, _, _, autoApprove, err := s.cursoRepo.ValidateForEnrollment(ctx, inscricao.CursoID)
+	if err != nil {
+		return err
+	}
+
+	// NOTE: status and date validation intentionally skipped for manual admin enrollments
 
 	// Check if CPF is already enrolled
 	exists, err := s.repo.ExistsByCPFAndCurso(ctx, inscricao.CPF, inscricao.CursoID)

--- a/internal/services/inscricao_service_test.go
+++ b/internal/services/inscricao_service_test.go
@@ -1310,6 +1310,153 @@ func TestInscricaoService_UpdateInscricao(t *testing.T) {
 	})
 }
 
+// TestInscricaoService_CreateByAdmin tests the CreateByAdmin method used by CSV import jobs.
+// It must bypass course status validation while preserving all other validations.
+func TestInscricaoService_CreateByAdmin(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("CreateByAdmin succeeds for closed course", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, true, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Errorf("CreateByAdmin should succeed for closed course, got: %v", err)
+		}
+	})
+
+	t.Run("CreateByAdmin succeeds for draft course", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoDraft), nil, nil, false, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Errorf("CreateByAdmin should succeed for draft course, got: %v", err)
+		}
+	})
+
+	t.Run("CreateByAdmin fails when CPF already enrolled", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return true, nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err == nil {
+			t.Error("Expected error for duplicate CPF")
+		}
+	})
+
+	t.Run("CreateByAdmin sets status approved when auto_approve is true", func(t *testing.T) {
+		var created *models.Inscricao
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				created = inscricao
+				return nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, true, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateByAdmin failed: %v", err)
+		}
+		if created.Status != models.StatusInscricaoApproved {
+			t.Errorf("Expected status approved, got %s", created.Status)
+		}
+	})
+
+	t.Run("CreateByAdmin sets status pending when auto_approve is false", func(t *testing.T) {
+		var created *models.Inscricao
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				created = inscricao
+				return nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateByAdmin failed: %v", err)
+		}
+		if created.Status != models.StatusInscricaoPending {
+			t.Errorf("Expected status pending, got %s", created.Status)
+		}
+	})
+
+	t.Run("Create (public) fails for closed course", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.Create(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil {
+			t.Error("Expected Create to fail for closed course")
+		}
+		if err.Error() != "curso não está aberto para inscrições" {
+			t.Errorf("Unexpected error message: %s", err.Error())
+		}
+	})
+}
+
 // TestInscricaoService_CreateManual tests the CreateManual method
 func TestInscricaoService_CreateManual(t *testing.T) {
 	ctx := context.Background()
@@ -1403,8 +1550,15 @@ func TestInscricaoService_CreateManual(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateManual fails when curso not opened", func(t *testing.T) {
-		inscricaoRepo := &MockInscricaoRepository{}
+	t.Run("CreateManual succeeds even when curso not opened", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return nil
+			},
+		}
 
 		cursoRepo := &MockCursoRepository{
 			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (status string, enrollmentStart *time.Time, enrollmentEnd *time.Time, autoApprove bool, err error) {
@@ -1416,12 +1570,13 @@ func TestInscricaoService_CreateManual(t *testing.T) {
 
 		inscricao := &models.Inscricao{
 			CPF:     "12345678900",
+			Name:    "Teste Admin",
 			CursoID: 1,
 		}
 
 		err := svc.CreateManual(ctx, inscricao)
-		if err == nil {
-			t.Error("Expected error when curso not opened")
+		if err != nil {
+			t.Errorf("CreateManual should succeed for closed course, got: %v", err)
 		}
 	})
 

--- a/internal/services/inscricao_service_test.go
+++ b/internal/services/inscricao_service_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -1453,6 +1454,420 @@ func TestInscricaoService_CreateByAdmin(t *testing.T) {
 		}
 		if err.Error() != "curso não está aberto para inscrições" {
 			t.Errorf("Unexpected error message: %s", err.Error())
+		}
+	})
+
+	t.Run("CreateByAdmin fails when ValidateForEnrollment errors", func(t *testing.T) {
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return "", nil, nil, false, fmt.Errorf("db error")
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(&MockInscricaoRepository{}, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil || err.Error() != "db error" {
+			t.Errorf("Expected db error, got: %v", err)
+		}
+	})
+
+	t.Run("CreateByAdmin fails when enrollment period not started", func(t *testing.T) {
+		future := time.Now().Add(24 * time.Hour)
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), &future, nil, false, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(&MockInscricaoRepository{}, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil {
+			t.Error("Expected error when enrollment period not started")
+		}
+	})
+
+	t.Run("CreateByAdmin fails when enrollment period ended", func(t *testing.T) {
+		past := time.Now().Add(-24 * time.Hour)
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, &past, false, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(&MockInscricaoRepository{}, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil {
+			t.Error("Expected error when enrollment period ended")
+		}
+	})
+
+	t.Run("CreateByAdmin fails when ExistsByCPFAndCurso errors", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, fmt.Errorf("db error checking cpf")
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil {
+			t.Error("Expected error from repo")
+		}
+	})
+
+	t.Run("CreateByAdmin fails when repo.Create errors", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return fmt.Errorf("insert failed")
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err == nil || err.Error() != "insert failed" {
+			t.Errorf("Expected insert failed error, got: %v", err)
+		}
+	})
+
+	t.Run("CreateByAdmin enriches data from citizen fetcher", func(t *testing.T) {
+		var created *models.Inscricao
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				created = inscricao
+				return nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+		citizenFetcher := &MockCitizenDataFetcher{
+			SyncFunc: func(ctx context.Context, cpf string) (*models.CitizenSnapshot, error) {
+				return &models.CitizenSnapshot{
+					CPF:     cpf,
+					Email:   "fetched@example.com",
+					Celular: "21999990000",
+					Nome:    "Nome do RMI",
+				}, nil
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, citizenFetcher, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Original", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateByAdmin failed: %v", err)
+		}
+		if created.Email != "fetched@example.com" {
+			t.Errorf("Expected email from RMI, got %s", created.Email)
+		}
+		if created.Phone != "21999990000" {
+			t.Errorf("Expected phone from RMI, got %s", created.Phone)
+		}
+	})
+
+	t.Run("CreateByAdmin continues when citizen fetcher errors", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+		citizenFetcher := &MockCitizenDataFetcher{
+			SyncFunc: func(ctx context.Context, cpf string) (*models.CitizenSnapshot, error) {
+				return nil, fmt.Errorf("rmi unavailable")
+			},
+		}
+
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, citizenFetcher, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Errorf("CreateByAdmin should not fail when citizen fetcher errors, got: %v", err)
+		}
+	})
+
+	t.Run("CreateByAdmin sends approved email when auto_approve is true", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error { return nil },
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, true, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{ID: id, Titulo: "Curso Fechado"}, nil
+			},
+		}
+		emailNotifier := newMockEmailNotifier()
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, emailNotifier, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateByAdmin failed: %v", err)
+		}
+		if !emailNotifier.waitForCall("enrollment.approved", 500*time.Millisecond) {
+			t.Error("Expected enrollment.approved email to be sent")
+		}
+	})
+
+	t.Run("CreateByAdmin sends pending email when auto_approve is false", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error { return nil },
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{ID: id, Titulo: "Curso Fechado"}, nil
+			},
+		}
+		emailNotifier := newMockEmailNotifier()
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, emailNotifier, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateByAdmin failed: %v", err)
+		}
+		if !emailNotifier.waitForCall("enrollment.created", 500*time.Millisecond) {
+			t.Error("Expected enrollment.created email to be sent")
+		}
+	})
+
+	t.Run("CreateByAdmin fails when GetByID errors on schedule validation", func(t *testing.T) {
+		scheduleID := uuid.New()
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return nil, fmt.Errorf("db error on GetByID")
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1, ScheduleID: &scheduleID})
+		if err == nil {
+			t.Error("Expected error when GetByID fails")
+		}
+	})
+
+	t.Run("CreateByAdmin fails when curso not found on schedule validation", func(t *testing.T) {
+		scheduleID := uuid.New()
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return nil, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1, ScheduleID: &scheduleID})
+		if err == nil || err.Error() != "curso não encontrado" {
+			t.Errorf("Expected 'curso não encontrado', got: %v", err)
+		}
+	})
+}
+
+// TestInscricaoService_CreateManual_Extended covers additional paths in CreateManual
+func TestInscricaoService_CreateManual_Extended(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("CreateManual fails when ValidateForEnrollment errors", func(t *testing.T) {
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return "", nil, nil, false, fmt.Errorf("db error")
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(&MockInscricaoRepository{}, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil || err.Error() != "db error" {
+			t.Errorf("Expected db error, got: %v", err)
+		}
+	})
+
+	t.Run("CreateManual fails when CPF already enrolled", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return true, nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
+		if err == nil {
+			t.Error("Expected error for duplicate CPF")
+		}
+	})
+
+	t.Run("CreateManual fails when repo.Create errors", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return fmt.Errorf("insert failed")
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err == nil || err.Error() != "insert failed" {
+			t.Errorf("Expected insert failed error, got: %v", err)
+		}
+	})
+
+	t.Run("CreateManual sends approved email when auto_approve is true", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error { return nil },
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, true, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{ID: id, Titulo: "Curso Manual"}, nil
+			},
+		}
+		emailNotifier := newMockEmailNotifier()
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, emailNotifier, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateManual failed: %v", err)
+		}
+		if !emailNotifier.waitForCall("enrollment.approved", 500*time.Millisecond) {
+			t.Error("Expected enrollment.approved email to be sent")
+		}
+	})
+
+	t.Run("CreateManual sends pending email when auto_approve is false", func(t *testing.T) {
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error { return nil },
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return &models.Curso{ID: id, Titulo: "Curso Manual"}, nil
+			},
+		}
+		emailNotifier := newMockEmailNotifier()
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, emailNotifier, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1})
+		if err != nil {
+			t.Fatalf("CreateManual failed: %v", err)
+		}
+		if !emailNotifier.waitForCall("enrollment.created", 500*time.Millisecond) {
+			t.Error("Expected enrollment.created email to be sent")
+		}
+	})
+
+	t.Run("CreateManual fails when GetByID errors on schedule validation", func(t *testing.T) {
+		scheduleID := uuid.New()
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return nil, fmt.Errorf("db error on GetByID")
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1, ScheduleID: &scheduleID})
+		if err == nil {
+			t.Error("Expected error when GetByID fails")
+		}
+	})
+
+	t.Run("CreateManual fails when curso not found on schedule validation", func(t *testing.T) {
+		scheduleID := uuid.New()
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+		}
+		cursoRepo := &MockCursoRepository{
+			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
+				return string(models.StatusCursoClosed), nil, nil, false, nil
+			},
+			GetByIDFunc: func(ctx context.Context, id int) (*models.Curso, error) {
+				return nil, nil
+			},
+		}
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
+
+		err := svc.CreateManual(ctx, &models.Inscricao{CPF: "12345678900", Name: "Teste", CursoID: 1, ScheduleID: &scheduleID})
+		if err == nil || err.Error() != "curso não encontrado" {
+			t.Errorf("Expected 'curso não encontrado', got: %v", err)
 		}
 	})
 }

--- a/internal/services/interfaces.go
+++ b/internal/services/interfaces.go
@@ -171,6 +171,7 @@ type InscricaoRepositoryInterface interface {
 // InscricaoServiceInterface defines the interface for Inscricao service
 type InscricaoServiceInterface interface {
 	Create(ctx context.Context, inscricao *models.Inscricao) error
+	CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error
 	CreateManual(ctx context.Context, inscricao *models.Inscricao) error
 	GetByID(ctx context.Context, id uuid.UUID) (*models.Inscricao, error)
 	GetByCursoID(ctx context.Context, cursoID int, filter map[string]interface{}, page, pageSize int) ([]*models.Inscricao, int, error)


### PR DESCRIPTION

## Description

The internal portal's "Add Participants" flow supports two methods: manual (one by one) and bulk (CSV/XLSX upload). The manual flow already worked for closed courses, but the bulk import returned `"curso não está aberto para inscrições"` for every row whenever the course status was anything other than `opened` or `published`.

The root cause was that `InscricaoService.Create()` used by both the import job and the public citizen enrollment endpoint validated the course status before proceeding. Removing this validation without further changes would silently open a server-side gap: any authenticated user could enroll themselves in a closed course via a direct POST, bypassing the frontend button lock.

This PR fixes the import flow and explicitly enforces the status restriction on the public endpoint at the service layer.

## Technical Decision

Rather than adding a flag/parameter to skip the status check (which would pollute the service interface with authorization concerns), we introduced a clear method separation:

| Method | Status check | Date check | Used by |
|--------|-------------|------------|---------|
| `Create()` | ✅ `published`/`opened` only | ✅ | Public citizen enrollment |
| `CreateByAdmin()` | ❌ any status allowed | ✅ | CSV/XLSX bulk import job |
| `CreateManual()` | ❌ any status allowed | ❌ | Manual admin enrollment |

All three methods still enforce: duplicate CPF check, schedule validation, vacancy check, and auto-approve logic.

## Changed Files

| File | What changed |
|------|-------------|
| `internal/services/inscricao_service.go` | Restored status check in `Create()`; added `CreateByAdmin()` without status check; removed status check from `CreateManual()` |
| `internal/services/interfaces.go` | Added `CreateByAdmin` to `InscricaoServiceInterface` |
| `internal/jobs/enrollment_import_job.go` | Changed `Create()` call to `CreateByAdmin()` at line 727 |
| `internal/services/inscricao_service_test.go` | Added 6 new unit tests for `CreateByAdmin`; updated `CreateManual` test to reflect new expected behavior |
| `internal/handlers/v1/*_test.go` + `internal/jobs/enrollment_import_job_test.go` | Added `CreateByAdmin` stub to all mock implementations |

## How to Test

### Prerequisites
- API running locally (`just dev`)
- PostgreSQL up (`docker compose up -d`)
- A course with status `closed` in the database



### Scenario 1 — Bulk import on closed course (should succeed)

### Scenario 2 — Public enrollment on closed course (should be blocked)

### Scenario 3 — Bulk import on published course (baseline, should still work)

----

[CARD](https://iplanrio-pcrj.atlassian.net/jira/software/c/projects/PREF/boards/4423?quickFilter=6610&selectedIssue=PREF-347)