### PR TITLE
feat(empregabilidade): restringe listagem e criação de vagas por secretaria

### DIFF
--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -13,6 +13,15 @@ import (
 	"github.com/prefeitura-rio/app-go-api/internal/utils"
 )
 
+func containsString(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
 func isPublishedStatus(status empregabilidade.StatusVaga) bool {
 	switch status {
 	case empregabilidade.StatusVagaPublicadoAtivo,
@@ -90,6 +99,12 @@ func (h *VagaHandler) Create(c *gin.Context) {
 		return
 	}
 
+	allowedOrgaos := middlewares.GetVagaAllowedOrgaos(c)
+	if allowedOrgaos != nil && !containsString(allowedOrgaos, entity.IDOrgaoParceiro) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Você não tem permissão para criar vagas neste órgão parceiro"})
+		return
+	}
+
 	id, err := h.service.Create(c.Request.Context(), &entity)
 	if err != nil {
 		handleVagaError(c, err)
@@ -145,6 +160,14 @@ func (h *VagaHandler) List(c *gin.Context) {
 	}
 
 	orgaoParceiroIDs := middlewares.GetVagaOrgaoParceiroIDs(c)
+
+	if orgaoParceiroIDs != nil && len(orgaoParceiroIDs) == 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"data": []*empregabilidade.Vaga{},
+			"meta": gin.H{"page": page, "page_size": pageSize, "total": 0},
+		})
+		return
+	}
 
 	filter := empregabilidade.VagaFilter{
 		Status:              c.Query("status"),

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -1731,5 +1732,95 @@ func TestVagaHandler_List_OrgaoParceiroID_FallsBackToQueryParam(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func setupVagaRouterWithAllowedOrgaos(vagaRepo services.VagaRepoInterface, empresaRepo services.EmpresaRepoInterface, allowedOrgaos []string) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if allowedOrgaos != nil {
+			c.Set("vaga_allowed_orgaos", allowedOrgaos)
+		}
+		c.Next()
+	})
+	candidaturaRepo := &mockCandidaturaRepoForVaga{}
+	svc := services.NewVagaServiceWithInterfaces(vagaRepo, empresaRepo, candidaturaRepo)
+	h := handlers.NewVagaHandler(svc)
+	r.POST("/vagas", h.Create)
+	return r
+}
+
+func TestVagaHandler_Create_SecretariaUser_AllowedOrgao_Success(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{entity: &empmodels.Empresa{CNPJ: "12345678000100"}}
+	r := setupVagaRouterWithAllowedOrgaos(vagaRepo, empresaRepo, []string{"orgao-1", "orgao-2"})
+
+	body := bodyOf(`{"titulo":"Dev Backend","id_orgao_parceiro":"orgao-1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/vagas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_Create_SecretariaUser_ForbiddenOrgao_Forbidden(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{entity: &empmodels.Empresa{CNPJ: "12345678000100"}}
+	r := setupVagaRouterWithAllowedOrgaos(vagaRepo, empresaRepo, []string{"orgao-1", "orgao-2"})
+
+	body := bodyOf(`{"titulo":"Dev Backend","id_orgao_parceiro":"orgao-99"}`)
+	req := httptest.NewRequest(http.MethodPost, "/vagas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_Create_Admin_NoRestriction_Success(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{entity: &empmodels.Empresa{CNPJ: "12345678000100"}}
+	r := setupVagaRouterWithAllowedOrgaos(vagaRepo, empresaRepo, nil)
+
+	body := bodyOf(`{"titulo":"Dev Backend","id_orgao_parceiro":"any-orgao"}`)
+	req := httptest.NewRequest(http.MethodPost, "/vagas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_List_EmptyOrgaoParceiroIDs_ReturnsEmpty(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{
+		listItems: []*empmodels.Vaga{{Titulo: "Dev Go"}},
+		listTotal: 1,
+	}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("vaga_orgao_parceiro_ids", []string{})
+		c.Next()
+	})
+	candidaturaRepo := &mockCandidaturaRepoForVaga{}
+	svc := services.NewVagaServiceWithInterfaces(vagaRepo, &mockEmpresaRepoForVaga{}, candidaturaRepo)
+	h := handlers.NewVagaHandler(svc)
+	r.GET("/vagas", h.List)
+
+	req := httptest.NewRequest(http.MethodGet, "/vagas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"total":0`) {
+		t.Errorf("expected total=0, got: %s", w.Body.String())
 	}
 }

