### PR TITLE
Feat/jr 81/aditional fields input mask

### DIFF
--- a/internal/db/migrations/065_add_format_type_to_custom_fields.sql
+++ b/internal/db/migrations/065_add_format_type_to_custom_fields.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE custom_fields ADD COLUMN format_type VARCHAR(50);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE custom_fields DROP COLUMN IF EXISTS format_type;
+-- +goose StatementEnd

--- a/internal/handlers/v1/course_handler_test.go
+++ b/internal/handlers/v1/course_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prefeitura-rio/app-go-api/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockCursoService is a mock implementation of CursoServiceInterface
@@ -3045,6 +3046,170 @@ func TestCourseHandler_List_StatusFilter(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		svc.AssertExpectations(t)
 	})
+}
+
+// ==================== FormatType in Custom Fields ====================
+
+func TestCourseHandler_Create_WithCustomFieldFormatType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+	r := gin.New()
+	r.POST("/api/v1/courses", handler.Create)
+
+	ft := "cpf"
+	curso := models.Curso{
+		Titulo: "Curso com Máscara",
+		CustomFields: []models.CustomField{
+			{Title: "CPF do participante", FieldType: "text", FormatType: &ft, Required: true},
+		},
+	}
+
+	mockService.On("Create", mock.Anything, mock.MatchedBy(func(c *models.Curso) bool {
+		return len(c.CustomFields) == 1 &&
+			c.CustomFields[0].FormatType != nil &&
+			*c.CustomFields[0].FormatType == "cpf"
+	})).Return(10, nil)
+
+	body, _ := json.Marshal(curso)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/courses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+func TestCourseHandler_CreateDraft_WithCustomFieldFormatType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+	r := gin.New()
+	r.POST("/api/v1/courses/draft", handler.CreateDraft)
+
+	ft := "phone"
+	curso := models.Curso{
+		Titulo: "Rascunho com Máscara",
+		CustomFields: []models.CustomField{
+			{Title: "Telefone", FieldType: "text", FormatType: &ft},
+		},
+	}
+
+	mockService.On("Create", mock.Anything, mock.MatchedBy(func(c *models.Curso) bool {
+		return c.Status == models.StatusCursoDraft &&
+			len(c.CustomFields) == 1 &&
+			c.CustomFields[0].FormatType != nil &&
+			*c.CustomFields[0].FormatType == "phone"
+	})).Return(11, nil)
+
+	body, _ := json.Marshal(curso)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/courses/draft", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+func TestCourseHandler_Update_WithCustomFieldFormatType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+	r := gin.New()
+	r.PUT("/api/v1/courses/:courseId", handler.Update)
+
+	existing := &models.Curso{
+		ID:     12,
+		Titulo: "Curso Existente",
+		Status: models.StatusCursoOpened,
+	}
+	mockService.On("GetByID", mock.Anything, 12).Return(existing, nil)
+
+	ft := "cep"
+	updated := models.Curso{
+		Titulo: "Curso Atualizado",
+		Status: models.StatusCursoOpened,
+		CustomFields: []models.CustomField{
+			{Title: "CEP", FieldType: "text", FormatType: &ft},
+		},
+	}
+
+	mockService.On("Update", mock.Anything, mock.MatchedBy(func(c *models.Curso) bool {
+		return len(c.CustomFields) == 1 &&
+			c.CustomFields[0].FormatType != nil &&
+			*c.CustomFields[0].FormatType == "cep"
+	})).Return(nil)
+
+	body, _ := json.Marshal(updated)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/courses/12", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+func TestCourseHandler_GetByID_CustomFieldFormatTypeInResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+	r := gin.New()
+	r.GET("/api/v1/courses/:courseId", handler.GetByID)
+
+	ft := "cpf"
+	curso := &models.Curso{
+		ID:     20,
+		Titulo: "Curso com FormatType",
+		Status: models.StatusCursoOpened,
+		CustomFields: []models.CustomField{
+			{Title: "CPF", FieldType: "text", FormatType: &ft, Required: true},
+			{Title: "Nome", FieldType: "text"},
+		},
+	}
+
+	mockService.On("GetByID", mock.Anything, 20).Return(curso, nil)
+	mockInscricaoService.On("CountVacanciesBySchedule", mock.Anything, mock.Anything).Return(map[string]int{}, nil).Maybe()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/20", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.True(t, response["success"].(bool))
+
+	data := response["data"].(map[string]interface{})
+	customFields := data["custom_fields"].([]interface{})
+	require.Len(t, customFields, 2)
+
+	field0 := customFields[0].(map[string]interface{})
+	assert.Equal(t, "cpf", field0["format_type"])
+
+	field1 := customFields[1].(map[string]interface{})
+	_, hasFormatType := field1["format_type"]
+	assert.False(t, hasFormatType, "format_type deve estar ausente quando nil (omitempty)")
+
+	mockService.AssertExpectations(t)
 }
 
 func TestCourseHandler_RequestDeletion(t *testing.T) {

--- a/internal/models/inscricao.go
+++ b/internal/models/inscricao.go
@@ -106,14 +106,15 @@ func (e *EnrolledUnit) Scan(value interface{}) error {
 }
 
 type CustomField struct {
-	ID        uuid.UUID      `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
-	CursoID   int            `json:"curso_id" gorm:"column:curso_id;not null"`
-	Title     string         `json:"title" gorm:"type:varchar(20000);not null"`
-	FieldType string         `json:"field_type" gorm:"type:varchar(50);default:'text'"`
-	Required  bool           `json:"required" gorm:"default:false"`
-	Options   datatypes.JSON `json:"options,omitempty" gorm:"type:jsonb"`
-	CreatedAt time.Time      `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt time.Time      `json:"updated_at" gorm:"autoUpdateTime"`
+	ID         uuid.UUID      `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	CursoID    int            `json:"curso_id" gorm:"column:curso_id;not null"`
+	Title      string         `json:"title" gorm:"type:varchar(20000);not null"`
+	FieldType  string         `json:"field_type" gorm:"type:varchar(50);default:'text'"`
+	FormatType *string        `json:"format_type,omitempty" gorm:"type:varchar(50)"`
+	Required   bool           `json:"required" gorm:"default:false"`
+	Options    datatypes.JSON `json:"options,omitempty" gorm:"type:jsonb"`
+	CreatedAt  time.Time      `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt  time.Time      `json:"updated_at" gorm:"autoUpdateTime"`
 
 	// Relacionamentos
 	Curso *Curso `json:"curso,omitempty" gorm:"foreignKey:CursoID"`

--- a/internal/models/inscricao_models_test.go
+++ b/internal/models/inscricao_models_test.go
@@ -158,6 +158,47 @@ func TestCustomField_TableName(t *testing.T) {
 	assert.Equal(t, "custom_fields", field.TableName())
 }
 
+func TestCustomField_FormatType_JSONSerialization(t *testing.T) {
+	t.Run("format_type present when set", func(t *testing.T) {
+		ft := "cpf"
+		field := CustomField{
+			ID:         uuid.New(),
+			Title:      "CPF",
+			FieldType:  "text",
+			FormatType: &ft,
+		}
+		data, err := json.Marshal(field)
+		require.NoError(t, err)
+
+		var out map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, "cpf", out["format_type"])
+	})
+
+	t.Run("format_type absent when nil (omitempty)", func(t *testing.T) {
+		field := CustomField{
+			ID:        uuid.New(),
+			Title:     "Nome",
+			FieldType: "text",
+		}
+		data, err := json.Marshal(field)
+		require.NoError(t, err)
+
+		var out map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &out))
+		_, exists := out["format_type"]
+		assert.False(t, exists, "format_type deve estar ausente no JSON quando nil")
+	})
+
+	t.Run("format_type deserialized from JSON", func(t *testing.T) {
+		raw := `{"title":"Telefone","field_type":"text","format_type":"phone"}`
+		var field CustomField
+		require.NoError(t, json.Unmarshal([]byte(raw), &field))
+		require.NotNil(t, field.FormatType)
+		assert.Equal(t, "phone", *field.FormatType)
+	})
+}
+
 func TestCourseSchedule_TableName(t *testing.T) {
 	schedule := &CourseSchedule{}
 	assert.Equal(t, "course_schedules", schedule.TableName())

--- a/internal/services/curso_service_expanded_test.go
+++ b/internal/services/curso_service_expanded_test.go
@@ -722,3 +722,128 @@ func TestCursoService_RepositoryErrorPropagation(t *testing.T) {
 		}
 	})
 }
