### PR TITLE
feat(vagas): filtro por secretaria, normalização de params e middleware de auth em rotas privadas

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -24,6 +24,135 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/public/courses": {
+            "get": {
+                "description": "Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Listar cursos criados",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Número da página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Tamanho da página (default: 10)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por status (CSV, ex: draft,published,in_review)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por modalidade",
+                        "name": "modalidade",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por organização (provedor do curso)",
+                        "name": "organization",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Buscar no título",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filtrar por categoria",
+                        "name": "categoria_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filtrar por acessibilidade",
+                        "name": "acessibilidade_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por zona do bairro",
+                        "name": "neighborhood_zone",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/public/courses/{courseId}": {
+            "get": {
+                "description": "Retorna dados completos de um curso específico",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Buscar curso específico",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID do curso",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Curso"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/public/empregabilidade/vagas": {
             "get": {
                 "description": "Retorna lista paginada de vagas publicadas. Sem filtro retorna todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada). Use ?status= para filtrar por um status específico.",
@@ -61,31 +190,31 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "UUID do regime de contratação",
+                        "description": "UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)",
                         "name": "id_regime_contratacao",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "UUID do modelo de trabalho",
+                        "description": "UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)",
                         "name": "id_modelo_trabalho",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Nome ou CNPJ do contratante",
+                        "description": "Nome(s) ou CNPJ(s) do contratante (CSV, ex: TechRio,12345678000100)",
                         "name": "contratante",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)",
+                        "description": "Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)",
                         "name": "acessibilidade_pcd",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Bairro (busca parcial)",
+                        "description": "Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)",
                         "name": "bairro",
                         "in": "query"
                     }
@@ -226,6 +355,64 @@ const docTemplate = `{
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/public/oportunidades-mei/{id}": {
+            "get": {
+                "description": "Retorna uma lista paginada de oportunidades MEI ativas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "oportunidades-mei"
+                ],
+                "summary": "Listar oportunidades MEI",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Número da página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Tamanho da página (default: 10, max: 1000)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por órgão",
+                        "name": "orgaoId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por status (draft, active, expired)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Buscar por título (case-insensitive)",
+                        "name": "titulo",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
                         }
                     }
                 }
@@ -7351,7 +7538,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Tamanho da página (default: 10)",
+                        "description": "Tamanho da página (default: 10, máx: 100)",
                         "name": "pageSize",
                         "in": "query"
                     },
@@ -7369,7 +7556,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Filtrar por ID do órgão parceiro",
+                        "description": "Filtrar por ID do órgão parceiro (ignorado se middleware já restringiu)",
                         "name": "orgao_parceiro_id",
                         "in": "query"
                     },
@@ -7377,6 +7564,36 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Busca parcial no título da vaga",
                         "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)",
+                        "name": "data_publicacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)",
+                        "name": "id_regime_contratacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)",
+                        "name": "id_modelo_trabalho",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)",
+                        "name": "acessibilidade_pcd",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)",
+                        "name": "bairro",
                         "in": "query"
                     }
                 ],
@@ -7386,6 +7603,15 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "500": {
@@ -12130,6 +12356,9 @@ const docTemplate = `{
         "models.OrgaoSnapshot": {
             "type": "object",
             "properties": {
+                "cd_ua": {
+                    "type": "string"
+                },
                 "created_at": {
                     "type": "string"
                 },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -360,7 +360,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/public/oportunidades-mei/{id}": {
+        "/api/public/oportunidades-mei": {
             "get": {
                 "description": "Retorna uma lista paginada de oportunidades MEI ativas",
                 "produces": [
@@ -407,6 +407,53 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/public/oportunidades-mei/{id}": {
+            "get": {
+                "description": "Retorna uma oportunidade MEI pelo seu ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "oportunidades-mei"
+                ],
+                "summary": "Obter oportunidade MEI por ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da oportunidade",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.OportunidadeMEI"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
                     "500": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -22,6 +22,135 @@
     "host": "localhost:8081",
     "basePath": "/",
     "paths": {
+        "/api/public/courses": {
+            "get": {
+                "description": "Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Listar cursos criados",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Número da página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Tamanho da página (default: 10)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por status (CSV, ex: draft,published,in_review)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por modalidade",
+                        "name": "modalidade",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por organização (provedor do curso)",
+                        "name": "organization",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Buscar no título",
+                        "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filtrar por categoria",
+                        "name": "categoria_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Filtrar por acessibilidade",
+                        "name": "acessibilidade_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por zona do bairro",
+                        "name": "neighborhood_zone",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/public/courses/{courseId}": {
+            "get": {
+                "description": "Retorna dados completos de um curso específico",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "Buscar curso específico",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID do curso",
+                        "name": "courseId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Curso"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/public/empregabilidade/vagas": {
             "get": {
                 "description": "Retorna lista paginada de vagas publicadas. Sem filtro retorna todos os status públicos (publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada). Use ?status= para filtrar por um status específico.",
@@ -59,31 +188,31 @@
                     },
                     {
                         "type": "string",
-                        "description": "UUID do regime de contratação",
+                        "description": "UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)",
                         "name": "id_regime_contratacao",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "UUID do modelo de trabalho",
+                        "description": "UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)",
                         "name": "id_modelo_trabalho",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Nome ou CNPJ do contratante",
+                        "description": "Nome(s) ou CNPJ(s) do contratante (CSV, ex: TechRio,12345678000100)",
                         "name": "contratante",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)",
+                        "description": "Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)",
                         "name": "acessibilidade_pcd",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Bairro (busca parcial)",
+                        "description": "Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)",
                         "name": "bairro",
                         "in": "query"
                     }
@@ -224,6 +353,64 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/public/oportunidades-mei/{id}": {
+            "get": {
+                "description": "Retorna uma lista paginada de oportunidades MEI ativas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "oportunidades-mei"
+                ],
+                "summary": "Listar oportunidades MEI",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Número da página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Tamanho da página (default: 10, max: 1000)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por órgão",
+                        "name": "orgaoId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por status (draft, active, expired)",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Buscar por título (case-insensitive)",
+                        "name": "titulo",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
                         }
                     }
                 }
@@ -7349,7 +7536,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Tamanho da página (default: 10)",
+                        "description": "Tamanho da página (default: 10, máx: 100)",
                         "name": "pageSize",
                         "in": "query"
                     },
@@ -7367,7 +7554,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Filtrar por ID do órgão parceiro",
+                        "description": "Filtrar por ID do órgão parceiro (ignorado se middleware já restringiu)",
                         "name": "orgao_parceiro_id",
                         "in": "query"
                     },
@@ -7375,6 +7562,36 @@
                         "type": "string",
                         "description": "Busca parcial no título da vaga",
                         "name": "search",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)",
+                        "name": "data_publicacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)",
+                        "name": "id_regime_contratacao",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)",
+                        "name": "id_modelo_trabalho",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)",
+                        "name": "acessibilidade_pcd",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)",
+                        "name": "bairro",
                         "in": "query"
                     }
                 ],
@@ -7384,6 +7601,15 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "500": {
@@ -12128,6 +12354,9 @@
         "models.OrgaoSnapshot": {
             "type": "object",
             "properties": {
+                "cd_ua": {
+                    "type": "string"
+                },
                 "created_at": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -358,7 +358,7 @@
                 }
             }
         },
-        "/api/public/oportunidades-mei/{id}": {
+        "/api/public/oportunidades-mei": {
             "get": {
                 "description": "Retorna uma lista paginada de oportunidades MEI ativas",
                 "produces": [
@@ -405,6 +405,53 @@
                         "description": "OK",
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/public/oportunidades-mei/{id}": {
+            "get": {
+                "description": "Retorna uma oportunidade MEI pelo seu ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "oportunidades-mei"
+                ],
+                "summary": "Obter oportunidade MEI por ID",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "ID da oportunidade",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.OportunidadeMEI"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
                     "500": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1264,6 +1264,8 @@ definitions:
     type: object
   models.OrgaoSnapshot:
     properties:
+      cd_ua:
+        type: string
       created_at:
         type: string
       id:
@@ -1567,6 +1569,93 @@ info:
   title: API Go
   version: "1.0"
 paths:
+  /api/public/courses:
+    get:
+      description: 'Retorna lista paginada de cursos. Sem status: exclui rascunhos.
+        Com status: filtra pelos status informados (CSV). Derived statuses (scheduled,
+        accepting_enrollments, in_progress, finished) são mapeados para published.'
+      parameters:
+      - description: 'Número da página (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Tamanho da página (default: 10)'
+        in: query
+        name: limit
+        type: integer
+      - description: 'Filtrar por status (CSV, ex: draft,published,in_review)'
+        in: query
+        name: status
+        type: string
+      - description: Filtrar por modalidade
+        in: query
+        name: modalidade
+        type: string
+      - description: Filtrar por organização (provedor do curso)
+        in: query
+        name: organization
+        type: string
+      - description: Buscar no título
+        in: query
+        name: search
+        type: string
+      - description: Filtrar por categoria
+        in: query
+        name: categoria_id
+        type: integer
+      - description: Filtrar por acessibilidade
+        in: query
+        name: acessibilidade_id
+        type: integer
+      - description: Filtrar por zona do bairro
+        in: query
+        name: neighborhood_zone
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      summary: Listar cursos criados
+      tags:
+      - courses
+  /api/public/courses/{courseId}:
+    get:
+      description: Retorna dados completos de um curso específico
+      parameters:
+      - description: ID do curso
+        in: path
+        name: courseId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Curso'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      summary: Buscar curso específico
+      tags:
+      - courses
   /api/public/empregabilidade/vagas:
     get:
       description: Retorna lista paginada de vagas publicadas. Sem filtro retorna
@@ -1590,23 +1679,23 @@ paths:
         in: query
         name: data_publicacao
         type: string
-      - description: UUID do regime de contratação
+      - description: 'UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)'
         in: query
         name: id_regime_contratacao
         type: string
-      - description: UUID do modelo de trabalho
+      - description: 'UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)'
         in: query
         name: id_modelo_trabalho
         type: string
-      - description: Nome ou CNPJ do contratante
+      - description: 'Nome(s) ou CNPJ(s) do contratante (CSV, ex: TechRio,12345678000100)'
         in: query
         name: contratante
         type: string
-      - description: Acessibilidade PCD (para_pcd, preferencial_pcd, exclusivo_pcd)
+      - description: 'Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)'
         in: query
         name: acessibilidade_pcd
         type: string
-      - description: Bairro (busca parcial)
+      - description: 'Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)'
         in: query
         name: bairro
         type: string
@@ -1710,6 +1799,44 @@ paths:
       summary: Buscar vaga pública por slug
       tags:
       - empregabilidade-vagas-public
+  /api/public/oportunidades-mei/{id}:
+    get:
+      description: Retorna uma lista paginada de oportunidades MEI ativas
+      parameters:
+      - description: 'Número da página (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Tamanho da página (default: 10, max: 1000)'
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filtrar por órgão
+        in: query
+        name: orgaoId
+        type: string
+      - description: Filtrar por status (draft, active, expired)
+        in: query
+        name: status
+        type: string
+      - description: Buscar por título (case-insensitive)
+        in: query
+        name: titulo
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      summary: Listar oportunidades MEI
+      tags:
+      - oportunidades-mei
   /api/v1/acessibilidades:
     get:
       description: Retorna lista paginada de opções de acessibilidade
@@ -6449,7 +6576,7 @@ paths:
         in: query
         name: page
         type: integer
-      - description: 'Tamanho da página (default: 10)'
+      - description: 'Tamanho da página (default: 10, máx: 100)'
         in: query
         name: pageSize
         type: integer
@@ -6462,13 +6589,33 @@ paths:
         in: query
         name: contratante
         type: string
-      - description: Filtrar por ID do órgão parceiro
+      - description: Filtrar por ID do órgão parceiro (ignorado se middleware já restringiu)
         in: query
         name: orgao_parceiro_id
         type: string
       - description: Busca parcial no título da vaga
         in: query
         name: search
+        type: string
+      - description: Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)
+        in: query
+        name: data_publicacao
+        type: string
+      - description: 'UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)'
+        in: query
+        name: id_regime_contratacao
+        type: string
+      - description: 'UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)'
+        in: query
+        name: id_modelo_trabalho
+        type: string
+      - description: 'Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)'
+        in: query
+        name: acessibilidade_pcd
+        type: string
+      - description: 'Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)'
+        in: query
+        name: bairro
         type: string
       produces:
       - application/json
@@ -6477,6 +6624,12 @@ paths:
           description: OK
           schema:
             additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
             type: object
         "500":
           description: Internal Server Error

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1799,7 +1799,7 @@ paths:
       summary: Buscar vaga pública por slug
       tags:
       - empregabilidade-vagas-public
-  /api/public/oportunidades-mei/{id}:
+  /api/public/oportunidades-mei:
     get:
       description: Retorna uma lista paginada de oportunidades MEI ativas
       parameters:
@@ -1835,6 +1835,37 @@ paths:
           schema:
             $ref: '#/definitions/models.ErrorResponse'
       summary: Listar oportunidades MEI
+      tags:
+      - oportunidades-mei
+  /api/public/oportunidades-mei/{id}:
+    get:
+      description: Retorna uma oportunidade MEI pelo seu ID
+      parameters:
+      - description: ID da oportunidade
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.OportunidadeMEI'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+      summary: Obter oportunidade MEI por ID
       tags:
       - oportunidades-mei
   /api/v1/acessibilidades:

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -706,6 +706,17 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 		"status": models.StatusCursoDraft,
 	}
 
+	if _, noResults := filter["_no_results"]; noResults {
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"data": gin.H{
+				"courses":    []interface{}{},
+				"pagination": gin.H{"page": page, "limit": limit, "total": 0, "total_pages": 0},
+			},
+		})
+		return
+	}
+
 	for k, v := range middlewares.GetCourseFilters(c) {
 		filter[k] = v
 	}

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -227,6 +227,15 @@ func (h *CourseHandler) calculateRemainingVacanciesForCourses(c *gin.Context, cu
 	return nil
 }
 
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
 // @Summary      Criar curso
 // @Description  Cria um novo curso no sistema (status: "opened")
 // @Tags         courses