--- a/internal/middlewares/vaga_auth.go
+++ b/internal/middlewares/vaga_auth.go
@@ -6,7 +6,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-const vagaOrgaoParceiroIDsKey = "vaga_orgao_parceiro_ids"
+const (
+	vagaOrgaoParceiroIDsKey  = "vaga_orgao_parceiro_ids"
+	vagaAllowedOrgaosKey     = "vaga_allowed_orgaos"
+)
 
 func VagaAuthorization() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -46,7 +49,11 @@ func VagaListFilter() gin.HandlerFunc {
 			} else if HasRole(c, "go:empregabilidade:editor") || HasRole(c, "go:empregabilidade:editor_sem_curadoria") {
 				if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
 					c.Set(vagaOrgaoParceiroIDsKey, []string{orgaoID})
+				} else {
+					c.Set(vagaOrgaoParceiroIDsKey, []string{})
 				}
+			} else {
+				c.Set(vagaOrgaoParceiroIDsKey, []string{})
 			}
 		}
 		c.Next()
@@ -57,6 +64,54 @@ func VagaListFilter() gin.HandlerFunc {
 // Returns nil when no restriction applies (admin / empregabilidade:admin).
 func GetVagaOrgaoParceiroIDs(c *gin.Context) []string {
 	if v, exists := c.Get(vagaOrgaoParceiroIDsKey); exists {
+		if ids, ok := v.([]string); ok {
+			return ids
+		}
+	}
+	return nil
+}
+
+// VagaOrgaoInjector injects allowed orgao IDs into the context for write operations (POST).
+// Admin and go:empregabilidade:admin bypass all restrictions (nil injected = unrestricted).
+// Secretaria users are restricted to their mapped orgao IDs (injected into context).
+// Editor/editor_sem_curadoria users are restricted to their single orgao ID.
+// Anyone else is denied with 403.
+func VagaOrgaoInjector() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if IsAdmin(c) || HasRole(c, "go:empregabilidade:admin") {
+			c.Next()
+			return
+		}
+
+		secretariaIDs := GetUserSecretariaOrgaoIDs(c)
+		if secretariaIDs != nil {
+			if len(secretariaIDs) == 0 {
+				c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: nenhuma secretaria associada"})
+				c.Abort()
+				return
+			}
+			c.Set(vagaAllowedOrgaosKey, secretariaIDs)
+			c.Next()
+			return
+		}
+
+		if HasRole(c, "go:empregabilidade:editor") || HasRole(c, "go:empregabilidade:editor_sem_curadoria") {
+			if orgaoID := GetUserOrgaoID(c); orgaoID != "" {
+				c.Set(vagaAllowedOrgaosKey, []string{orgaoID})
+				c.Next()
+				return
+			}
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para criar: órgão não identificado"})
+		c.Abort()
+	}
+}
+
+// GetVagaAllowedOrgaos returns the allowed orgao IDs injected by VagaOrgaoInjector.
+// Returns nil when no restriction applies (admin / empregabilidade:admin).
+func GetVagaAllowedOrgaos(c *gin.Context) []string {
+	if v, exists := c.Get(vagaAllowedOrgaosKey); exists {
 		if ids, ok := v.([]string); ok {
 			return ids
 		}

--- a/internal/middlewares/vaga_auth_test.go
+++ b/internal/middlewares/vaga_auth_test.go
@@ -204,3 +204,169 @@ func TestGetVagaOrgaoParceiroIDs_KeyNotSet_ReturnsNil(t *testing.T) {
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
 	assert.Contains(t, w.Body.String(), `"is_nil":true`)
 }
+
+func TestVagaOrgaoInjector_Admin_NoRestriction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserRoleKey, "ADMIN")
+		c.Next()
+	})
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"is_nil":true`)
+}
+
+func TestVagaOrgaoInjector_EmpAdmin_NoRestriction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:admin", "", nil))
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"is_nil":true`)
+}
+
+func TestVagaOrgaoInjector_SecretariaUser_InjectsIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("", "", []string{"orgao-1", "orgao-2"}))
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"ids": ids})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "orgao-1")
+	assert.Contains(t, w.Body.String(), "orgao-2")
+}
+
+func TestVagaOrgaoInjector_SecretariaUser_EmptyList_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("", "", []string{}))
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestVagaOrgaoInjector_Editor_InjectsSingleID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor", "orgao-42", nil))
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"ids": ids, "len": len(ids)})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "orgao-42")
+	assert.Contains(t, w.Body.String(), `"len":1`)
+}
+
+func TestVagaOrgaoInjector_EditorSemCuradoria_InjectsSingleID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor_sem_curadoria", "orgao-99", nil))
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"ids": ids})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "orgao-99")
+}
+
+func TestVagaOrgaoInjector_Editor_NoOrgao_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor", "", nil))
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestVagaOrgaoInjector_NoRole_Forbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middlewares.VagaOrgaoInjector())
+	r.POST("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/test", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestGetVagaAllowedOrgaos_KeyNotSet_ReturnsNil(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaAllowedOrgaos(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Contains(t, w.Body.String(), `"is_nil":true`)
+}
+
+func TestVagaListFilter_NoRole_InjectsEmptySlice(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil, "len": len(ids)})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"is_nil":false`)
+	assert.Contains(t, w.Body.String(), `"len":0`)
+}
+
+func TestVagaListFilter_Editor_NoOrgao_InjectsEmptySlice(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectVagaRoles("go:empregabilidade:editor", "", nil))
+	r.Use(middlewares.VagaListFilter())
+	r.GET("/test", func(c *gin.Context) {
+		ids := middlewares.GetVagaOrgaoParceiroIDs(c)
+		c.JSON(http.StatusOK, gin.H{"is_nil": ids == nil, "len": len(ids)})
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"is_nil":false`)
+	assert.Contains(t, w.Body.String(), `"len":0`)
+}

