### PR TITLE
fix: rota do RMI consertada para chamar o endpoint correto

### DIFF
--- a/internal/clients/rmi_client.go
+++ b/internal/clients/rmi_client.go
@@ -382,7 +382,7 @@ func (c *RMIClient) GetCPFSecretarias(ctx context.Context, serviceToken string, 
 		return nil, fmt.Errorf("RMI base URL not configured")
 	}
 
-	url := fmt.Sprintf("%s/cpf-secretaria/%s", c.baseURL, cpf)
+	url := fmt.Sprintf("%s/v1/cpf-secretaria/%s", c.baseURL, cpf)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
A rota a ser chamada no RMI não possuía o prefixo ```/v1```, acarretando em chamadas para o endpoint incorreto. Este fix altera isso para que o endpoint correto seja chamado.