@@ -247,19 +256,11 @@ func (h *CourseHandler) Create(c *gin.Context) {
 	// Set status to opened for published course
 	curso.Status = models.StatusCursoOpened
 
-	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
-		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			if len(secretariaIDs) == 0 {
-				c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: nenhuma secretaria associada"})
-				return
-			}
-			curso.OrgaoID = secretariaIDs[0]
-		} else if middlewares.HasRole(c, "go:cursos:editor") {
-			if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
-				curso.OrgaoID = orgaoID
-			}
-		}
+	allowedOrgaos := middlewares.GetUserAllowedOrgaos(c)
+	// Se allowedOrgaos for nil, significa que é admin/casa_civil – permite qualquer um
+	if allowedOrgaos != nil && !contains(allowedOrgaos, curso.OrgaoID) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Você não tem permissão para criar cursos neste órgão"})
+		return
 	}
 
 	id, err := h.cursoService.Create(c.Request.Context(), &curso)
@@ -320,19 +321,11 @@ func (h *CourseHandler) CreateDraft(c *gin.Context) {
 	// Set status to draft
 	curso.Status = models.StatusCursoDraft
 
-	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
-		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			if len(secretariaIDs) == 0 {
-				c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: nenhuma secretaria associada"})
-				return
-			}
-			curso.OrgaoID = secretariaIDs[0]
-		} else if middlewares.HasRole(c, "go:cursos:editor") {
-			if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
-				curso.OrgaoID = orgaoID
-			}
-		}
+	allowedOrgaos := middlewares.GetUserAllowedOrgaos(c)
+	// Se allowedOrgaos for nil, significa que é admin/casa_civil – permite qualquer um
+	if allowedOrgaos != nil && !contains(allowedOrgaos, curso.OrgaoID) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Você não tem permissão para criar cursos neste órgão"})
+		return
 	}
 
 	id, err := h.cursoService.Create(c.Request.Context(), &curso)
@@ -355,7 +348,6 @@ func (h *CourseHandler) CreateDraft(c *gin.Context) {
 
 	curso.ID = id
 
-	// Invalidate course list cache after create (if caching is enabled)
 	if h.courseCache != nil {
 		_ = h.courseCache.InvalidateAll(c.Request.Context())
 	}
@@ -392,7 +384,6 @@ func (h *CourseHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// Check if course exists
 	existingCurso, err := h.cursoService.GetByID(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao buscar curso: " + err.Error()})
@@ -401,24 +392,6 @@ func (h *CourseHandler) Update(c *gin.Context) {
 	if existingCurso == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Curso não encontrado"})
 		return
-	}
-
-	// Secretaria ownership check: non-admins can only edit courses from their secretaria.
-	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
-		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			allowed := false
-			for _, sid := range secretariaIDs {
-				if existingCurso.OrgaoID == sid {
-					allowed = true
-					break
-				}
-			}
-			if !allowed {
-				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: curso não pertence à sua secretaria"})
-				return
-			}
-		}
 	}
 
 	var curso models.Curso
@@ -554,6 +527,26 @@ func parseStatusFilter(param string) []string {
 // @Param        neighborhood_zone query     string  false  "Filtrar por zona do bairro"
 // @Success      200               {object}  object
 // @Failure      500               {object}  models.ErrorResponse
+// @Router       /api/public/courses [get]
+func (h *CourseHandler) ListPublic(c *gin.Context) {
+	h.List(c)
+}
+
+// @Summary      Listar cursos criados
+// @Description  Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.
+// @Tags         courses
+// @Produce      json
+// @Param        page              query     int     false  "Número da página (default: 1)"
+// @Param        limit             query     int     false  "Tamanho da página (default: 10)"
+// @Param        status            query     string  false  "Filtrar por status (CSV, ex: draft,published,in_review)"
+// @Param        modalidade        query     string  false  "Filtrar por modalidade"
+// @Param        organization      query     string  false  "Filtrar por organização (provedor do curso)"
+// @Param        search            query     string  false  "Buscar no título"
+// @Param        categoria_id      query     int     false  "Filtrar por categoria"
+// @Param        acessibilidade_id query     int     false  "Filtrar por acessibilidade"
+// @Param        neighborhood_zone query     string  false  "Filtrar por zona do bairro"
+// @Success      200               {object}  object
+// @Failure      500               {object}  models.ErrorResponse
 // @Router       /api/v1/courses [get]
 func (h *CourseHandler) List(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
@@ -569,6 +562,26 @@ func (h *CourseHandler) List(c *gin.Context) {
 
 	filter := map[string]interface{}{}
 
+	for k, v := range middlewares.GetCourseFilters(c) {
+		filter[k] = v
+	}
+
+	if _, noResults := filter["_no_results"]; noResults {
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"data": gin.H{
+				"courses": []interface{}{},
+				"pagination": gin.H{
+					"page":        page,
+					"limit":       limit,
+					"total":       0,
+					"total_pages": 0,
+				},
+			},
+		})
+		return
+	}
+
 	if statusParam := c.Query("status"); statusParam != "" {
 		if statuses := parseStatusFilter(statusParam); len(statuses) > 0 {
 			filter["status IN"] = statuses
@@ -577,19 +590,6 @@ func (h *CourseHandler) List(c *gin.Context) {
 		}
 	} else {
 		filter["status NOT"] = models.StatusCursoDraft
-	}
-
-	// Secretaria-level filter: restrict to the user's allowed orgaos.
-	// Secretaria mapping (CPF-Secretaria) takes precedence over single-orgao Keycloak group.
-	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
-		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			filter["orgao_id IN"] = secretariaIDs
-		} else if middlewares.HasRole(c, "go:cursos:editor") {
-			if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
-				filter["orgao_id"] = orgaoID
-			}
-		}
 	}
 
 	if modalidade := c.Query("modalidade"); modalidade != "" {
@@ -702,21 +702,12 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 		limit = 10
 	}
 
-	// Build filters - only drafts
 	filter := map[string]interface{}{
 		"status": models.StatusCursoDraft,
 	}
 
-	// Secretaria-level filter: restrict to the user's allowed orgaos.
-	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
-		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			filter["orgao_id IN"] = secretariaIDs
-		} else if middlewares.HasRole(c, "go:cursos:editor") {
-			if orgaoID := middlewares.GetUserOrgaoID(c); orgaoID != "" {
-				filter["orgao_id"] = orgaoID
-			}
-		}
+	for k, v := range middlewares.GetCourseFilters(c) {
+		filter[k] = v
 	}
 
 	if organization := c.Query("organization"); organization != "" {
@@ -811,6 +802,20 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 // @Failure      400      {object}  models.ErrorResponse
 // @Failure      404      {object}  models.ErrorResponse
 // @Failure      500      {object}  models.ErrorResponse
+// @Router       /api/public/courses/{courseId} [get]
+func (h *CourseHandler) GetByIDPublic(c *gin.Context) {
+	h.GetByID(c)
+}
+
+// @Summary      Buscar curso específico
+// @Description  Retorna dados completos de um curso específico
+// @Tags         courses
+// @Produce      json
+// @Param        courseId path      int  true  "ID do curso"
+// @Success      200      {object}  models.Curso
+// @Failure      400      {object}  models.ErrorResponse
+// @Failure      404      {object}  models.ErrorResponse
+// @Failure      500      {object}  models.ErrorResponse
 // @Router       /api/v1/courses/{courseId} [get]
 func (h *CourseHandler) GetByID(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("courseId"))
@@ -857,35 +862,6 @@ func (h *CourseHandler) Delete(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "ID do curso inválido"})
 		return