+
+// ==================== FormatType Propagation ====================
+
+func TestCursoService_Create_CustomField_FormatType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("format_type is preserved when creating custom fields", func(t *testing.T) {
+		var capturedFields []models.CustomField
+
+		repo := &MockCursoRepository{
+			CreateFunc: func(ctx context.Context, curso *models.Curso) (int, error) {
+				return 1, nil
+			},
+			CreateCustomFieldsFunc: func(ctx context.Context, fields []models.CustomField) error {
+				capturedFields = fields
+				return nil
+			},
+		}
+		svc := services.NewCursoServiceWithInterface(repo)
+
+		ft := "cpf"
+		curso := &models.Curso{
+			Titulo: "Curso com Máscara",
+			Status: models.StatusCursoDraft,
+			CustomFields: []models.CustomField{
+				{Title: "CPF do participante", FieldType: "text", FormatType: &ft, Required: true},
+			},
+		}
+
+		_, err := svc.Create(ctx, curso)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(capturedFields) != 1 {
+			t.Fatalf("expected 1 custom field, got %d", len(capturedFields))
+		}
+		if capturedFields[0].FormatType == nil || *capturedFields[0].FormatType != "cpf" {
+			t.Errorf("expected FormatType 'cpf', got %v", capturedFields[0].FormatType)
+		}
+		if capturedFields[0].CursoID != 1 {
+			t.Errorf("expected CursoID 1, got %d", capturedFields[0].CursoID)
+		}
+	})
+
+	t.Run("format_type nil is preserved (free text field)", func(t *testing.T) {
+		var capturedFields []models.CustomField
+
+		repo := &MockCursoRepository{
+			CreateFunc: func(ctx context.Context, curso *models.Curso) (int, error) {
+				return 2, nil
+			},
+			CreateCustomFieldsFunc: func(ctx context.Context, fields []models.CustomField) error {
+				capturedFields = fields
+				return nil
+			},
+		}
+		svc := services.NewCursoServiceWithInterface(repo)
+
+		curso := &models.Curso{
+			Titulo: "Curso texto livre",
+			Status: models.StatusCursoDraft,
+			CustomFields: []models.CustomField{
+				{Title: "Observações", FieldType: "text"},
+			},
+		}
+
+		_, err := svc.Create(ctx, curso)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(capturedFields) != 1 {
+			t.Fatalf("expected 1 custom field, got %d", len(capturedFields))
+		}
+		if capturedFields[0].FormatType != nil {
+			t.Errorf("expected FormatType nil, got %v", capturedFields[0].FormatType)
+		}
+	})
+
+	t.Run("multiple fields with mixed format_type values", func(t *testing.T) {
+		var capturedFields []models.CustomField
+
+		repo := &MockCursoRepository{
+			CreateFunc: func(ctx context.Context, curso *models.Curso) (int, error) {
+				return 3, nil
+			},
+			CreateCustomFieldsFunc: func(ctx context.Context, fields []models.CustomField) error {
+				capturedFields = fields
+				return nil
+			},
+		}
+		svc := services.NewCursoServiceWithInterface(repo)
+
+		ftCPF := "cpf"
+		ftPhone := "phone"
+		curso := &models.Curso{
+			Titulo: "Curso múltiplos campos",
+			Status: models.StatusCursoDraft,
+			CustomFields: []models.CustomField{
+				{Title: "CPF", FieldType: "text", FormatType: &ftCPF},
+				{Title: "Nome", FieldType: "text"},
+				{Title: "Telefone", FieldType: "text", FormatType: &ftPhone},
+			},
+		}
+
+		_, err := svc.Create(ctx, curso)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(capturedFields) != 3 {
+			t.Fatalf("expected 3 custom fields, got %d", len(capturedFields))
+		}
+		if capturedFields[0].FormatType == nil || *capturedFields[0].FormatType != "cpf" {
+			t.Errorf("field[0]: expected FormatType 'cpf', got %v", capturedFields[0].FormatType)
+		}
+		if capturedFields[1].FormatType != nil {
+			t.Errorf("field[1]: expected FormatType nil, got %v", capturedFields[1].FormatType)
+		}
+		if capturedFields[2].FormatType == nil || *capturedFields[2].FormatType != "phone" {
+			t.Errorf("field[2]: expected FormatType 'phone', got %v", capturedFields[2].FormatType)
+		}
+	})
+}