--- a/internal/router/routes_emp.go
+++ b/internal/router/routes_emp.go
@@ -37,9 +37,9 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 	// Vagas
 	empVagas := emp.Group("/vagas")
 	{
-		empVagas.POST("", vagaAuth, app.EmpVagaHandler.Create)
-		empVagas.POST("/draft", vagaAuth, app.EmpVagaHandler.Create)
-		empVagas.GET("", middlewares.VagaListFilter(), app.EmpVagaHandler.List)
+		empVagas.POST("", vagaAuth, middlewares.VagaOrgaoInjector(), app.EmpVagaHandler.Create)
+		empVagas.POST("/draft", vagaAuth, middlewares.VagaOrgaoInjector(), app.EmpVagaHandler.Create)
+		empVagas.GET("", vagaAuth, middlewares.VagaListFilter(), app.EmpVagaHandler.List)
 		empVagas.GET("/:id", app.EmpVagaHandler.GetByID)
 		empVagas.PUT("/:id", vagaAuth, app.EmpVagaHandler.Update)
 		empVagas.DELETE("/:id", vagaAuth, app.EmpVagaHandler.Delete)


### PR DESCRIPTION
## O que muda

Corrige falha de autorização no módulo de empregabilidade: a listagem e criação de vagas em `/api/v1/empregabilidade/vagas` não aplicava filtro por secretaria, permitindo que qualquer usuário autenticado visualizasse e criasse vagas em órgãos fora do seu acesso.

## Mudanças

**`internal/middlewares/vaga_auth.go`**
- Novo `VagaOrgaoInjector()`: injeta os órgãos permitidos no contexto para operações de escrita; bloqueia com 403 se o usuário não tiver mapeamento de secretaria ou orgao_id
- Novo `GetVagaAllowedOrgaos()`: getter do contexto para o handler de criação
- `VagaListFilter()` corrigido: passa a injetar `[]string{}` para usuários sem role reconhecido (antes não injetava nada, deixando a query sem filtro)

**`internal/router/routes_emp.go`**
- `GET /vagas`: adicionado `VagaAuthorization()` antes de `VagaListFilter()` — rota estava aberta
- `POST /vagas` e `POST /vagas/draft`: adicionado `VagaOrgaoInjector()` na chain

**`internal/handlers/v1/empregabilidade/vaga_handler.go`**
- `Create()`: valida `IDOrgaoParceiro` da vaga contra os órgãos permitidos da secretaria do usuário
- `List()`: retorna 200 com lista vazia imediatamente quando o filtro de órgãos está ativo mas vazio

## Rotas públicas

Nenhuma alteração nas rotas `/api/public/empregabilidade/vagas` — continuam sem middleware de autenticação.

## Matriz de comportamento

| Usuário | `GET /vagas` | `POST /vagas` |
|---|---|---|
| Admin / `empregabilidade:admin` | Vê tudo | Cria em qualquer órgão |
| Secretaria | Filtrado pelos órgãos da secretaria | Restrito aos órgãos da secretaria |
| Editor (com orgao_id) | Filtrado pelo seu órgão | Restrito ao seu órgão |
| Sem role / não autorizado | 403 | 403 |

## Testes

- 11 novos testes em `vaga_auth_test.go` cobrindo todos os branches de `VagaOrgaoInjector` e `VagaListFilter`
- 4 novos testes em `vaga_handler_test.go`: criação com órgão permitido, criação com órgão proibido, admin sem restrição, listagem com filtro vazio retorna zero resultados