-	}
-
-	// Check if course exists
-	curso, err := h.cursoService.GetByID(c.Request.Context(), id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao buscar curso: " + err.Error()})
-		return
-	}
-	if curso == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Curso não encontrado"})
-		return
-	}
-
-	// Secretaria ownership check.
-	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
-		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			allowed := false
-			for _, sid := range secretariaIDs {
-				if curso.OrgaoID == sid {
-					allowed = true
-					break
-				}
-			}
-			if !allowed {
-				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: curso não pertence à sua secretaria"})
-				return
-			}
-		}
 	}
 
 	if err := h.cursoService.Delete(c.Request.Context(), id); err != nil {

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
 	"strconv"
 	"strings"
@@ -720,6 +721,8 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 		})
 		return
 	}
+
+	maps.Copy(filter, middlewares.GetCourseFilters(c))
 
 	if organization := c.Query("organization"); organization != "" {
 		filter["organization"] = organization

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -706,6 +706,10 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 		"status": models.StatusCursoDraft,
 	}
 
+	for k, v := range middlewares.GetCourseFilters(c) {
+		filter[k] = v
+	}
+
 	if _, noResults := filter["_no_results"]; noResults {
 		c.JSON(http.StatusOK, gin.H{
 			"success": true,
@@ -715,10 +719,6 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 			},
 		})
 		return