### PR DESCRIPTION
## Description

The admin portal's course creation and editing flow supports custom enrollment form fields (text, select, checkbox, etc.). These fields lacked a `format_type` attribute, which meant the frontend had no way to persist or retrieve the input mask configuration (e.g. CPF, phone, CEP, date) set by the admin.

The root cause was a missing column in the `custom_fields` table and a missing field in the Go struct. Without it, admins could configure masks on the frontend but the value was silently dropped on save and the public enrollment form had no mask to apply.

This PR adds the `format_type` column and wires it through the full stack with zero breaking changes to existing data or API consumers.

## Technical Decision

Rather than creating a CRUD endpoint for format types (which would be overengineering for a small, stable set of values), `format_type` is stored as a plain `VARCHAR(50)`. The valid values (`cpf`, `phone`, `cep`, `date`, etc.) are an enum owned by both frontends. The API is a transparent transport layer it stores and returns whatever string the admin frontend sends.

The Go field uses `*string` (pointer) with `omitempty`:

| Field value | JSON output |
|---|---|
| `"cpf"` | `"format_type": "cpf"` |
| `nil` (existing records) | key absent from JSON |

This ensures backward compatibility: existing courses and custom fields return exactly the same JSON as before no new keys, no nulls, no surprises for current API consumers.

