### PR TITLE
Fix/jr 347/courses adjusts

### DIFF
--- a/internal/services/inscricao_service.go
+++ b/internal/services/inscricao_service.go
@@ -192,21 +192,13 @@ func (s *InscricaoService) Create(ctx context.Context, inscricao *models.Inscric
 	return nil
 }
 
-// CreateByAdmin creates an enrollment bypassing course status validation.
+// CreateByAdmin creates an enrollment bypassing course status and date validation.
 // Used by internal flows (CSV import) where an admin is enrolling participants
-// in courses that may be closed. All other validations still apply.
+// in courses that may be closed or past their enrollment period.
 func (s *InscricaoService) CreateByAdmin(ctx context.Context, inscricao *models.Inscricao) error {
-	_, enrollmentStart, enrollmentEnd, autoApprove, err := s.cursoRepo.ValidateForEnrollment(ctx, inscricao.CursoID)
+	_, _, _, autoApprove, err := s.cursoRepo.ValidateForEnrollment(ctx, inscricao.CursoID)
 	if err != nil {
 		return err
-	}
-
-	now := time.Now()
-	if enrollmentStart != nil && now.Before(*enrollmentStart) {
-		return fmt.Errorf("período de inscrições ainda não iniciou")
-	}
-	if enrollmentEnd != nil && now.After(*enrollmentEnd) {
-		return fmt.Errorf("período de inscrições já encerrou")
 	}
 
 	exists, err := s.repo.ExistsByCPFAndCurso(ctx, inscricao.CPF, inscricao.CursoID)

--- a/internal/services/inscricao_service_test.go
+++ b/internal/services/inscricao_service_test.go
@@ -1471,33 +1471,49 @@ func TestInscricaoService_CreateByAdmin(t *testing.T) {
 		}
 	})
 
-	t.Run("CreateByAdmin fails when enrollment period not started", func(t *testing.T) {
+	t.Run("CreateByAdmin bypasses enrollment period not started", func(t *testing.T) {
 		future := time.Now().Add(24 * time.Hour)
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return nil
+			},
+		}
 		cursoRepo := &MockCursoRepository{
 			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
 				return string(models.StatusCursoClosed), &future, nil, false, nil
 			},
 		}
-		svc := services.NewInscricaoServiceWithInterface(&MockInscricaoRepository{}, cursoRepo, nil, nil, nil, &config.AppConfig{})
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
 
 		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
-		if err == nil {
-			t.Error("Expected error when enrollment period not started")
+		if err != nil {
+			t.Errorf("Expected no error when enrollment period not started (admin bypass), got: %v", err)
 		}
 	})
 
-	t.Run("CreateByAdmin fails when enrollment period ended", func(t *testing.T) {
+	t.Run("CreateByAdmin bypasses enrollment period ended", func(t *testing.T) {
 		past := time.Now().Add(-24 * time.Hour)
+		inscricaoRepo := &MockInscricaoRepository{
+			ExistsByCPFAndCursoFunc: func(ctx context.Context, cpf string, cursoID int) (bool, error) {
+				return false, nil
+			},
+			CreateFunc: func(ctx context.Context, inscricao *models.Inscricao) error {
+				return nil
+			},
+		}
 		cursoRepo := &MockCursoRepository{
 			ValidateForEnrollmentFunc: func(ctx context.Context, cursoID int) (string, *time.Time, *time.Time, bool, error) {
 				return string(models.StatusCursoClosed), nil, &past, false, nil
 			},
 		}
-		svc := services.NewInscricaoServiceWithInterface(&MockInscricaoRepository{}, cursoRepo, nil, nil, nil, &config.AppConfig{})
+		svc := services.NewInscricaoServiceWithInterface(inscricaoRepo, cursoRepo, nil, nil, nil, &config.AppConfig{})
 
 		err := svc.CreateByAdmin(ctx, &models.Inscricao{CPF: "12345678900", CursoID: 1})
-		if err == nil {
-			t.Error("Expected error when enrollment period ended")
+		if err != nil {
+			t.Errorf("Expected no error when enrollment period ended (admin bypass), got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Description

Follow-up to #126. `CreateByAdmin` was validating enrollment dates despite being intended to bypass course status checks. Any course with a past `enrollment_end_date` caused every row in the bulk import to fail with "período de inscrições já encerrou".

Root cause: the method separation introduced in #126 only skipped the **status** check,  the **date** check remained, making `CreateByAdmin` behave identically to `Create()` for expired courses.

## Changed Files

| File | What changed |
|------|-------------|
| `internal/services/inscricao_service.go` | Removed date validation from `CreateByAdmin()` |
| `internal/services/inscricao_service_test.go` | Updated two tests that were asserting the old (incorrect) behavior |