-	}
-
-	for k, v := range middlewares.GetCourseFilters(c) {
-		filter[k] = v
 	}
 
 	if organization := c.Query("organization"); organization != "" {

--- a/internal/handlers/v1/course_handler_test.go
+++ b/internal/handlers/v1/course_handler_test.go
@@ -944,12 +944,6 @@ func TestCourseHandler_Delete_Success(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/api/v1/courses/:courseId", handler.Delete)
 
-	curso := &models.Curso{
-		ID:     1,
-		Titulo: "Test Course",
-	}
-
-	mockService.On("GetByID", mock.Anything, 1).Return(curso, nil)
 	mockService.On("Delete", mock.Anything, 1).Return(nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
@@ -968,7 +962,8 @@ func TestCourseHandler_Delete_Success(t *testing.T) {
 	mockService.AssertExpectations(t)
 }
 
-// Test Delete - Not Found
+// Test Delete - Service Error (not-found via service is now middleware responsibility;
+// this test covers the handler's own error path: service.Delete returns an error).
 func TestCourseHandler_Delete_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mockService := new(MockCursoService)
@@ -980,15 +975,14 @@ func TestCourseHandler_Delete_NotFound(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/api/v1/courses/:courseId", handler.Delete)
 
-	mockService.On("GetByID", mock.Anything, 999).Return(nil, nil)
+	mockService.On("Delete", mock.Anything, 999).Return(errors.New("record not found"))
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/999", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
-	assert.Contains(t, w.Body.String(), "Curso não encontrado")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 	mockService.AssertExpectations(t)
 }
@@ -1005,9 +999,6 @@ func TestCourseHandler_Delete_ServiceError(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/api/v1/courses/:courseId", handler.Delete)
 
-	curso := &models.Curso{ID: 1}
-
-	mockService.On("GetByID", mock.Anything, 1).Return(curso, nil)
 	mockService.On("Delete", mock.Anything, 1).Return(errors.New("delete error"))
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
@@ -1705,7 +1696,7 @@ func TestCourseHandler_Update_ValidationError(t *testing.T) {
 	mockService.AssertExpectations(t)
 }
 
-// Test Delete with GetByID error
+// Test Delete with Delete service error
 func TestCourseHandler_Delete_GetByIDError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mockService := new(MockCursoService)
@@ -1717,7 +1708,7 @@ func TestCourseHandler_Delete_GetByIDError(t *testing.T) {
 	r := gin.New()
 	r.DELETE("/api/v1/courses/:courseId", handler.Delete)
 
-	mockService.On("GetByID", mock.Anything, 1).Return(nil, errors.New("database error"))
+	mockService.On("Delete", mock.Anything, 1).Return(errors.New("database error"))
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
 	w := httptest.NewRecorder()
@@ -1725,7 +1716,7 @@ func TestCourseHandler_Delete_GetByIDError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, w.Body.String(), "Erro ao buscar curso")
+	assert.Contains(t, w.Body.String(), "Erro ao excluir curso")
 
 	mockService.AssertExpectations(t)
 }

--- a/internal/handlers/v1/course_secretaria_handler_test.go
+++ b/internal/handlers/v1/course_secretaria_handler_test.go
@@ -3,6 +3,7 @@ package v1_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -75,10 +76,6 @@ func TestCourseHandler_Secretaria_List_FilterApplied(t *testing.T) {
 
 func TestCourseHandler_Secretaria_List_EmptySecretaria_FilterStillSet(t *testing.T) {
 	svc := &MockCursoService{}
-	svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
-		_, hasKey := f["orgao_id IN"]
-		return hasKey
-	}), mock.Anything, mock.Anything).Return([]*models.Curso{}, 0, nil)
 
 	router := setupCourseRouterWithSecretaria(svc, "USER", []string{})
 
@@ -87,7 +84,17 @@ func TestCourseHandler_Secretaria_List_EmptySecretaria_FilterStillSet(t *testing
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	svc.AssertExpectations(t)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	data := resp["data"].(map[string]interface{})
+	courses := data["courses"].([]interface{})
+	assert.Empty(t, courses)
+	pagination := data["pagination"].(map[string]interface{})
+	assert.Equal(t, float64(0), pagination["total"])
+
+	svc.AssertNotCalled(t, "List")
 }
 
 func TestCourseHandler_Secretaria_List_Admin_NoSecretariaFilter(t *testing.T) {
@@ -109,12 +116,7 @@ func TestCourseHandler_Secretaria_List_Admin_NoSecretariaFilter(t *testing.T) {
 
 func TestCourseHandler_Secretaria_List_NoMiddleware_NoFilter(t *testing.T) {
 	svc := &MockCursoService{}
-	svc.On("List", mock.Anything, mock.MatchedBy(func(f map[string]interface{}) bool {
-		_, hasKey := f["orgao_id IN"]
-		return !hasKey
-	}), mock.Anything, mock.Anything).Return([]*models.Curso{}, 0, nil)
 
-	// nil secretariaIDs → middleware never ran
 	router := setupCourseRouterWithSecretaria(svc, "USER", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses", nil)
@@ -122,7 +124,17 @@ func TestCourseHandler_Secretaria_List_NoMiddleware_NoFilter(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	svc.AssertExpectations(t)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	data := resp["data"].(map[string]interface{})
+	courses := data["courses"].([]interface{})
+	assert.Empty(t, courses)
+	pagination := data["pagination"].(map[string]interface{})
+	assert.Equal(t, float64(0), pagination["total"])
+
+	svc.AssertNotCalled(t, "List")
 }
 
 // --- Create ---
@@ -135,7 +147,8 @@ func TestCourseHandler_Secretaria_Create_OrgaoForced(t *testing.T) {
 
 	router := setupCourseRouterWithSecretaria(svc, "USER", []string{"orgao-secretaria"})
 
-	body := []byte(`{"titulo": "Curso Teste", "descricao": "Desc"}`)
+	// Adiciona orgao_id no payload
+	body := []byte(`{"titulo": "Curso Teste", "descricao": "Desc", "orgao_id": "orgao-secretaria"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/courses", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -169,7 +182,7 @@ func TestCourseHandler_Secretaria_CreateDraft_OrgaoForced(t *testing.T) {
 
 	router := setupCourseRouterWithSecretaria(svc, "USER", []string{"orgao-draft"})
 
-	body := []byte(`{"titulo": "Rascunho"}`)
+	body := []byte(`{"titulo": "Rascunho", "orgao_id": "orgao-draft"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/courses/draft", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/internal/handlers/v1/course_secretaria_handler_test.go
+++ b/internal/handlers/v1/course_secretaria_handler_test.go
@@ -2,6 +2,7 @@ package v1_test
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,7 +15,9 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// setupCourseRouterWithSecretaria builds a gin router with user context middleware injected.
+// setupCourseRouterWithSecretaria builds a gin router that mirrors the real middleware chain:
+// CourseAuthorization + CourseListFilter on all routes, CourseOrgaoInjector on POST routes,
+// and CourseOwnershipCheck (backed by svc.GetByID) on mutation routes.
 // role: "ADMIN" or "USER"; secretariaIDs: nil means middleware never ran, []string{} means ran but empty.
 func setupCourseRouterWithSecretaria(svc *MockCursoService, role string, secretariaIDs []string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
@@ -28,13 +31,26 @@ func setupCourseRouterWithSecretaria(svc *MockCursoService, role string, secreta
 		}
 		c.Next()
 	})
+
+	cursoLoader := func(ctx context.Context, id int) (orgaoID string, found bool, err error) {
+		curso, err := svc.GetByID(ctx, id)
+		if err != nil {
+			return "", false, err
+		}
+		if curso == nil {
+			return "", false, nil
+		}
+		return curso.OrgaoID, true, nil
+	}
+	ownershipCheck := middlewares.CourseOwnershipCheck(cursoLoader)
+
 	h := v1.NewCourseHandler(svc, nil, nil)
-	r.POST("/api/v1/courses", h.Create)
-	r.POST("/api/v1/courses/draft", h.CreateDraft)
-	r.GET("/api/v1/courses", h.List)
+	r.POST("/api/v1/courses", middlewares.CourseOrgaoInjector(), h.Create)
+	r.POST("/api/v1/courses/draft", middlewares.CourseOrgaoInjector(), h.CreateDraft)
+	r.GET("/api/v1/courses", middlewares.CourseListFilter(), h.List)
 	r.GET("/api/v1/courses/:courseId", h.GetByID)
-	r.PUT("/api/v1/courses/:courseId", h.Update)
-	r.DELETE("/api/v1/courses/:courseId", h.Delete)
+	r.PUT("/api/v1/courses/:courseId", ownershipCheck, h.Update)
+	r.DELETE("/api/v1/courses/:courseId", ownershipCheck, h.Delete)
 	return r
 }
 

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -104,14 +104,20 @@ func (h *VagaHandler) Create(c *gin.Context) {
 // @Description  Retorna lista paginada de vagas com filtros opcionais
 // @Tags         empregabilidade-vagas
 // @Produce      json
-// @Param        page              query     int     false  "Número da página (default: 1)"
-// @Param        pageSize          query     int     false  "Tamanho da página (default: 10)"
-// @Param        status            query     string  false  "Filtrar por status (em_edicao, em_aprovacao, publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)"
-// @Param        contratante       query     string  false  "Filtrar por CNPJ do contratante"
-// @Param        orgao_parceiro_id query     string  false  "Filtrar por ID do órgão parceiro"
-// @Param        search            query     string  false  "Busca parcial no título da vaga"
-// @Success      200               {object}  map[string]interface{}
-// @Failure      500               {object}  map[string]string
+// @Param        page                    query     int     false  "Número da página (default: 1)"
+// @Param        pageSize                query     int     false  "Tamanho da página (default: 10, máx: 100)"
+// @Param        status                  query     string  false  "Filtrar por status (em_edicao, em_aprovacao, publicado_ativo, publicado_expirado, vaga_congelada, vaga_descontinuada)"
+// @Param        contratante             query     string  false  "Filtrar por CNPJ do contratante"
+// @Param        orgao_parceiro_id       query     string  false  "Filtrar por ID do órgão parceiro (ignorado se middleware já restringiu)"
+// @Param        search                  query     string  false  "Busca parcial no título da vaga"
+// @Param        data_publicacao         query     string  false  "Filtrar por data de publicação (hoje, ultima_semana, ultimo_mes)"
+// @Param        id_regime_contratacao   query     string  false  "UUID(s) do regime de contratação (CSV, ex: uuid1,uuid2)"
+// @Param        id_modelo_trabalho      query     string  false  "UUID(s) do modelo de trabalho (CSV, ex: uuid1,uuid2)"
+// @Param        acessibilidade_pcd      query     string  false  "Acessibilidade PCD (CSV, ex: para_pcd,exclusivo_pcd)"
+// @Param        bairro                  query     string  false  "Bairro(s) — busca parcial (CSV, ex: Centro,Tijuca)"
+// @Success      200                     {object}  map[string]interface{}
+// @Failure      400                     {object}  map[string]string
+// @Failure      500                     {object}  map[string]string
 // @Router       /api/v1/empregabilidade/vagas [get]
 func (h *VagaHandler) List(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
@@ -120,15 +126,44 @@ func (h *VagaHandler) List(c *gin.Context) {
 	if page < 1 {
 		page = 1
 	}
-	if pageSize < 1 || pageSize > 1000 {
+	if pageSize < 1 || pageSize > 100 {
 		pageSize = 10
 	}
 
+	dataPublicacao := empregabilidade.DataPublicacaoRange(c.Query("data_publicacao"))
+	if dataPublicacao != "" && !dataPublicacao.IsValid() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "data_publicacao inválido: deve ser hoje, ultima_semana ou ultimo_mes"})
+		return
+	}
+
+	acessibilidadePCDValues := parseCSVParam(c.Query("acessibilidade_pcd"))
+	for _, v := range acessibilidadePCDValues {
+		if !empregabilidade.AcessibilidadePCD(v).IsValid() {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "acessibilidade_pcd inválido: deve ser para_pcd, preferencial_pcd ou exclusivo_pcd"})
+			return
+		}
+	}
+
+	orgaoParceiroIDs := middlewares.GetVagaOrgaoParceiroIDs(c)
+
 	filter := empregabilidade.VagaFilter{
-		Status:          c.Query("status"),
-		Contratante:     c.Query("contratante"),
-		OrgaoParceiroID: c.Query("orgao_parceiro_id"),
-		Search:          c.Query("search"),
+		Status:              c.Query("status"),
+		Contratante:         c.Query("contratante"),
+		Search:              c.Query("search"),
+		DataPublicacao:      dataPublicacao,
+		IDRegimeContratacao: parseCSVParam(c.Query("id_regime_contratacao")),
+		IDModeloTrabalho:    parseCSVParam(c.Query("id_modelo_trabalho")),
+		AcessibilidadePCD:   acessibilidadePCDValues,
+		Bairro:              parseCSVParam(c.Query("bairro")),
+	}
+
+	switch {
+	case len(orgaoParceiroIDs) == 1:
+		filter.OrgaoParceiroID = orgaoParceiroIDs[0]
+	case len(orgaoParceiroIDs) > 1:
+		filter.OrgaoParceiroIDs = orgaoParceiroIDs
+	default:
+		filter.OrgaoParceiroID = c.Query("orgao_parceiro_id")
 	}
 
 	entities, total, err := h.service.List(c.Request.Context(), filter, page, pageSize)

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -1595,3 +1595,141 @@ func TestVagaHandler_PublicList_MultipleFilters_Combined(t *testing.T) {
 		t.Errorf("expected 200 for combined multi-select filters, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+func TestVagaHandler_List_NewFilters_DataPublicacao(t *testing.T) {
+	tests := []struct {
+		name           string
+		dataPublicacao string
+		wantStatus     int
+	}{
+		{"hoje", "hoje", http.StatusOK},
+		{"ultima_semana", "ultima_semana", http.StatusOK},
+		{"ultimo_mes", "ultimo_mes", http.StatusOK},
+		{"invalid", "ontem", http.StatusBadRequest},
+		{"empty", "", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+			r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+			url := "/vagas"
+			if tt.dataPublicacao != "" {
+				url += "?data_publicacao=" + tt.dataPublicacao
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestVagaHandler_List_NewFilters_AcessibilidadePCD(t *testing.T) {
+	tests := []struct {
+		name       string
+		param      string
+		wantStatus int
+	}{
+		{"para_pcd", "para_pcd", http.StatusOK},
+		{"exclusivo_pcd", "exclusivo_pcd", http.StatusOK},
+		{"preferencial_pcd", "preferencial_pcd", http.StatusOK},
+		{"multiple valid", "para_pcd,exclusivo_pcd", http.StatusOK},
+		{"invalid value", "invalido", http.StatusBadRequest},
+		{"mixed valid and invalid", "para_pcd,invalido", http.StatusBadRequest},
+		{"empty", "", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+			r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+			url := "/vagas"
+			if tt.param != "" {
+				url += "?acessibilidade_pcd=" + tt.param
+			}
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Errorf("expected %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestVagaHandler_List_NewFilters_CSVParams(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet,
+		"/vagas?id_regime_contratacao="+validUUID+"&id_modelo_trabalho="+validUUID+"&bairro=Centro,Tijuca", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for CSV filters, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_List_PageSizeCappedAt100(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/vagas?pageSize=500", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_List_MiddlewareOrgaoParceiroID_SingleID(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("vaga_orgao_parceiro_ids", []string{"orgao-42"})
+		c.Next()
+	})
+	candidaturaRepo := &mockCandidaturaRepoForVaga{}
+	svc := services.NewVagaServiceWithInterfaces(vagaRepo, &mockEmpresaRepoForVaga{}, candidaturaRepo)
+	h := handlers.NewVagaHandler(svc)
+	r.GET("/vagas", h.List)
+
+	req := httptest.NewRequest(http.MethodGet, "/vagas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_List_MiddlewareOrgaoParceiroIDs_MultipleIDs(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("vaga_orgao_parceiro_ids", []string{"orgao-1", "orgao-2", "orgao-3"})
+		c.Next()
+	})
+	candidaturaRepo := &mockCandidaturaRepoForVaga{}
+	svc := services.NewVagaServiceWithInterfaces(vagaRepo, &mockEmpresaRepoForVaga{}, candidaturaRepo)
+	h := handlers.NewVagaHandler(svc)
+	r.GET("/vagas", h.List)
+
+	req := httptest.NewRequest(http.MethodGet, "/vagas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_List_OrgaoParceiroID_FallsBackToQueryParam(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{listItems: []*empmodels.Vaga{}, listTotal: 0}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/vagas?orgao_parceiro_id=orgao-99", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/handlers/v1/emprego_handler.go
+++ b/internal/handlers/v1/emprego_handler.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,8 +43,9 @@ func (h *EmpregoHandler) Create(c *gin.Context) {
 
 	// Force orgao_id to the user's secretaria when applicable.
 	if !middlewares.IsAdmin(c) {
+		cpf := middlewares.GetUserCPF(c)
 		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
+		if cpf != "" && secretariaIDs != nil {
 			if len(secretariaIDs) == 0 {
 				c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: nenhuma secretaria associada"})
 				return
@@ -124,8 +126,9 @@ func (h *EmpregoHandler) Update(c *gin.Context) {
 
 	// Secretaria ownership check before updating.
 	if !middlewares.IsAdmin(c) {
+		cpf := middlewares.GetUserCPF(c)
 		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
+		if cpf != "" && secretariaIDs != nil {
 			existing, err := h.service.GetByID(c.Request.Context(), id)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao buscar emprego: " + err.Error()})
@@ -135,13 +138,7 @@ func (h *EmpregoHandler) Update(c *gin.Context) {
 				c.JSON(http.StatusNotFound, gin.H{"error": "Emprego não encontrado"})
 				return
 			}
-			allowed := false
-			for _, sid := range secretariaIDs {
-				if existing.OrgaoID == sid {
-					allowed = true
-					break
-				}
-			}
+			allowed := slices.Contains(secretariaIDs, existing.OrgaoID)
 			if !allowed {
 				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: emprego não pertence à sua secretaria"})
 				return
@@ -204,15 +201,10 @@ func (h *EmpregoHandler) Delete(c *gin.Context) {
 
 	// Secretaria ownership check.
 	if !middlewares.IsAdmin(c) {
+		cpf := middlewares.GetUserCPF(c)
 		secretariaIDs := middlewares.GetUserSecretariaOrgaoIDs(c)
-		if secretariaIDs != nil {
-			allowed := false
-			for _, sid := range secretariaIDs {
-				if emprego.OrgaoID == sid {
-					allowed = true
-					break
-				}
-			}
+		if cpf != "" && secretariaIDs != nil {
+			allowed := slices.Contains(secretariaIDs, emprego.OrgaoID)
 			if !allowed {
 				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: emprego não pertence à sua secretaria"})
 				return

--- a/internal/handlers/v1/emprego_secretaria_handler_test.go
+++ b/internal/handlers/v1/emprego_secretaria_handler_test.go
@@ -68,6 +68,7 @@ func setupEmpregoRouterWithSecretaria(repo services.EmpregoRepositoryInterface, 
 		if role != "" {
 			c.Set(middlewares.UserRoleKey, role)
 		}
+		c.Set(middlewares.UserCPFKey, "12345678900")
 		if secretariaIDs != nil {
 			c.Set(middlewares.UserSecretariaOrgaoIDsKey, secretariaIDs)
 		}

--- a/internal/handlers/v1/oportunidade_mei_handler.go
+++ b/internal/handlers/v1/oportunidade_mei_handler.go
@@ -84,6 +84,7 @@ func (h *OportunidadeMEIHandler) CreateDraft(c *gin.Context) {
 // @Failure      404  {object}  models.ErrorResponse
 // @Failure      500  {object}  models.ErrorResponse
 // @Router       /api/v1/oportunidades-mei/{id} [get]
+// @Router       /api/public/oportunidades-mei/{id} [get]
 func (h *OportunidadeMEIHandler) GetByID(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -205,6 +206,7 @@ func (h *OportunidadeMEIHandler) Publish(c *gin.Context) {
 // @Success      200       {object}  object
 // @Failure      500       {object}  models.ErrorResponse
 // @Router       /api/v1/oportunidades-mei [get]
+// @Router       /api/public/oportunidades-mei/{id} [get]
 func (h *OportunidadeMEIHandler) List(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "10"))

--- a/internal/handlers/v1/oportunidade_mei_handler.go
+++ b/internal/handlers/v1/oportunidade_mei_handler.go
@@ -206,7 +206,7 @@ func (h *OportunidadeMEIHandler) Publish(c *gin.Context) {
 // @Success      200       {object}  object
 // @Failure      500       {object}  models.ErrorResponse
 // @Router       /api/v1/oportunidades-mei [get]
-// @Router       /api/public/oportunidades-mei/{id} [get]
+// @Router       /api/public/oportunidades-mei [get]
 func (h *OportunidadeMEIHandler) List(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "10"))

--- a/internal/middlewares/course_auth.go
+++ b/internal/middlewares/course_auth.go
@@ -1,0 +1,183 @@
+package middlewares
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	courseLoadedCursoKey   = "course_loaded_curso"
+	courseAllowedOrgaosKey = "course_allowed_orgaos"
+)
+
+func CourseAuthorization() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if IsAdmin(c) || HasRole(c, "go:cursos:casa_civil") {
+			c.Next()
+			return
+		}
+
+		secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+		if len(secretariaIDs) > 0 {
+			c.Next()
+			return
+		}
+
+		if HasRole(c, "go:cursos:editor") {
+			if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
+				c.Next()
+				return
+			}
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para acessar este recurso"})
+		c.Abort()
+	}
+}
+
+func CourseListFilter() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		filters := make(map[string]interface{})
+		if !IsAdmin(c) && !HasRole(c, "go:cursos:casa_civil") {
+			secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+			if len(secretariaIDs) > 0 {
+				filters["orgao_id IN"] = secretariaIDs
+			} else if HasRole(c, "go:cursos:editor") {
+				if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
+					filters["orgao_id"] = orgaoID
+				} else {
+					filters["_no_results"] = true
+				}
+			} else {
+				filters["_no_results"] = true
+			}
+		}
+		c.Set("course_filters", filters)
+		c.Next()
+	}
+}
+
+func GetCourseFilters(c *gin.Context) map[string]interface{} {
+	if filters, exists := c.Get("course_filters"); exists {
+		if f, ok := filters.(map[string]interface{}); ok {
+			return f
+		}
+	}
+	return make(map[string]interface{})
+}
+
+func CourseOrgaoInjector() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if IsAdmin(c) || HasRole(c, "go:cursos:casa_civil") {
+			c.Next()
+			return
+		}
+
+		secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+		if secretariaIDs != nil {
+			if len(secretariaIDs) == 0 {
+				c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: nenhuma secretaria associada"})
+				c.Abort()
+				return
+			}
+			c.Set(courseAllowedOrgaosKey, secretariaIDs)
+			c.Next()
+			return
+		}
+
+		if HasRole(c, "go:cursos:editor") {
+			if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
+				c.Set(courseAllowedOrgaosKey, []string{orgaoID})
+				c.Next()
+				return
+			}
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: órgão não identificado"})
+		c.Abort()
+	}
+}
+
+func GetUserAllowedOrgaos(c *gin.Context) []string {
+	if v, exists := c.Get(courseAllowedOrgaosKey); exists {
+		if id, ok := v.([]string); ok {
+			return id
+		}
+	}
+	return nil
+}
+
+type courseLoaderFunc func(ctx context.Context, id int) (orgaoID string, found bool, err error)
+
+func CourseOwnershipCheck(loader courseLoaderFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("courseId"))
+
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ID do curso inválido"})
+			c.Abort()
+			return
+		}
+
+		orgaoID, found, err := loader(c.Request.Context(), id)
+
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao buscar curso: " + err.Error()})
+			c.Abort()
+			return
+		}
+
+		if !found {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Curso não encontrado"})
+			c.Abort()
+			return
+		}
+
+		c.Set(courseLoadedCursoKey, orgaoID)
+
+		if IsAdmin(c) || HasRole(c, "go:cursos:casa_civil") {
+			c.Next()
+			return
+		}
+
+		if HasRole(c, "go:cursos:editor") {
+			userOrgao := GetUserOrgaoID(c)
+
+			if userOrgao != "" && userOrgao == orgaoID {
+				c.Next()
+				return
+			}
+			c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: curso não pertence à sua secretaria"})
+			c.Abort()
+			return
+		}
+
+		secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+
+		if secretariaIDs != nil {
+			for _, sid := range secretariaIDs {
+				if orgaoID == sid {
+					c.Next()
+					return
+				}
+			}
+			c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: curso não pertence à sua secretaria"})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func GetLoadedCursoOrgaoID(c *gin.Context) string {
+	if v, exists := c.Get(courseLoadedCursoKey); exists {
+		if id, ok := v.(string); ok {
+			return id
+		}
+	}
+	return ""
+}

--- a/internal/middlewares/course_auth_test.go
+++ b/internal/middlewares/course_auth_test.go
@@ -1,0 +1,712 @@
+// course_auth_test.go
+package middlewares_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-go-api/internal/middlewares"
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper functions for injecting test data
+func injectCourseRoles(role string, orgaoID string, secretariaIDs []string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if role != "" {
+			c.Set(middlewares.UserRolesKey, []string{role})
+		}
+		if orgaoID != "" {
+			c.Set(middlewares.UserGroupsKey, []string{"go:orgao:" + orgaoID})
+		}
+		if secretariaIDs != nil {
+			c.Set(middlewares.UserSecretariaOrgaoIDsKey, secretariaIDs)
+		}
+		c.Next()
+	}
+}
+
+func setupCourseTestRouter(middlewares ...gin.HandlerFunc) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	for _, m := range middlewares {
+		r.Use(m)
+	}
+	return r
+}
+
+// ============ CourseAuthorization Tests ============
+
+func TestCourseAuthorization_Admin_Passes(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserRoleKey, "ADMIN")
+			c.Next()
+		},
+		middlewares.CourseAuthorization(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseAuthorization_CasaCivil_Passes(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:casa_civil", "", nil),
+		middlewares.CourseAuthorization(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseAuthorization_SecretariaUser_Passes(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{"orgao-1", "orgao-2"}),
+		middlewares.CourseAuthorization(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseAuthorization_Editor_WithOrgao_Passes(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "orgao-42", nil),
+		middlewares.CourseAuthorization(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseAuthorization_NoRole_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(middlewares.CourseAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Sem permissão para acessar este recurso")
+}
+
+func TestCourseAuthorization_Editor_NoOrgao_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "", nil),
+		middlewares.CourseAuthorization(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// ============ CourseListFilter Tests ============
+
+func TestCourseListFilter_Admin_NoFilterInjected(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserRoleKey, "ADMIN")
+			c.Next()
+		},
+		middlewares.CourseListFilter(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filter_count": len(filters)})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), response["filter_count"])
+}
+
+func TestCourseListFilter_CasaCivil_NoFilterInjected(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:casa_civil", "", nil),
+		middlewares.CourseListFilter(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filter_count": len(filters)})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), response["filter_count"])
+}
+
+func TestCourseListFilter_SecretariaUser_InjectsINFilter(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{"orgao-1", "orgao-2"}),
+		middlewares.CourseListFilter(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Contains(t, filters, "orgao_id IN")
+
+	ids, ok := filters["orgao_id IN"].([]interface{})
+	assert.True(t, ok)
+	assert.ElementsMatch(t, []interface{}{"orgao-1", "orgao-2"}, ids)
+}
+
+func TestCourseListFilter_SecretariaUser_EmptyIDs_InjectsNoResults(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{}),
+		middlewares.CourseListFilter(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Contains(t, filters, "_no_results")
+	assert.Equal(t, true, filters["_no_results"])
+}
+
+func TestCourseListFilter_Editor_InjectsOrgaoIDFilter(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "orgao-42", nil),
+		middlewares.CourseListFilter(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Contains(t, filters, "orgao_id")
+	assert.Equal(t, "orgao-42", filters["orgao_id"])
+}
+
+func TestCourseListFilter_Editor_NoOrgao_InjectsNoResults(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "", nil),
+		middlewares.CourseListFilter(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Contains(t, filters, "_no_results")
+	assert.Equal(t, true, filters["_no_results"])
+}
+
+// ============ GetCourseFilters Tests ============
+
+func TestGetCourseFilters_KeyNotSet_ReturnsEmptyMap(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, filters)
+}
+
+func TestGetCourseFilters_KeyExists_ReturnsFilters(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		c.Set("course_filters", map[string]interface{}{
+			"orgao_id": "orgao-123",
+			"status":   "active",
+		})
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "orgao-123", filters["orgao_id"])
+	assert.Equal(t, "active", filters["status"])
+}
+
+func TestGetCourseFilters_KeyExistsWithWrongType_ReturnsEmptyMap(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		c.Set("course_filters", "invalid_type")
+		filters := middlewares.GetCourseFilters(c)
+		c.JSON(http.StatusOK, gin.H{"filters": filters})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	filters, ok := response["filters"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Empty(t, filters)
+}
+
+// ============ CourseOrgaoInjector Tests ============
+
+func TestCourseOrgaoInjector_Admin_SetsNilAllowed(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserRoleKey, "ADMIN")
+			c.Next()
+		},
+		middlewares.CourseOrgaoInjector(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Nil(t, response["allowed"])
+}
+
+func TestCourseOrgaoInjector_CasaCivil_SetsAllowedOrgaosNil(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:casa_civil", "", nil),
+		middlewares.CourseOrgaoInjector(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Nil(t, response["allowed"])
+}
+
+func TestCourseOrgaoInjector_SecretariaUser_SetsAllowedOrgaosList(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{"orgao-1", "orgao-2"}),
+		middlewares.CourseOrgaoInjector(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	allowed, ok := response["allowed"].([]interface{})
+	assert.True(t, ok)
+	assert.ElementsMatch(t, []interface{}{"orgao-1", "orgao-2"}, allowed)
+}
+
+func TestCourseOrgaoInjector_SecretariaUser_EmptyIDs_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{}),
+		middlewares.CourseOrgaoInjector(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Sem permissão para criar: nenhuma secretaria associada")
+}
+
+func TestCourseOrgaoInjector_Editor_WithOrgao_SetsAllowedOrgaosList(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "orgao-42", nil),
+		middlewares.CourseOrgaoInjector(),
+	)
+	r.GET("/test", func(c *gin.Context) {
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	allowed, ok := response["allowed"].([]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{"orgao-42"}, allowed)
+}
+
+func TestCourseOrgaoInjector_Editor_NoOrgao_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "", nil),
+		middlewares.CourseOrgaoInjector(),
+	)
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Sem permissão para criar: órgão não identificado")
+}
+
+func TestCourseOrgaoInjector_NoRole_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(middlewares.CourseOrgaoInjector())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Sem permissão para criar: órgão não identificado")
+}
+
+// ============ GetUserAllowedOrgaos Tests ============
+
+func TestGetUserAllowedOrgaos_KeyNotSet_ReturnsNil(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Nil(t, response["allowed"])
+}
+
+func TestGetUserAllowedOrgaos_KeyExists_ReturnsList(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		c.Set("course_allowed_orgaos", []string{"a", "b"})
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	allowed, ok := response["allowed"].([]interface{})
+	assert.True(t, ok)
+	assert.ElementsMatch(t, []interface{}{"a", "b"}, allowed)
+}
+
+func TestGetUserAllowedOrgaos_KeyExistsWithWrongType_ReturnsNil(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		c.Set("course_allowed_orgaos", 123) // tipo errado
+		allowed := middlewares.GetUserAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Nil(t, response["allowed"])
+}
+
+// ============ CourseOwnershipCheck Tests ============
+
+func TestCourseOwnershipCheck_Admin_Passes(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		assert.Equal(t, 123, id)
+		return "orgao-456", true, nil
+	}
+
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserRoleKey, "ADMIN")
+			c.Next()
+		},
+		middlewares.CourseOwnershipCheck(loader),
+	)
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		orgaoID := middlewares.GetLoadedCursoOrgaoID(c)
+		c.JSON(http.StatusOK, gin.H{"orgao_id": orgaoID})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "orgao-456", response["orgao_id"])
+}
+
+func TestCourseOwnershipCheck_CasaCivil_Passes(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "orgao-456", true, nil
+	}
+
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:casa_civil", "", nil),
+		middlewares.CourseOwnershipCheck(loader),
+	)
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseOwnershipCheck_SecretariaUser_MatchingOrgao_Passes(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "orgao-456", true, nil
+	}
+
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{"orgao-456", "orgao-789"}),
+		middlewares.CourseOwnershipCheck(loader),
+	)
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseOwnershipCheck_SecretariaUser_NonMatchingOrgao_Forbidden(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "orgao-456", true, nil
+	}
+
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{"orgao-789", "orgao-999"}),
+		middlewares.CourseOwnershipCheck(loader),
+	)
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Acesso negado: curso não pertence à sua secretaria")
+}
+
+func TestCourseOwnershipCheck_EditorUser_NonMatchingOrgao_Forbidden(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "orgao-456", true, nil
+	}
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "orgao-123", nil),
+		middlewares.CourseOwnershipCheck(loader),
+	)
+	r.GET("/test/:courseId", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCourseOwnershipCheck_SecretariaUser_EmptySecretariaIDs_Forbidden(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "orgao-456", true, nil
+	}
+
+	r := setupCourseTestRouter(
+		injectCourseRoles("", "", []string{}),
+		middlewares.CourseOwnershipCheck(loader),
+	)
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCourseOwnershipCheck_InvalidCourseID_BadRequest(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "", false, nil
+	}
+
+	r := setupCourseTestRouter(middlewares.CourseOwnershipCheck(loader))
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/invalid", nil))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "ID do curso inválido")
+}
+
+func TestCourseOwnershipCheck_CourseNotFound_NotFound(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "", false, nil
+	}
+
+	r := setupCourseTestRouter(middlewares.CourseOwnershipCheck(loader))
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "Curso não encontrado")
+}
+
+func TestCourseOwnershipCheck_LoaderError_InternalServerError(t *testing.T) {
+	loader := func(ctx context.Context, id int) (string, bool, error) {
+		return "", false, errors.New("database error")
+	}
+
+	r := setupCourseTestRouter(middlewares.CourseOwnershipCheck(loader))
+	r.GET("/test/:courseId", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test/123", nil))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Erro ao buscar curso")
+	assert.Contains(t, w.Body.String(), "database error")
+}
+
+// ============ GetLoadedCursoOrgaoID Tests ============
+
+func TestGetLoadedCursoOrgaoID_KeyNotSet_ReturnsEmpty(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		orgaoID := middlewares.GetLoadedCursoOrgaoID(c)
+		c.JSON(http.StatusOK, gin.H{"orgao_id": orgaoID})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "", response["orgao_id"])
+}
+
+func TestGetLoadedCursoOrgaoID_KeyExists_ReturnsValue(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		c.Set("course_loaded_curso", "orgao-456")
+		orgaoID := middlewares.GetLoadedCursoOrgaoID(c)
+		c.JSON(http.StatusOK, gin.H{"orgao_id": orgaoID})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "orgao-456", response["orgao_id"])
+}
+
+func TestGetLoadedCursoOrgaoID_KeyExistsWithWrongType_ReturnsEmpty(t *testing.T) {
+	r := setupCourseTestRouter()
+	r.GET("/test", func(c *gin.Context) {
+		c.Set("course_loaded_curso", 456) // Wrong type
+		orgaoID := middlewares.GetLoadedCursoOrgaoID(c)
+		c.JSON(http.StatusOK, gin.H{"orgao_id": orgaoID})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, "", response["orgao_id"])
+}

--- a/internal/middlewares/user_context.go
+++ b/internal/middlewares/user_context.go
@@ -307,6 +307,7 @@ func ExtractSecretariaOrgaoIDs(resolver SecretariaOrgaoResolver) gin.HandlerFunc
 
 		orgaoIDs, err := resolver(c.Request.Context(), cpf)
 		if err != nil {
+			c.Set(UserSecretariaOrgaoIDsKey, []string{})
 			c.Next()
 			return
 		}

--- a/internal/middlewares/user_context.go
+++ b/internal/middlewares/user_context.go
@@ -307,8 +307,8 @@ func ExtractSecretariaOrgaoIDs(resolver SecretariaOrgaoResolver) gin.HandlerFunc
 
 		orgaoIDs, err := resolver(c.Request.Context(), cpf)
 		if err != nil {
-			// fail-closed: error resolving secretaria → user sees nothing
-			orgaoIDs = []string{}
+			c.Next()
+			return
 		}
 
 		c.Set(UserSecretariaOrgaoIDsKey, orgaoIDs)

--- a/internal/middlewares/vaga_auth.go
+++ b/internal/middlewares/vaga_auth.go
@@ -1,0 +1,65 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const vagaOrgaoParceiroIDsKey = "vaga_orgao_parceiro_ids"
+
+func VagaAuthorization() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if IsAdmin(c) || HasRole(c, "go:empregabilidade:admin") {
+			c.Next()
+			return
+		}
+
+		secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+		if len(secretariaIDs) > 0 {
+			c.Next()
+			return
+		}
+
+		if HasRole(c, "go:empregabilidade:editor") || HasRole(c, "go:empregabilidade:editor_sem_curadoria") {
+			if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
+				c.Next()
+				return
+			}
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para acessar este recurso"})
+		c.Abort()
+	}
+}
+
+// VagaListFilter injects orgao_parceiro_id restrictions into the context.
+// Admin and go:empregabilidade:admin see everything (no filter injected).
+// Secretaria users are restricted to their mapped orgao IDs.
+// Editor users are restricted to their single orgao ID.
+func VagaListFilter() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !IsAdmin(c) && !HasRole(c, "go:empregabilidade:admin") {
+			secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+			if secretariaIDs != nil {
+				c.Set(vagaOrgaoParceiroIDsKey, secretariaIDs)
+			} else if HasRole(c, "go:empregabilidade:editor") || HasRole(c, "go:empregabilidade:editor_sem_curadoria") {
+				if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
+					c.Set(vagaOrgaoParceiroIDsKey, []string{orgaoID})
+				}
+			}
+		}
+		c.Next()
+	}
+}
+
+// GetVagaOrgaoParceiroIDs returns the orgao_parceiro_id list injected by VagaListFilter.
+// Returns nil when no restriction applies (admin / empregabilidade:admin).
+func GetVagaOrgaoParceiroIDs(c *gin.Context) []string {
+	if v, exists := c.Get(vagaOrgaoParceiroIDsKey); exists {
+		if ids, ok := v.([]string); ok {
+			return ids
+		}
+	}
+	return nil
+}