## Changed Files

| File | What changed |
|------|-------------|
| `internal/db/migrations/065_add_format_type_to_custom_fields.sql` | New migration: `ALTER TABLE custom_fields ADD COLUMN format_type VARCHAR(50)` — nullable, no default |
| `internal/models/inscricao.go` | Added `FormatType *string` with `json:"format_type,omitempty"` to `CustomField` struct |
| `internal/models/inscricao_models_test.go` | 3 sub-tests: serialization with value, omitempty when nil, deserialization from JSON |
| `internal/services/curso_service_expanded_test.go` | 3 sub-tests: `format_type` preserved on `CreateCustomFields`, nil preserved, mixed values |
| `internal/handlers/v1/course_handler_test.go` | 4 new tests: Create, CreateDraft, Update with `format_type` in body; GetByID verifies presence/absence in response |

No changes needed in `curso_repository.go`, `course_handler.go`, or `curso_service.go` — GORM's DELETE+INSERT pattern and `ShouldBindJSON` handle the new field automatically.

## How to Test

### Prerequisites
- API running locally (`just dev`)
- PostgreSQL up (`docker compose up -d`)
- Migration applied (`just migrate`)

### Scenario 1 — Create course with format_type (should persist and return)
```bash
curl -X POST http://localhost:8080/api/v1/courses \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Curso Teste Máscara",
    "modalidade": "Remoto",
    "custom_fields": [
      {"title": "CPF", "field_type": "text", "format_type": "cpf", "required": true},
      {"title": "Observações", "field_type": "text"}
    ]
  }'
# Expected: 201 — GET by ID returns format_type: "cpf" on CPF field, key absent on Observações
```

### Scenario 2 — Update course replacing format_type (should reflect new value)
```bash
curl -X PUT http://localhost:8080/api/v1/courses/<ID> \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Curso Teste Máscara",
    "modalidade": "Remoto",
    "status": "published",
    "custom_fields": [
      {"title": "CEP", "field_type": "text", "format_type": "cep"}
    ]
  }'
# Expected: 200 — GET by ID returns only the CEP field with format_type: "cep"; previous fields gone
```

### Scenario 3 — Existing course without format_type (backward compatibility)
```bash
curl http://localhost:8080/api/v1/courses/<OLD_COURSE_ID> -H "Authorization: Bearer <TOKEN>"
# Expected: 200 custom_fields array has no "format_type" key (omitempty working)
# Response shape identical to before this PR
```

---

[CARD](https://iplanrio-pcrj.atlassian.net/jira/software/c/projects/PREF/boards/4423?quickFilter=6610&selectedIssue=PREF-81)