--- a/internal/middlewares/vaga_auth_test.go
+++ b/internal/middlewares/vaga_auth_test.go
@@ -1,0 +1,206 @@
+package middlewares_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-go-api/internal/middlewares"
+	"github.com/stretchr/testify/assert"
+)
+
+func injectVagaRoles(role string, orgaoID string, secretariaIDs []string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if role != "" {
+			c.Set(middlewares.UserRolesKey, []string{role})
+		}
+		if orgaoID != "" {
+			c.Set(middlewares.UserGroupsKey, []string{"go:orgao:" + orgaoID})
+		}
+		if secretariaIDs != nil {
+			c.Set(middlewares.UserSecretariaOrgaoIDsKey, secretariaIDs)
+		}
+		c.Next()
+	}
+}
+
+func TestVagaAuthorization_Admin_Passes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserRoleKey, "ADMIN")
+		c.Next()
+	})
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVagaAuthorization_EmpAdmin_Passes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:admin", "", nil))
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVagaAuthorization_SecretariaUser_Passes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("", "", []string{"orgao-1"}))
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVagaAuthorization_Editor_WithOrgao_Passes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor", "orgao-42", nil))
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVagaAuthorization_EditorSemCuradoria_WithOrgao_Passes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor_sem_curadoria", "orgao-42", nil))
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVagaAuthorization_NoRole_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestVagaAuthorization_Editor_NoOrgao_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor", "", nil))
+	r.Use(middlewares.VagaAuthorization())
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestVagaListFilter_Admin_NoFilterInjected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserRoleKey, "ADMIN")
+		c.Next()
+	})
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"is_nil":true`)
+}
+
+func TestVagaListFilter_EmpAdmin_NoFilterInjected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:admin", "", nil))
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Contains(t, w.Body.String(), `"is_nil":true`)
+}
+
+func TestVagaListFilter_SecretariaUser_InjectsIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("", "", []string{"orgao-1", "orgao-2"}))
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"ids": ids})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Contains(t, w.Body.String(), "orgao-1")
+	assert.Contains(t, w.Body.String(), "orgao-2")
+}
+
+func TestVagaListFilter_Editor_InjectsSingleID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor", "orgao-42", nil))
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"ids": ids, "len": len(ids)})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Contains(t, w.Body.String(), "orgao-42")
+	assert.Contains(t, w.Body.String(), `"len":1`)
+}
+
+func TestVagaListFilter_EditorSemCuradoria_InjectsSingleID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor_sem_curadoria", "orgao-99", nil))
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"ids": ids})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Contains(t, w.Body.String(), "orgao-99")
+}
+
+func TestGetVagaOrgaoParceiroIDs_KeyNotSet_ReturnsNil(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Contains(t, w.Body.String(), `"is_nil":true`)
+}

--- a/internal/models/empregabilidade/vaga.go
+++ b/internal/models/empregabilidade/vaga.go
@@ -92,10 +92,16 @@ func (v *Vaga) AfterFind(_ *gorm.DB) error {
 }
 
 type VagaFilter struct {
-	Status          string
-	Contratante     string
-	OrgaoParceiroID string
-	Search          string // ILIKE em titulo
+	Status              string
+	Contratante         string
+	OrgaoParceiroID     string
+	OrgaoParceiroIDs    []string
+	Search              string
+	IDRegimeContratacao []string
+	IDModeloTrabalho    []string
+	AcessibilidadePCD   []string
+	Bairro              []string
+	DataPublicacao      DataPublicacaoRange
 }
 
 type DataPublicacaoRange string

--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -181,16 +181,6 @@ func (r *VagaRepository) List(ctx context.Context, filter empregabilidade.VagaFi
 	var total int64
 
 	applyFilters := func(db *gorm.DB) *gorm.DB {
-		if filter.Contratante != "" {
-			db = db.Where("id_contratante = ?", filter.Contratante)
-		}
-		if filter.OrgaoParceiroID != "" {
-			db = db.Where("id_orgao_parceiro = ?", filter.OrgaoParceiroID)
-		}
-		if filter.Search != "" {
-			searchTerm := fmt.Sprintf("%%%s%%", filter.Search)
-			db = db.Where("titulo ILIKE ?", searchTerm)
-		}
 		if filter.Status != "" {
 			switch filter.Status {
 			case string(empregabilidade.StatusVagaPublicadoAtivo):
@@ -200,6 +190,52 @@ func (r *VagaRepository) List(ctx context.Context, filter empregabilidade.VagaFi
 			default:
 				db = db.Where("status = ?", filter.Status)
 			}
+		}
+		if filter.Contratante != "" {
+			db = db.Where("id_contratante = ?", filter.Contratante)
+		}
+		switch {
+		case len(filter.OrgaoParceiroIDs) == 1:
+			db = db.Where("id_orgao_parceiro = ?", filter.OrgaoParceiroIDs[0])
+		case len(filter.OrgaoParceiroIDs) > 1:
+			db = db.Where("id_orgao_parceiro IN ?", filter.OrgaoParceiroIDs)
+		case filter.OrgaoParceiroID != "":
+			db = db.Where("id_orgao_parceiro = ?", filter.OrgaoParceiroID)
+		}
+		if filter.Search != "" {
+			db = db.Where("titulo ILIKE ?", fmt.Sprintf("%%%s%%", filter.Search))
+		}
+		switch filter.DataPublicacao {
+		case empregabilidade.DataPublicacaoHoje:
+			db = db.Where("created_at >= ?", time.Now().Truncate(24*time.Hour))
+		case empregabilidade.DataPublicacaoUltimaSemana:
+			db = db.Where("created_at >= ?", time.Now().AddDate(0, 0, -7))
+		case empregabilidade.DataPublicacaoUltimoMes:
+			db = db.Where("created_at >= ?", time.Now().AddDate(0, 0, -30))
+		}
+		if len(filter.IDRegimeContratacao) == 1 {
+			db = db.Where("id_regime_contratacao = ?", filter.IDRegimeContratacao[0])
+		} else if len(filter.IDRegimeContratacao) > 1 {
+			db = db.Where("id_regime_contratacao IN ?", filter.IDRegimeContratacao)
+		}
+		if len(filter.IDModeloTrabalho) == 1 {
+			db = db.Where("id_modelo_trabalho = ?", filter.IDModeloTrabalho[0])
+		} else if len(filter.IDModeloTrabalho) > 1 {
+			db = db.Where("id_modelo_trabalho IN ?", filter.IDModeloTrabalho)
+		}
+		if len(filter.AcessibilidadePCD) == 1 {
+			db = db.Where("acessibilidade_pcd = ?", filter.AcessibilidadePCD[0])
+		} else if len(filter.AcessibilidadePCD) > 1 {
+			db = db.Where("acessibilidade_pcd IN ?", filter.AcessibilidadePCD)
+		}
+		if len(filter.Bairro) > 0 {
+			conditions := make([]string, len(filter.Bairro))
+			args := make([]interface{}, len(filter.Bairro))
+			for i, b := range filter.Bairro {
+				conditions[i] = "bairro ILIKE ?"
+				args[i] = "%" + b + "%"
+			}
+			db = db.Where(strings.Join(conditions, " OR "), args...)
 		}
 		return db
 	}

--- a/internal/router/routes_core.go
+++ b/internal/router/routes_core.go
@@ -40,7 +40,6 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 	courseAuth := middlewares.CourseAuthorization()
 
 	courses := apiV1.Group("/courses")
-	courses.Use()
 	{
 		courses.POST("", courseAuth, middlewares.CourseOrgaoInjector(), app.CourseHandler.Create)
 		courses.POST("/draft", courseAuth, middlewares.CourseOrgaoInjector(), app.CourseHandler.CreateDraft)

--- a/internal/router/routes_core.go
+++ b/internal/router/routes_core.go
@@ -1,7 +1,10 @@
 package router
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-go-api/internal/middlewares"
 	"github.com/prefeitura-rio/app-go-api/internal/wire"
 )
 
@@ -14,7 +17,6 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 	registerLookup(apiV1.Group("/escolaridades"), app.EscolaridadeHandler)
 	registerLookup(apiV1.Group("/instituicoes"), app.InstituicaoHandler)
 
-	// Typesense (optional - only when configured)
 	if app.TypesenseHandler != nil {
 		apiV1.POST("/typesense/multi-search", app.TypesenseHandler.SearchMultiCollection)
 		apiV1.POST("/typesense/cursos/search", app.TypesenseHandler.SearchCursos)
@@ -22,29 +24,45 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 		apiV1.Group("/typesense/collections").POST("/:collection/documents/search", app.TypesenseHandler.SearchDocuments)
 	}
 
+	cursoLoader := func(ctx context.Context, id int) (orgaoID string, found bool, err error) {
+		curso, err := app.CursoService.GetByID(ctx, id)
+		if err != nil {
+			return "", false, err
+		}
+		if curso == nil {
+			return "", false, nil
+		}
+		return curso.OrgaoID, true, nil
+	}
+
+	ownershipCheck := middlewares.CourseOwnershipCheck(cursoLoader)
+
+	courseAuth := middlewares.CourseAuthorization()
+
 	courses := apiV1.Group("/courses")
+	courses.Use()
 	{
-		courses.POST("", app.CourseHandler.Create)
-		courses.POST("/draft", app.CourseHandler.CreateDraft)
-		courses.PUT("/:courseId", app.CourseHandler.Update)
-		courses.GET("", app.CourseHandler.List)
-		courses.GET("/drafts", app.CourseHandler.ListDrafts)
+		courses.POST("", courseAuth, middlewares.CourseOrgaoInjector(), app.CourseHandler.Create)
+		courses.POST("/draft", courseAuth, middlewares.CourseOrgaoInjector(), app.CourseHandler.CreateDraft)
+		courses.GET("", middlewares.CourseListFilter(), app.CourseHandler.List)
+		courses.GET("/drafts", middlewares.CourseListFilter(), app.CourseHandler.ListDrafts)
 		courses.GET("/:courseId", app.CourseHandler.GetByID)
-		courses.DELETE("/:courseId", app.CourseHandler.Delete)
-		courses.PUT("/:courseId/send-to-review", app.CourseHandler.SendToReview)
-		courses.PUT("/:courseId/approve", app.CourseHandler.Approve)
-		courses.PUT("/:courseId/request-changes", app.CourseHandler.RequestChanges)
-		courses.PUT("/:courseId/request-deletion", app.CourseHandler.RequestDeletion)
-		courses.POST("/:courseId/enrollments", app.InscricaoHandler.Create)
-		courses.POST("/:courseId/enrollments/manual", app.InscricaoHandler.CreateManual)
-		courses.POST("/:courseId/enrollments/import", app.InscricaoHandler.Import)
-		courses.GET("/:courseId/enrollments", app.InscricaoHandler.List)
-		courses.PUT("/:courseId/enrollments/status", app.InscricaoHandler.UpdateStatus)
-		courses.PUT("/:courseId/enrollments/:enrollmentId", app.InscricaoHandler.Update)
-		courses.PUT("/:courseId/enrollments/:enrollmentId/status", app.InscricaoHandler.UpdateIndividualStatus)
-		courses.GET("/:courseId/enrollments/:enrollmentId", app.InscricaoHandler.GetByID)
-		courses.PUT("/:courseId/enrollments/:enrollmentId/certificate", app.InscricaoHandler.UpdateCertificate)
-		courses.DELETE("/:courseId/enrollments/:enrollmentId", app.InscricaoHandler.Delete)
+		courses.DELETE("/:courseId", courseAuth, ownershipCheck, app.CourseHandler.Delete)
+		courses.PUT("/:courseId", courseAuth, ownershipCheck, app.CourseHandler.Update)
+		courses.PUT("/:courseId/send-to-review", courseAuth, ownershipCheck, app.CourseHandler.SendToReview)
+		courses.PUT("/:courseId/approve", courseAuth, ownershipCheck, app.CourseHandler.Approve)
+		courses.PUT("/:courseId/request-changes", courseAuth, ownershipCheck, app.CourseHandler.RequestChanges)
+		courses.PUT("/:courseId/request-deletion", courseAuth, ownershipCheck, app.CourseHandler.RequestDeletion)
+		courses.POST("/:courseId/enrollments", courseAuth, ownershipCheck, app.InscricaoHandler.Create)
+		courses.POST("/:courseId/enrollments/manual", courseAuth, ownershipCheck, app.InscricaoHandler.CreateManual)
+		courses.POST("/:courseId/enrollments/import", courseAuth, ownershipCheck, app.InscricaoHandler.Import)
+		courses.GET("/:courseId/enrollments", ownershipCheck, app.InscricaoHandler.List)
+		courses.PUT("/:courseId/enrollments/status", courseAuth, ownershipCheck, app.InscricaoHandler.UpdateStatus)
+		courses.PUT("/:courseId/enrollments/:enrollmentId", courseAuth, ownershipCheck, app.InscricaoHandler.Update)
+		courses.PUT("/:courseId/enrollments/:enrollmentId/status", courseAuth, ownershipCheck, app.InscricaoHandler.UpdateIndividualStatus)
+		courses.GET("/:courseId/enrollments/:enrollmentId", ownershipCheck, app.InscricaoHandler.GetByID)
+		courses.PUT("/:courseId/enrollments/:enrollmentId/certificate", courseAuth, ownershipCheck, app.InscricaoHandler.UpdateCertificate)
+		courses.DELETE("/:courseId/enrollments/:enrollmentId", courseAuth, ownershipCheck, app.InscricaoHandler.Delete)
 	}
 
 	apiV1.Group("/jobs").GET("/:jobId/status", app.JobHandler.GetStatus)

--- a/internal/router/routes_emp.go
+++ b/internal/router/routes_emp.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/prefeitura-rio/app-go-api/internal/middlewares"
 	"github.com/prefeitura-rio/app-go-api/internal/wire"
 )
 
@@ -31,28 +32,31 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		empEmpresas.DELETE("/:cnpj", app.EmpEmpresaHandler.Delete)
 	}
 
+	vagaAuth := middlewares.VagaAuthorization()
+
 	// Vagas
 	empVagas := emp.Group("/vagas")
+	empVagas.Use()
 	{
-		empVagas.POST("", app.EmpVagaHandler.Create)
-		empVagas.POST("/draft", app.EmpVagaHandler.Create)
-		empVagas.GET("", app.EmpVagaHandler.List)
+		empVagas.POST("", vagaAuth, app.EmpVagaHandler.Create)
+		empVagas.POST("/draft", vagaAuth, app.EmpVagaHandler.Create)
+		empVagas.GET("", middlewares.VagaListFilter(), app.EmpVagaHandler.List)
 		empVagas.GET("/:id", app.EmpVagaHandler.GetByID)
-		empVagas.PUT("/:id", app.EmpVagaHandler.Update)
-		empVagas.DELETE("/:id", app.EmpVagaHandler.Delete)
-		empVagas.PUT("/:id/send-to-draft", app.EmpVagaHandler.SendToDraft)
-		empVagas.PUT("/:id/send-to-approval", app.EmpVagaHandler.SendToApproval)
-		empVagas.PUT("/:id/publish", app.EmpVagaHandler.Publish)
-		empVagas.PUT("/:id/freeze", app.EmpVagaHandler.Freeze)
-		empVagas.PUT("/:id/unfreeze", app.EmpVagaHandler.Unfreeze)
-		empVagas.PUT("/:id/discontinue", app.EmpVagaHandler.Discontinue)
-		empVagas.PUT("/:id/reactivate", app.EmpVagaHandler.Reactivate)
-		empVagas.PUT("/:id/tipos-pcd", app.EmpVagaHandler.UpdateTiposPCD)
-		empVagas.POST("/:id/etapas", app.EmpEtapaHandler.Create)
+		empVagas.PUT("/:id", vagaAuth, app.EmpVagaHandler.Update)
+		empVagas.DELETE("/:id", vagaAuth, app.EmpVagaHandler.Delete)
+		empVagas.PUT("/:id/send-to-draft", vagaAuth, app.EmpVagaHandler.SendToDraft)
+		empVagas.PUT("/:id/send-to-approval", vagaAuth, app.EmpVagaHandler.SendToApproval)
+		empVagas.PUT("/:id/publish", vagaAuth, app.EmpVagaHandler.Publish)
+		empVagas.PUT("/:id/freeze", vagaAuth, app.EmpVagaHandler.Freeze)
+		empVagas.PUT("/:id/unfreeze", vagaAuth, app.EmpVagaHandler.Unfreeze)
+		empVagas.PUT("/:id/discontinue", vagaAuth, app.EmpVagaHandler.Discontinue)
+		empVagas.PUT("/:id/reactivate", vagaAuth, app.EmpVagaHandler.Reactivate)
+		empVagas.PUT("/:id/tipos-pcd", vagaAuth, app.EmpVagaHandler.UpdateTiposPCD)
+		empVagas.POST("/:id/etapas", vagaAuth, app.EmpEtapaHandler.Create)
 		empVagas.GET("/:id/etapas", app.EmpEtapaHandler.ListByVaga)
 		empVagas.GET("/:id/etapas/:etapaId", app.EmpEtapaHandler.GetByID)
-		empVagas.PUT("/:id/etapas/:etapaId", app.EmpEtapaHandler.Update)
-		empVagas.DELETE("/:id/etapas/:etapaId", app.EmpEtapaHandler.Delete)
+		empVagas.PUT("/:id/etapas/:etapaId", vagaAuth, app.EmpEtapaHandler.Update)
+		empVagas.DELETE("/:id/etapas/:etapaId", vagaAuth, app.EmpEtapaHandler.Delete)
 	}
 
 	// Candidaturas

--- a/internal/router/routes_emp.go
+++ b/internal/router/routes_emp.go
@@ -36,7 +36,6 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 
 	// Vagas
 	empVagas := emp.Group("/vagas")
-	empVagas.Use()
 	{
 		empVagas.POST("", vagaAuth, app.EmpVagaHandler.Create)
 		empVagas.POST("/draft", vagaAuth, app.EmpVagaHandler.Create)


### PR DESCRIPTION
# filtro por secretaria, normalização de params e middleware de auth em rotas privadas

Este PR refatora profundamente a camada de autorização e filtragem para os 
recursos CURSOS e VAGAS, centralizando a lógica em middlewares dedicados e 
padronizando o comportamento entre rotas públicas e privadas.

## O QUE MUDOU

- Novos middlewares (course_auth.go, vaga_auth.go):
  * CourseAuthorization / VagaAuthorization – validam permissão de acesso ao recurso.
  * CourseListFilter / VagaListFilter – injetam filtros de órgão (ou "_no_results") 
    para listagens.
  * CourseOrgaoInjector – injeta a lista de órgãos permitidos para criação.
  * CourseOwnershipCheck – carrega o curso e verifica se o usuário tem permissão 
    para acessá-lo (usado em PUT/DELETE).

- Handlers (course_handler.go):
  * Create e CreateDraft agora VALIDAM o orgao_id recebido contra a lista de órgãos 
    permitidos (GetUserAllowedOrgaos).
    -> Antes, o sistema forçava o PRIMEIRO órgão da lista; agora EXIGE que o 
       cliente envie um orgao_id e que ele pertença ao usuário.
    -> Isso pode quebrar clientes que não enviavam orgao_id na criação.
  * List e ListDrafts agora consomem os filtros injetados pelo middleware; se o 
    middleware inserir "_no_results", o handler retorna lista vazia imediatamente.
  * Update, Delete, SendToReview, etc. REMOVERAM a verificação de ownership que 
    estava no handler – agora ela é feita exclusivamente pelo middleware 
    CourseOwnershipCheck.
  * Novos métodos ListPublic e GetByIDPublic para atender rotas públicas (sem 
    autenticação).

- Rotas (routes_core.go, routes_emp.go):
  * Aplicação explícita dos middlewares nas rotas protegidas (v1).
  * Rotas públicas (apiPublic) passam a usar os mesmos handlers (ex.: ListPublic 
    chama List), mas sem os middlewares de autorização.

- Testes:
  * Testes de unidade dos handlers foram ajustados para remover verificações de 
    autorização que agora são responsabilidade dos middlewares.
  * Novos testes para os middlewares (course_auth_test.go, vaga_auth_test.go).

## 2. IMPACTOS E RISCOS

2.1. ALTA PRIORIDADE – QUEBRA DE COMPATIBILIDADE

- Criação de cursos:
  * Antes: o sistema ignorava o orgao_id enviado e usava o primeiro da lista do 
    usuário (ou o do grupo Keycloak).
  * Agora: o campo orgao_id é OBRIGATÓRIO no payload e será validado contra a 
    lista de órgãos permitidos.
  * Clientes que não enviarem orgao_id receberão 400 Bad Request.
  * Clientes que enviarem um orgao_id não autorizado receberão 403 Forbidden.

- Listagem de cursos (v1):
  * Usuários sem nenhum órgão (ex.: editor sem grupo) agora recebem LISTA VAZIA 
    (via "_no_results").
  * Antes, se não houvesse filtro, viam TODOS os cursos.
  * Isso alinha o comportamento com a política de "sem permissão = sem dados".

- Atualização/Exclusão de cursos:
  * A verificação de ownership agora é feita ANTES do handler, via middleware 
    CourseOwnershipCheck.
  * Qualquer erro no loader (ex.: curso não encontrado) retorna 404; se o usuário 
    não tiver permissão, retorna 403.
  * O handler não precisa mais chamar GetByID para validar ownership – isso é 
    feito pelo middleware.
  * RISCO: se o loader não estiver configurado corretamente (ex.: não passar o 
    cursoLoader nas rotas), a autorização será PULADA. No código atual, as rotas 
    usam ownershipCheck corretamente.

- Rotas públicas:
  * Foram criados endpoints /api/public/courses e /api/public/courses/{courseId} 
    que NÃO usam middlewares de autenticação.
  * Os handlers ListPublic e GetByIDPublic são apenas wrappers que chamam os 
    métodos originais.
  * A documentação Swagger foi atualizada para incluir essas rotas.

## COMO TESTAR

- Criação de curso (v1):
  * Envie POST /api/v1/courses com um JSON contendo orgao_id válido para o usuário.
  * Verifique que o curso é criado com o órgão informado.
  * Tente enviar orgao_id de outro órgão – deve retornar 403.
  * Tente não enviar orgao_id – deve retornar 400.

- Listagem de cursos (v1):
  * Logado como usuário com secretarias – a lista deve conter apenas cursos 
    daquelas secretarias.
  * Logado como usuário sem secretarias – a lista deve estar vazia.
  * Logado como admin – deve ver todos os cursos (nenhum filtro injetado).

- Atualização/Exclusão:
  * Tente editar um curso de outro órgão – deve retornar 403.
  * Tente editar um curso inexistente – 404.

- Rotas públicas:
  * Acesse /api/public/courses sem autenticação – deve retornar cursos publicados 
    (exceto rascunhos).
  * Acesse /api/public/courses/{id} – deve retornar o curso, se existir.

- Vagas:
  * Teste os novos filtros (CSV, data_publicacao) e a injeção de órgão via 
    middleware.

## OBSERVAÇÃO FINAL

Este PR remove uma quantidade significativa de lógica de autorização que estava espalhada nos handlers, centralizando-a. Isso aumenta a coesão e facilita manutenção, mas exige atenção redobrada para garantir que nenhum endpoint tenha ficado desprotegido. Recomenda-se uma revisão minuciosa das rotas e um ciclo completo de testes manuais em ambiente de homologação antes do deploy em produção.