### PR TITLE
feat(empregabilidade): critérios de elegibilidade configuráveis para vagas

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1999,6 +1999,121 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/empregabilidade/candidatura-bloqueios": {
+            "get": {
+                "description": "Retorna lista paginada de bloqueios de candidatura, com filtros opcionais. Restrito a administradores.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-candidatura-bloqueios"
+                ],
+                "summary": "Listar bloqueios de candidatura (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Número da página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Tamanho da página (default: 10)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por CPF",
+                        "name": "cpf",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por ID da vaga",
+                        "name": "id_vaga",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Registra a tentativa de candidatura de um CPF a uma vaga que foi bloqueada por não atender critérios de elegibilidade",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-candidatura-bloqueios"
+                ],
+                "summary": "Registrar bloqueio de candidatura",
+                "parameters": [
+                    {
+                        "description": "Dados do bloqueio",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.CandidaturaBloqueio"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.CandidaturaBloqueio"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/empregabilidade/candidaturas": {
             "get": {
                 "description": "Retorna lista paginada de candidaturas com filtros e busca universal. Restrito a administradores.",
@@ -8359,6 +8474,68 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/empregabilidade/vagas/{id}/idiomas-requisito": {
+            "put": {
+                "description": "Atualiza os idiomas e níveis mínimos exigidos como critério de elegibilidade da vaga",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-vagas"
+                ],
+                "summary": "Atualizar requisitos de idioma da vaga",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da vaga",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Requisitos de idioma",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.UpdateIdiomasRequisitoRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/empregabilidade/vagas/{id}/publish": {
             "put": {
                 "description": "Publica uma vaga em edição",
@@ -8742,6 +8919,316 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/empregabilidade/vagas/{id}/zonas": {
+            "put": {
+                "description": "Atualiza as zonas geográficas de elegibilidade da vaga",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-vagas"
+                ],
+                "summary": "Atualizar zonas de elegibilidade da vaga",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da vaga",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "IDs das zonas",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.UpdateZonasRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/empregabilidade/zonas": {
+            "get": {
+                "description": "Retorna uma lista paginada de zonas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Listar zonas",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Número da página",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Tamanho da página",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Cria uma nova zona",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Criar zona",
+                "parameters": [
+                    {
+                        "description": "Dados da zona",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/empregabilidade/zonas/{id}": {
+            "get": {
+                "description": "Retorna uma zona específica",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Buscar zona por ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da zona",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Atualiza uma zona existente",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Atualizar zona",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da zona",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Dados da zona",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Remove uma zona",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Excluir zona",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da zona",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -10639,6 +11126,29 @@ const docTemplate = `{
                 }
             }
         },
+        "empregabilidade.CandidaturaBloqueio": {
+            "type": "object",
+            "properties": {
+                "cpf": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "criterios_nao_atendidos": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "id_vaga": {
+                    "type": "string"
+                }
+            }
+        },
         "empregabilidade.CurriculoCompleto": {
             "type": "object",
             "properties": {
@@ -10950,6 +11460,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "ordem": {
+                    "type": "integer"
+                },
                 "updated_at": {
                     "type": "string"
                 }
@@ -11114,6 +11627,9 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                },
+                "ordem": {
+                    "type": "integer"
                 },
                 "updated_at": {
                     "type": "string"
@@ -11294,6 +11810,17 @@ const docTemplate = `{
                 }
             }
         },
+        "empregabilidade.UpdateIdiomasRequisitoRequest": {
+            "type": "object",
+            "properties": {
+                "requisitos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/empregabilidade.VagaIdiomaRequisito"
+                    }
+                }
+            }
+        },
         "empregabilidade.UpdateStatusRequest": {
             "type": "object",
             "properties": {
@@ -11313,14 +11840,37 @@ const docTemplate = `{
                 }
             }
         },
+        "empregabilidade.UpdateZonasRequest": {
+            "type": "object",
+            "properties": {
+                "zona_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "empregabilidade.Vaga": {
             "type": "object",
             "properties": {
                 "acessibilidade_pcd": {
                     "$ref": "#/definitions/empregabilidade.AcessibilidadePCD"
                 },
+                "areas_formacao_elegibilidade": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "bairro": {
                     "type": "string"
+                },
+                "bairros_elegibilidade": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "beneficios": {
                     "type": "string"
@@ -11349,6 +11899,9 @@ const docTemplate = `{
                 "diferenciais": {
                     "type": "string"
                 },
+                "escolaridade_minima": {
+                    "$ref": "#/definitions/empregabilidade.Escolaridade"
+                },
                 "etapas": {
                     "type": "array",
                     "items": {
@@ -11361,6 +11914,9 @@ const docTemplate = `{
                 "id_contratante": {
                     "type": "string"
                 },
+                "id_escolaridade_minima": {
+                    "type": "string"
+                },
                 "id_modelo_trabalho": {
                     "type": "string"
                 },
@@ -11369,6 +11925,19 @@ const docTemplate = `{
                 },
                 "id_regime_contratacao": {
                     "type": "string"
+                },
+                "idade_maxima": {
+                    "type": "integer"
+                },
+                "idade_minima": {
+                    "description": "Critérios de elegibilidade",
+                    "type": "integer"
+                },
+                "idiomas_requisito": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/empregabilidade.VagaIdiomaRequisito"
+                    }
                 },
                 "informacoes_complementares": {
                     "type": "array",
@@ -11414,6 +11983,63 @@ const docTemplate = `{
                 },
                 "valor_vaga": {
                     "type": "number"
+                },
+                "zonas": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/empregabilidade.Zona"
+                    }
+                }
+            }
+        },
+        "empregabilidade.VagaIdiomaRequisito": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id_idioma": {
+                    "type": "string"
+                },
+                "id_nivel_minimo": {
+                    "type": "string"
+                },
+                "id_vaga": {
+                    "type": "string"
+                },
+                "idioma": {
+                    "$ref": "#/definitions/empregabilidade.Idioma"
+                },
+                "nivel_minimo": {
+                    "$ref": "#/definitions/empregabilidade.NivelIdioma"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "vaga": {
+                    "description": "Relationships",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/empregabilidade.Vaga"
+                        }
+                    ]
+                }
+            }
+        },
+        "empregabilidade.Zona": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "descricao": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1997,6 +1997,121 @@
                 }
             }
         },
+        "/api/v1/empregabilidade/candidatura-bloqueios": {
+            "get": {
+                "description": "Retorna lista paginada de bloqueios de candidatura, com filtros opcionais. Restrito a administradores.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-candidatura-bloqueios"
+                ],
+                "summary": "Listar bloqueios de candidatura (admin)",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Número da página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Tamanho da página (default: 10)",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por CPF",
+                        "name": "cpf",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtrar por ID da vaga",
+                        "name": "id_vaga",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Registra a tentativa de candidatura de um CPF a uma vaga que foi bloqueada por não atender critérios de elegibilidade",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-candidatura-bloqueios"
+                ],
+                "summary": "Registrar bloqueio de candidatura",
+                "parameters": [
+                    {
+                        "description": "Dados do bloqueio",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.CandidaturaBloqueio"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.CandidaturaBloqueio"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/empregabilidade/candidaturas": {
             "get": {
                 "description": "Retorna lista paginada de candidaturas com filtros e busca universal. Restrito a administradores.",
@@ -8357,6 +8472,68 @@
                 }
             }
         },
+        "/api/v1/empregabilidade/vagas/{id}/idiomas-requisito": {
+            "put": {
+                "description": "Atualiza os idiomas e níveis mínimos exigidos como critério de elegibilidade da vaga",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-vagas"
+                ],
+                "summary": "Atualizar requisitos de idioma da vaga",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da vaga",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Requisitos de idioma",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.UpdateIdiomasRequisitoRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/empregabilidade/vagas/{id}/publish": {
             "put": {
                 "description": "Publica uma vaga em edição",
@@ -8740,6 +8917,316 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/empregabilidade/vagas/{id}/zonas": {
+            "put": {
+                "description": "Atualiza as zonas geográficas de elegibilidade da vaga",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-vagas"
+                ],
+                "summary": "Atualizar zonas de elegibilidade da vaga",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da vaga",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "IDs das zonas",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.UpdateZonasRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/empregabilidade/zonas": {
+            "get": {
+                "description": "Retorna uma lista paginada de zonas",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Listar zonas",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Número da página",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 100,
+                        "description": "Tamanho da página",
+                        "name": "pageSize",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Cria uma nova zona",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Criar zona",
+                "parameters": [
+                    {
+                        "description": "Dados da zona",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/empregabilidade/zonas/{id}": {
+            "get": {
+                "description": "Retorna uma zona específica",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Buscar zona por ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da zona",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Atualiza uma zona existente",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Atualizar zona",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da zona",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Dados da zona",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/empregabilidade.Zona"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Remove uma zona",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "empregabilidade-zonas"
+                ],
+                "summary": "Excluir zona",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID da zona",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -10637,6 +11124,29 @@
                 }
             }
         },
+        "empregabilidade.CandidaturaBloqueio": {
+            "type": "object",
+            "properties": {
+                "cpf": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "criterios_nao_atendidos": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "id_vaga": {
+                    "type": "string"
+                }
+            }
+        },
         "empregabilidade.CurriculoCompleto": {
             "type": "object",
             "properties": {
@@ -10948,6 +11458,9 @@
                 "id": {
                     "type": "string"
                 },
+                "ordem": {
+                    "type": "integer"
+                },
                 "updated_at": {
                     "type": "string"
                 }
@@ -11112,6 +11625,9 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "ordem": {
+                    "type": "integer"
                 },
                 "updated_at": {
                     "type": "string"
@@ -11292,6 +11808,17 @@
                 }
             }
         },
+        "empregabilidade.UpdateIdiomasRequisitoRequest": {
+            "type": "object",
+            "properties": {
+                "requisitos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/empregabilidade.VagaIdiomaRequisito"
+                    }
+                }
+            }
+        },
         "empregabilidade.UpdateStatusRequest": {
             "type": "object",
             "properties": {
@@ -11311,14 +11838,37 @@
                 }
             }
         },
+        "empregabilidade.UpdateZonasRequest": {
+            "type": "object",
+            "properties": {
+                "zona_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "empregabilidade.Vaga": {
             "type": "object",
             "properties": {
                 "acessibilidade_pcd": {
                     "$ref": "#/definitions/empregabilidade.AcessibilidadePCD"
                 },
+                "areas_formacao_elegibilidade": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "bairro": {
                     "type": "string"
+                },
+                "bairros_elegibilidade": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "beneficios": {
                     "type": "string"
@@ -11347,6 +11897,9 @@
                 "diferenciais": {
                     "type": "string"
                 },
+                "escolaridade_minima": {
+                    "$ref": "#/definitions/empregabilidade.Escolaridade"
+                },
                 "etapas": {
                     "type": "array",
                     "items": {
@@ -11359,6 +11912,9 @@
                 "id_contratante": {
                     "type": "string"
                 },
+                "id_escolaridade_minima": {
+                    "type": "string"
+                },
                 "id_modelo_trabalho": {
                     "type": "string"
                 },
@@ -11367,6 +11923,19 @@
                 },
                 "id_regime_contratacao": {
                     "type": "string"
+                },
+                "idade_maxima": {
+                    "type": "integer"
+                },
+                "idade_minima": {
+                    "description": "Critérios de elegibilidade",
+                    "type": "integer"
+                },
+                "idiomas_requisito": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/empregabilidade.VagaIdiomaRequisito"
+                    }
                 },
                 "informacoes_complementares": {
                     "type": "array",
@@ -11412,6 +11981,63 @@
                 },
                 "valor_vaga": {
                     "type": "number"
+                },
+                "zonas": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/empregabilidade.Zona"
+                    }
+                }
+            }
+        },
+        "empregabilidade.VagaIdiomaRequisito": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id_idioma": {
+                    "type": "string"
+                },
+                "id_nivel_minimo": {
+                    "type": "string"
+                },
+                "id_vaga": {
+                    "type": "string"
+                },
+                "idioma": {
+                    "$ref": "#/definitions/empregabilidade.Idioma"
+                },
+                "nivel_minimo": {
+                    "$ref": "#/definitions/empregabilidade.NivelIdioma"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "vaga": {
+                    "description": "Relationships",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/empregabilidade.Vaga"
+                        }
+                    ]
+                }
+            }
+        },
+        "empregabilidade.Zona": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "descricao": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,6 +74,21 @@ definitions:
         - $ref: '#/definitions/empregabilidade.Vaga'
         description: Relationships
     type: object
+  empregabilidade.CandidaturaBloqueio:
+    properties:
+      cpf:
+        type: string
+      created_at:
+        type: string
+      criterios_nao_atendidos:
+        items:
+          type: string
+        type: array
+      id:
+        type: string
+      id_vaga:
+        type: string
+    type: object
   empregabilidade.CurriculoCompleto:
     properties:
       conquistas:
@@ -273,6 +288,8 @@ definitions:
         type: string
       id:
         type: string
+      ordem:
+        type: integer
       updated_at:
         type: string
     type: object
@@ -378,6 +395,8 @@ definitions:
         type: string
       id:
         type: string
+      ordem:
+        type: integer
       updated_at:
         type: string
     type: object
@@ -504,6 +523,13 @@ definitions:
       id_etapa_atual:
         type: string
     type: object
+  empregabilidade.UpdateIdiomasRequisitoRequest:
+    properties:
+      requisitos:
+        items:
+          $ref: '#/definitions/empregabilidade.VagaIdiomaRequisito'
+        type: array
+    type: object
   empregabilidade.UpdateStatusRequest:
     properties:
       status:
@@ -516,12 +542,27 @@ definitions:
           type: string
         type: array
     type: object
+  empregabilidade.UpdateZonasRequest:
+    properties:
+      zona_ids:
+        items:
+          type: string
+        type: array
+    type: object
   empregabilidade.Vaga:
     properties:
       acessibilidade_pcd:
         $ref: '#/definitions/empregabilidade.AcessibilidadePCD'
+      areas_formacao_elegibilidade:
+        items:
+          type: string
+        type: array
       bairro:
         type: string
+      bairros_elegibilidade:
+        items:
+          type: string
+        type: array
       beneficios:
         type: string
       contratante:
@@ -539,6 +580,8 @@ definitions:
         type: string
       diferenciais:
         type: string
+      escolaridade_minima:
+        $ref: '#/definitions/empregabilidade.Escolaridade'
       etapas:
         items:
           $ref: '#/definitions/empregabilidade.Etapa'
@@ -547,12 +590,23 @@ definitions:
         type: string
       id_contratante:
         type: string
+      id_escolaridade_minima:
+        type: string
       id_modelo_trabalho:
         type: string
       id_orgao_parceiro:
         type: string
       id_regime_contratacao:
         type: string
+      idade_maxima:
+        type: integer
+      idade_minima:
+        description: Critérios de elegibilidade
+        type: integer
+      idiomas_requisito:
+        items:
+          $ref: '#/definitions/empregabilidade.VagaIdiomaRequisito'
+        type: array
       informacoes_complementares:
         items:
           $ref: '#/definitions/empregabilidade.InformacaoComplementar'
@@ -583,6 +637,42 @@ definitions:
         type: string
       valor_vaga:
         type: number
+      zonas:
+        items:
+          $ref: '#/definitions/empregabilidade.Zona'
+        type: array
+    type: object
+  empregabilidade.VagaIdiomaRequisito:
+    properties:
+      created_at:
+        type: string
+      id_idioma:
+        type: string
+      id_nivel_minimo:
+        type: string
+      id_vaga:
+        type: string
+      idioma:
+        $ref: '#/definitions/empregabilidade.Idioma'
+      nivel_minimo:
+        $ref: '#/definitions/empregabilidade.NivelIdioma'
+      updated_at:
+        type: string
+      vaga:
+        allOf:
+        - $ref: '#/definitions/empregabilidade.Vaga'
+        description: Relationships
+    type: object
+  empregabilidade.Zona:
+    properties:
+      created_at:
+        type: string
+      descricao:
+        type: string
+      id:
+        type: string
+      updated_at:
+        type: string
     type: object
   models.Acessibilidade:
     properties:
@@ -2895,6 +2985,84 @@ paths:
       summary: Listar cursos rascunho
       tags:
       - courses
+  /api/v1/empregabilidade/candidatura-bloqueios:
+    get:
+      description: Retorna lista paginada de bloqueios de candidatura, com filtros
+        opcionais. Restrito a administradores.
+      parameters:
+      - description: 'Número da página (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Tamanho da página (default: 10)'
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filtrar por CPF
+        in: query
+        name: cpf
+        type: string
+      - description: Filtrar por ID da vaga
+        in: query
+        name: id_vaga
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Listar bloqueios de candidatura (admin)
+      tags:
+      - empregabilidade-candidatura-bloqueios
+    post:
+      consumes:
+      - application/json
+      description: Registra a tentativa de candidatura de um CPF a uma vaga que foi
+        bloqueada por não atender critérios de elegibilidade
+      parameters:
+      - description: Dados do bloqueio
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/empregabilidade.CandidaturaBloqueio'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/empregabilidade.CandidaturaBloqueio'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Registrar bloqueio de candidatura
+      tags:
+      - empregabilidade-candidatura-bloqueios
   /api/v1/empregabilidade/candidaturas:
     get:
       description: Retorna lista paginada de candidaturas com filtros e busca universal.
@@ -7097,6 +7265,48 @@ paths:
       summary: Congelar vaga
       tags:
       - empregabilidade-vagas
+  /api/v1/empregabilidade/vagas/{id}/idiomas-requisito:
+    put:
+      consumes:
+      - application/json
+      description: Atualiza os idiomas e níveis mínimos exigidos como critério de
+        elegibilidade da vaga
+      parameters:
+      - description: ID da vaga
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Requisitos de idioma
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/empregabilidade.UpdateIdiomasRequisitoRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Atualizar requisitos de idioma da vaga
+      tags:
+      - empregabilidade-vagas
   /api/v1/empregabilidade/vagas/{id}/publish:
     put:
       description: Publica uma vaga em edição
@@ -7365,6 +7575,47 @@ paths:
       summary: Descongelar vaga
       tags:
       - empregabilidade-vagas
+  /api/v1/empregabilidade/vagas/{id}/zonas:
+    put:
+      consumes:
+      - application/json
+      description: Atualiza as zonas geográficas de elegibilidade da vaga
+      parameters:
+      - description: ID da vaga
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: IDs das zonas
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/empregabilidade.UpdateZonasRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Atualizar zonas de elegibilidade da vaga
+      tags:
+      - empregabilidade-vagas
   /api/v1/empregabilidade/vagas/draft:
     post:
       consumes:
@@ -7399,6 +7650,171 @@ paths:
       summary: Criar vaga
       tags:
       - empregabilidade-vagas
+  /api/v1/empregabilidade/zonas:
+    get:
+      description: Retorna uma lista paginada de zonas
+      parameters:
+      - default: 1
+        description: Número da página
+        in: query
+        name: page
+        type: integer
+      - default: 100
+        description: Tamanho da página
+        in: query
+        name: pageSize
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Listar zonas
+      tags:
+      - empregabilidade-zonas
+    post:
+      consumes:
+      - application/json
+      description: Cria uma nova zona
+      parameters:
+      - description: Dados da zona
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/empregabilidade.Zona'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/empregabilidade.Zona'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Criar zona
+      tags:
+      - empregabilidade-zonas
+  /api/v1/empregabilidade/zonas/{id}:
+    delete:
+      description: Remove uma zona
+      parameters:
+      - description: ID da zona
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Excluir zona
+      tags:
+      - empregabilidade-zonas
+    get:
+      description: Retorna uma zona específica
+      parameters:
+      - description: ID da zona
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/empregabilidade.Zona'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Buscar zona por ID
+      tags:
+      - empregabilidade-zonas
+    put:
+      consumes:
+      - application/json
+      description: Atualiza uma zona existente
+      parameters:
+      - description: ID da zona
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Dados da zona
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/empregabilidade.Zona'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/empregabilidade.Zona'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Atualizar zona
+      tags:
+      - empregabilidade-zonas
   /api/v1/empregos:
     get:
       description: Retorna uma lista paginada de empregos com filtros opcionais

--- a/internal/db/migrations/20260710233213_create_empregabilidade_zonas.sql
+++ b/internal/db/migrations/20260710233213_create_empregabilidade_zonas.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Zonas (região geográfica de elegibilidade da vaga)
+CREATE TABLE emp_zonas (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    descricao VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO emp_zonas (descricao) VALUES
+    ('Zona Norte'),
+    ('Zona Sul'),
+    ('Zona Oeste'),
+    ('Centro');
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS emp_zonas;
+
+-- +goose StatementEnd

--- a/internal/db/migrations/20260710233523_add_ordem_to_escolaridades_and_niveis_idioma.sql
+++ b/internal/db/migrations/20260710233523_add_ordem_to_escolaridades_and_niveis_idioma.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE emp_escolaridades ADD COLUMN ordem INTEGER;
+ALTER TABLE emp_niveis_idioma ADD COLUMN ordem INTEGER;
+
+UPDATE emp_escolaridades SET ordem = 1 WHERE descricao = 'Fundamental incompleto';
+UPDATE emp_escolaridades SET ordem = 2 WHERE descricao = 'Fundamental completo';
+UPDATE emp_escolaridades SET ordem = 3 WHERE descricao = 'Médio incompleto';
+UPDATE emp_escolaridades SET ordem = 4 WHERE descricao = 'Médio completo';
+UPDATE emp_escolaridades SET ordem = 5 WHERE descricao = 'Técnico';
+UPDATE emp_escolaridades SET ordem = 6 WHERE descricao = 'Superior incompleto';
+UPDATE emp_escolaridades SET ordem = 7 WHERE descricao = 'Superior completo';
+UPDATE emp_escolaridades SET ordem = 8 WHERE descricao = 'Pós-graduação/MBA';
+UPDATE emp_escolaridades SET ordem = 9 WHERE descricao = 'Mestrado';
+UPDATE emp_escolaridades SET ordem = 10 WHERE descricao = 'Doutorado';
+
+UPDATE emp_niveis_idioma SET ordem = 1 WHERE descricao = 'Básico';
+UPDATE emp_niveis_idioma SET ordem = 2 WHERE descricao = 'Intermediário';
+UPDATE emp_niveis_idioma SET ordem = 3 WHERE descricao = 'Avançado';
+UPDATE emp_niveis_idioma SET ordem = 4 WHERE descricao = 'Nativo/Fluente';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE emp_escolaridades DROP COLUMN IF EXISTS ordem;
+ALTER TABLE emp_niveis_idioma DROP COLUMN IF EXISTS ordem;
+
+-- +goose StatementEnd

--- a/internal/db/migrations/20260710233935_add_criterios_elegibilidade_to_vagas.sql
+++ b/internal/db/migrations/20260710233935_add_criterios_elegibilidade_to_vagas.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE emp_vagas ADD COLUMN idade_minima INTEGER;
+ALTER TABLE emp_vagas ADD COLUMN idade_maxima INTEGER;
+ALTER TABLE emp_vagas ADD COLUMN bairros_elegibilidade JSONB;
+ALTER TABLE emp_vagas ADD COLUMN id_escolaridade_minima UUID REFERENCES emp_escolaridades(id);
+ALTER TABLE emp_vagas ADD COLUMN areas_formacao_elegibilidade JSONB;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE emp_vagas DROP COLUMN IF EXISTS idade_minima;
+ALTER TABLE emp_vagas DROP COLUMN IF EXISTS idade_maxima;
+ALTER TABLE emp_vagas DROP COLUMN IF EXISTS bairros_elegibilidade;
+ALTER TABLE emp_vagas DROP COLUMN IF EXISTS id_escolaridade_minima;
+ALTER TABLE emp_vagas DROP COLUMN IF EXISTS areas_formacao_elegibilidade;
+
+-- +goose StatementEnd

--- a/internal/db/migrations/20260710235339_create_empregabilidade_vagas_zonas.sql
+++ b/internal/db/migrations/20260710235339_create_empregabilidade_vagas_zonas.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE emp_vagas_zonas (
+    id_vaga UUID REFERENCES emp_vagas(id) ON DELETE CASCADE,
+    id_zona UUID REFERENCES emp_zonas(id) ON DELETE CASCADE,
+    PRIMARY KEY (id_vaga, id_zona)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS emp_vagas_zonas;
+
+-- +goose StatementEnd

--- a/internal/db/migrations/20260711115003_create_empregabilidade_vagas_idiomas_requisitos.sql
+++ b/internal/db/migrations/20260711115003_create_empregabilidade_vagas_idiomas_requisitos.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Requisitos de idioma + nível mínimo exigidos por uma vaga (critério de elegibilidade).
+-- Entidade própria (não many2many simples) por carregar a coluna id_nivel_minimo.
+CREATE TABLE emp_vagas_idiomas_requisitos (
+    id_vaga UUID REFERENCES emp_vagas(id) ON DELETE CASCADE,
+    id_idioma UUID REFERENCES emp_idiomas(id) ON DELETE CASCADE,
+    id_nivel_minimo UUID NOT NULL REFERENCES emp_niveis_idioma(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id_vaga, id_idioma)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS emp_vagas_idiomas_requisitos;
+
+-- +goose StatementEnd

--- a/internal/db/migrations/20260711115006_create_empregabilidade_candidatura_bloqueios.sql
+++ b/internal/db/migrations/20260711115006_create_empregabilidade_candidatura_bloqueios.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Registra tentativas de candidatura bloqueadas por não atenderem aos critérios
+-- de elegibilidade configurados na vaga. Não há FK para emp_vagas nem para
+-- candidaturas: o candidato bloqueado nunca chega a se candidatar de fato,
+-- então nenhuma linha em emp_candidaturas é criada para esse fluxo.
+CREATE TABLE emp_candidatura_bloqueios (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cpf VARCHAR(14) NOT NULL,
+    id_vaga UUID NOT NULL,
+    criterios_nao_atendidos JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_emp_candidatura_bloqueios_id_vaga ON emp_candidatura_bloqueios(id_vaga);
+CREATE INDEX idx_emp_candidatura_bloqueios_cpf ON emp_candidatura_bloqueios(cpf);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX IF EXISTS idx_emp_candidatura_bloqueios_cpf;
+DROP INDEX IF EXISTS idx_emp_candidatura_bloqueios_id_vaga;
+DROP TABLE IF EXISTS emp_candidatura_bloqueios;
+
+-- +goose StatementEnd

--- a/internal/handlers/v1/empregabilidade/candidatura_bloqueio_handler.go
+++ b/internal/handlers/v1/empregabilidade/candidatura_bloqueio_handler.go
@@ -1,0 +1,99 @@
+package empregabilidade
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	services "github.com/prefeitura-rio/app-go-api/internal/services/empregabilidade"
+	"github.com/prefeitura-rio/app-go-api/internal/utils"
+)
+
+func handleCandidaturaBloqueioError(c *gin.Context, err error) {
+	dbErr := utils.ParseDatabaseError(err)
+	c.JSON(dbErr.GetHTTPStatusCode(), gin.H{"error": dbErr.GetUserFriendlyMessage()})
+}
+
+type CandidaturaBloqueioHandler struct {
+	service *services.CandidaturaBloqueioService
+}
+
+func NewCandidaturaBloqueioHandler(service *services.CandidaturaBloqueioService) *CandidaturaBloqueioHandler {
+	return &CandidaturaBloqueioHandler{service: service}
+}
+
+// @Summary      Registrar bloqueio de candidatura
+// @Description  Registra a tentativa de candidatura de um CPF a uma vaga que foi bloqueada por não atender critérios de elegibilidade
+// @Tags         empregabilidade-candidatura-bloqueios
+// @Accept       json
+// @Produce      json
+// @Param        request  body      empregabilidade.CandidaturaBloqueio  true  "Dados do bloqueio"
+// @Success      201      {object}  empregabilidade.CandidaturaBloqueio
+// @Failure      400      {object}  map[string]string
+// @Failure      500      {object}  map[string]string
+// @Router       /api/v1/empregabilidade/candidatura-bloqueios [post]
+func (h *CandidaturaBloqueioHandler) Create(c *gin.Context) {
+	var entity empregabilidade.CandidaturaBloqueio
+	if err := c.ShouldBindJSON(&entity); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := h.service.Create(c.Request.Context(), &entity)
+	if err != nil {
+		handleCandidaturaBloqueioError(c, err)
+		return
+	}
+
+	entity.ID = id
+	c.JSON(http.StatusCreated, entity)
+}
+
+// @Summary      Listar bloqueios de candidatura (admin)
+// @Description  Retorna lista paginada de bloqueios de candidatura, com filtros opcionais. Restrito a administradores.
+// @Tags         empregabilidade-candidatura-bloqueios
+// @Produce      json
+// @Param        page      query     int     false  "Número da página (default: 1)"
+// @Param        pageSize  query     int     false  "Tamanho da página (default: 10)"
+// @Param        cpf       query     string  false  "Filtrar por CPF"
+// @Param        id_vaga   query     string  false  "Filtrar por ID da vaga"
+// @Success      200       {object}  map[string]interface{}
+// @Failure      400       {object}  map[string]string
+// @Failure      500       {object}  map[string]string
+// @Router       /api/v1/empregabilidade/candidatura-bloqueios [get]
+func (h *CandidaturaBloqueioHandler) List(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "10"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 1000 {
+		pageSize = 10
+	}
+
+	filter := map[string]interface{}{}
+	if cpf := c.Query("cpf"); cpf != "" {
+		filter["cpf"] = cpf
+	}
+	if raw := c.Query("id_vaga"); raw != "" {
+		id, err := uuid.Parse(raw)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "ID da vaga inválido"})
+			return
+		}
+		filter["id_vaga"] = id
+	}
+
+	entities, total, err := h.service.List(c.Request.Context(), filter, page, pageSize)
+	if err != nil {
+		handleCandidaturaBloqueioError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": entities,
+		"meta": gin.H{"page": page, "page_size": pageSize, "total": total},
+	})
+}

--- a/internal/handlers/v1/empregabilidade/candidatura_bloqueio_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/candidatura_bloqueio_handler_test.go
@@ -1,0 +1,141 @@
+package empregabilidade_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	handlers "github.com/prefeitura-rio/app-go-api/internal/handlers/v1/empregabilidade"
+	empmodels "github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	services "github.com/prefeitura-rio/app-go-api/internal/services/empregabilidade"
+)
+
+type mockCandidaturaBloqueioRepoH struct {
+	listItems []*empmodels.CandidaturaBloqueio
+	listTotal int
+	err       error
+}
+
+func (m *mockCandidaturaBloqueioRepoH) Create(_ context.Context, _ *empmodels.CandidaturaBloqueio) (uuid.UUID, error) {
+	if m.err != nil {
+		return uuid.Nil, m.err
+	}
+	return uuid.New(), nil
+}
+
+func (m *mockCandidaturaBloqueioRepoH) List(_ context.Context, _ map[string]interface{}, _, _ int) ([]*empmodels.CandidaturaBloqueio, int, error) {
+	return m.listItems, m.listTotal, m.err
+}
+
+func setupCandidaturaBloqueioRouter(repo services.CandidaturaBloqueioRepositoryInterface) *gin.Engine {
+	r := gin.New()
+	svc := services.NewCandidaturaBloqueioServiceWithInterface(repo)
+	h := handlers.NewCandidaturaBloqueioHandler(svc)
+	r.POST("/candidatura-bloqueios", h.Create)
+	r.GET("/candidatura-bloqueios", h.List)
+	return r
+}
+
+func TestCandidaturaBloqueioHandler_Create_Success(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{}
+	r := setupCandidaturaBloqueioRouter(repo)
+	body := bodyOf(`{"cpf":"12345678900","id_vaga":"` + validUUID + `","criterios_nao_atendidos":["idade_minima"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/candidatura-bloqueios", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCandidaturaBloqueioHandler_Create_BadJSON(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{}
+	r := setupCandidaturaBloqueioRouter(repo)
+	body := bodyOf(`{bad}`)
+	req := httptest.NewRequest(http.MethodPost, "/candidatura-bloqueios", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCandidaturaBloqueioHandler_Create_ServiceError(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{err: fmt.Errorf("db error")}
+	r := setupCandidaturaBloqueioRouter(repo)
+	body := bodyOf(`{"cpf":"12345678900","id_vaga":"` + validUUID + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/candidatura-bloqueios", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusCreated {
+		t.Error("expected error status, got 201")
+	}
+}
+
+func TestCandidaturaBloqueioHandler_List_Success(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{
+		listItems: []*empmodels.CandidaturaBloqueio{{ID: uuid.New(), CPF: "12345678900", IDVaga: uuid.New()}},
+		listTotal: 1,
+	}
+	r := setupCandidaturaBloqueioRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/candidatura-bloqueios", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCandidaturaBloqueioHandler_List_WithFilters(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{
+		listItems: []*empmodels.CandidaturaBloqueio{{ID: uuid.New(), CPF: "12345678900", IDVaga: uuid.New()}},
+		listTotal: 1,
+	}
+	r := setupCandidaturaBloqueioRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/candidatura-bloqueios?cpf=12345678900&id_vaga="+validUUID, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCandidaturaBloqueioHandler_List_InvalidVagaID(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{}
+	r := setupCandidaturaBloqueioRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/candidatura-bloqueios?id_vaga=bad-id", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCandidaturaBloqueioHandler_List_PaginationClamping(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{}
+	r := setupCandidaturaBloqueioRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/candidatura-bloqueios?page=0&pageSize=99999", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCandidaturaBloqueioHandler_List_ServiceError(t *testing.T) {
+	repo := &mockCandidaturaBloqueioRepoH{err: fmt.Errorf("db error")}
+	r := setupCandidaturaBloqueioRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/candidatura-bloqueios", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}

--- a/internal/handlers/v1/empregabilidade/lookup_handlers.go
+++ b/internal/handlers/v1/empregabilidade/lookup_handlers.go
@@ -1231,3 +1231,155 @@ func (h *DisponibilidadeHandler) Delete(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "Disponibilidade excluída com sucesso"})
 }
+
+// ZonaHandler
+
+type ZonaHandler struct {
+	service *services.ZonaService
+}
+
+func NewZonaHandler(service *services.ZonaService) *ZonaHandler {
+	return &ZonaHandler{service: service}
+}
+
+// @Summary      Criar zona
+// @Description  Cria uma nova zona
+// @Tags         empregabilidade-zonas
+// @Accept       json
+// @Produce      json
+// @Param        body  body      empregabilidade.Zona  true  "Dados da zona"
+// @Success      201   {object}  empregabilidade.Zona
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Router       /api/v1/empregabilidade/zonas [post]
+func (h *ZonaHandler) Create(c *gin.Context) {
+	var entity empregabilidade.Zona
+	if err := c.ShouldBindJSON(&entity); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := h.service.Create(c.Request.Context(), &entity)
+	if err != nil {
+		handleLookupError(c, err)
+		return
+	}
+
+	entity.ID = id
+	c.JSON(http.StatusCreated, entity)
+}
+
+// @Summary      Listar zonas
+// @Description  Retorna uma lista paginada de zonas
+// @Tags         empregabilidade-zonas
+// @Produce      json
+// @Param        page      query     int  false  "Número da página"  default(1)
+// @Param        pageSize  query     int  false  "Tamanho da página"  default(100)
+// @Success      200       {object}  map[string]interface{}
+// @Failure      500       {object}  map[string]string
+// @Router       /api/v1/empregabilidade/zonas [get]
+func (h *ZonaHandler) List(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "100"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 1000 {
+		pageSize = 100
+	}
+
+	entities, total, err := h.service.List(c.Request.Context(), nil, page, pageSize)
+	if err != nil {
+		handleLookupError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": entities, "meta": gin.H{"page": page, "page_size": pageSize, "total": total}})
+}
+
+// @Summary      Buscar zona por ID
+// @Description  Retorna uma zona específica
+// @Tags         empregabilidade-zonas
+// @Produce      json
+// @Param        id   path      string  true  "ID da zona"
+// @Success      200  {object}  empregabilidade.Zona
+// @Failure      400  {object}  map[string]string
+// @Failure      404  {object}  map[string]string
+// @Router       /api/v1/empregabilidade/zonas/{id} [get]
+func (h *ZonaHandler) GetByID(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+		return
+	}
+
+	entity, err := h.service.GetByID(c.Request.Context(), id)
+	if err != nil {
+		handleLookupError(c, err)
+		return
+	}
+
+	if entity == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Zona não encontrada"})
+		return
+	}
+
+	c.JSON(http.StatusOK, entity)
+}
+
+// @Summary      Atualizar zona
+// @Description  Atualiza uma zona existente
+// @Tags         empregabilidade-zonas
+// @Accept       json
+// @Produce      json
+// @Param        id    path      string                true  "ID da zona"
+// @Param        body  body      empregabilidade.Zona  true  "Dados da zona"
+// @Success      200   {object}  empregabilidade.Zona
+// @Failure      400   {object}  map[string]string
+// @Failure      500   {object}  map[string]string
+// @Router       /api/v1/empregabilidade/zonas/{id} [put]
+func (h *ZonaHandler) Update(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+		return
+	}
+
+	var entity empregabilidade.Zona
+	if err := c.ShouldBindJSON(&entity); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	entity.ID = id
+	if err := h.service.Update(c.Request.Context(), &entity); err != nil {
+		handleLookupError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, entity)
+}
+
+// @Summary      Excluir zona
+// @Description  Remove uma zona
+// @Tags         empregabilidade-zonas
+// @Produce      json
+// @Param        id   path      string  true  "ID da zona"
+// @Success      200  {object}  map[string]string
+// @Failure      400  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Router       /api/v1/empregabilidade/zonas/{id} [delete]
+func (h *ZonaHandler) Delete(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+		return
+	}
+
+	if err := h.service.Delete(c.Request.Context(), id); err != nil {
+		handleLookupError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Zona excluída com sucesso"})
+}

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -433,6 +433,82 @@ func (h *VagaHandler) UpdateTiposPCD(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Tipos PCD atualizados com sucesso"})
 }
 
+type UpdateZonasRequest struct {
+	ZonaIDs []uuid.UUID `json:"zona_ids"`
+}
+
+// @Summary      Atualizar zonas de elegibilidade da vaga
+// @Description  Atualiza as zonas geográficas de elegibilidade da vaga
+// @Tags         empregabilidade-vagas
+// @Accept       json
+// @Produce      json
+// @Param        id       path      string              true  "ID da vaga"
+// @Param        request  body      UpdateZonasRequest  true  "IDs das zonas"
+// @Success      200      {object}  map[string]string
+// @Failure      400      {object}  map[string]string
+// @Failure      500      {object}  map[string]string
+// @Router       /api/v1/empregabilidade/vagas/{id}/zonas [put]
+func (h *VagaHandler) UpdateZonas(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+		return
+	}
+
+	var request UpdateZonasRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.service.UpdateZonas(c.Request.Context(), id, request.ZonaIDs); err != nil {
+		handleVagaError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Zonas atualizadas com sucesso"})
+}
+
+type UpdateIdiomasRequisitoRequest struct {
+	Requisitos []empregabilidade.VagaIdiomaRequisito `json:"requisitos"`
+}
+
+// @Summary      Atualizar requisitos de idioma da vaga
+// @Description  Atualiza os idiomas e níveis mínimos exigidos como critério de elegibilidade da vaga
+// @Tags         empregabilidade-vagas
+// @Accept       json
+// @Produce      json
+// @Param        id       path      string                         true  "ID da vaga"
+// @Param        request  body      UpdateIdiomasRequisitoRequest  true  "Requisitos de idioma"
+// @Success      200      {object}  map[string]string
+// @Failure      400      {object}  map[string]string
+// @Failure      500      {object}  map[string]string
+// @Router       /api/v1/empregabilidade/vagas/{id}/idiomas-requisito [put]
+func (h *VagaHandler) UpdateIdiomasRequisito(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ID inválido"})
+		return
+	}
+
+	var request UpdateIdiomasRequisitoRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	for i := range request.Requisitos {
+		request.Requisitos[i].IDVaga = id
+	}
+
+	if err := h.service.UpdateIdiomasRequisito(c.Request.Context(), id, request.Requisitos); err != nil {
+		handleVagaError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Requisitos de idioma atualizados com sucesso"})
+}
+
 // @Summary      Congelar vaga
 // @Description  Congela uma vaga publicada e atualiza o status de todas as candidaturas vinculadas para vaga_congelada
 // @Tags         empregabilidade-vagas

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -69,6 +69,14 @@ func (m *mockVagaRepoH) UpdateTiposPCD(_ context.Context, _ uuid.UUID, _ []uuid.
 	return m.err
 }
 
+func (m *mockVagaRepoH) UpdateZonas(_ context.Context, _ uuid.UUID, _ []uuid.UUID) error {
+	return m.err
+}
+
+func (m *mockVagaRepoH) UpdateIdiomasRequisito(_ context.Context, _ uuid.UUID, _ []empmodels.VagaIdiomaRequisito) error {
+	return m.err
+}
+
 func (m *mockVagaRepoH) ListByContratante(_ context.Context, _ string, _, _ int) ([]*empmodels.Vaga, int, error) {
 	return m.listItems, m.listTotal, m.err
 }
@@ -130,6 +138,8 @@ func setupVagaRouter(vagaRepo services.VagaRepoInterface, empresaRepo services.E
 	r.PUT("/vagas/:id/send-to-approval", h.SendToApproval)
 	r.PUT("/vagas/:id/publish", h.Publish)
 	r.PUT("/vagas/:id/tipos-pcd", h.UpdateTiposPCD)
+	r.PUT("/vagas/:id/zonas", h.UpdateZonas)
+	r.PUT("/vagas/:id/idiomas-requisito", h.UpdateIdiomasRequisito)
 	r.PUT("/vagas/:id/freeze", h.Freeze)
 	r.PUT("/vagas/:id/unfreeze", h.Unfreeze)
 	r.PUT("/vagas/:id/discontinue", h.Discontinue)
@@ -844,6 +854,154 @@ func TestVagaHandler_UpdateTiposPCD_EmptyArray(t *testing.T) {
 	r := setupVagaRouter(vagaRepo, empresaRepo, true)
 	body := bodyOf(`{"tipos_pcd_ids":[]}`)
 	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/tipos-pcd", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: UpdateZonas
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestVagaHandler_UpdateZonas_Success(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, false)
+	body := bodyOf(`{"zona_ids":["` + validUUID + `"]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_UpdateZonas_InvalidID(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, false)
+	body := bodyOf(`{"zona_ids":[]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/bad-id/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_UpdateZonas_BadJSON(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, true)
+	body := bodyOf(`{bad}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_UpdateZonas_ServiceError(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{err: errTest}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, true)
+	body := bodyOf(`{"zona_ids":["` + validUUID + `"]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}
+
+func TestVagaHandler_UpdateZonas_EmptyArray(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, true)
+	body := bodyOf(`{"zona_ids":[]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests: UpdateIdiomasRequisito
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestVagaHandler_UpdateIdiomasRequisito_Success(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, false)
+	body := bodyOf(`{"requisitos":[{"id_idioma":"` + validUUID + `","id_nivel_minimo":"` + validUUID + `"}]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/idiomas-requisito", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_UpdateIdiomasRequisito_InvalidID(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, false)
+	body := bodyOf(`{"requisitos":[]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/bad-id/idiomas-requisito", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_UpdateIdiomasRequisito_BadJSON(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, true)
+	body := bodyOf(`{bad}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/idiomas-requisito", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestVagaHandler_UpdateIdiomasRequisito_ServiceError(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{err: errTest}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, true)
+	body := bodyOf(`{"requisitos":[{"id_idioma":"` + validUUID + `","id_nivel_minimo":"` + validUUID + `"}]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/idiomas-requisito", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}
+
+func TestVagaHandler_UpdateIdiomasRequisito_EmptyArray(t *testing.T) {
+	vagaRepo := &mockVagaRepoH{}
+	empresaRepo := &mockEmpresaRepoForVaga{}
+	r := setupVagaRouter(vagaRepo, empresaRepo, true)
+	body := bodyOf(`{"requisitos":[]}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID+"/idiomas-requisito", body)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/internal/handlers/v1/empregabilidade/zona_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/zona_handler_test.go
@@ -1,0 +1,245 @@
+package empregabilidade_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	handlers "github.com/prefeitura-rio/app-go-api/internal/handlers/v1/empregabilidade"
+	empmodels "github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	services "github.com/prefeitura-rio/app-go-api/internal/services/empregabilidade"
+)
+
+type mockZonaRepoH struct {
+	entity    *empmodels.Zona
+	listItems []*empmodels.Zona
+	listTotal int
+	err       error
+}
+
+func (m *mockZonaRepoH) Create(_ context.Context, _ *empmodels.Zona) (uuid.UUID, error) {
+	if m.err != nil {
+		return uuid.Nil, m.err
+	}
+	return uuid.New(), nil
+}
+func (m *mockZonaRepoH) GetByID(_ context.Context, _ uuid.UUID) (*empmodels.Zona, error) {
+	return m.entity, m.err
+}
+func (m *mockZonaRepoH) Update(_ context.Context, _ *empmodels.Zona) error { return m.err }
+func (m *mockZonaRepoH) Delete(_ context.Context, _ uuid.UUID) error       { return m.err }
+func (m *mockZonaRepoH) List(_ context.Context, _ map[string]interface{}, _, _ int) ([]*empmodels.Zona, int, error) {
+	return m.listItems, m.listTotal, m.err
+}
+
+func setupZonaRouter(repo services.ZonaRepositoryInterface) *gin.Engine {
+	r := gin.New()
+	svc := services.NewZonaServiceWithInterface(repo)
+	h := handlers.NewZonaHandler(svc)
+	r.POST("/zonas", h.Create)
+	r.GET("/zonas", h.List)
+	r.GET("/zonas/:id", h.GetByID)
+	r.PUT("/zonas/:id", h.Update)
+	r.DELETE("/zonas/:id", h.Delete)
+	return r
+}
+
+func TestZonaHandler_Create_Success(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"Zona Norte"}`)
+	req := httptest.NewRequest(http.MethodPost, "/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_Create_Error(t *testing.T) {
+	repo := &mockZonaRepoH{err: fmt.Errorf("db error")}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"Zona Norte"}`)
+	req := httptest.NewRequest(http.MethodPost, "/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusCreated {
+		t.Error("expected error status, got 201")
+	}
+}
+
+func TestZonaHandler_Create_BadJSON(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`invalid json`)
+	req := httptest.NewRequest(http.MethodPost, "/zonas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_List(t *testing.T) {
+	repo := &mockZonaRepoH{
+		listItems: []*empmodels.Zona{{ID: uuid.New(), Descricao: "Centro"}},
+		listTotal: 1,
+	}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/zonas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_List_Error(t *testing.T) {
+	repo := &mockZonaRepoH{err: fmt.Errorf("db error")}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/zonas", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}
+
+func TestZonaHandler_GetByID_Found(t *testing.T) {
+	id := uuid.New()
+	repo := &mockZonaRepoH{entity: &empmodels.Zona{ID: id, Descricao: "Centro"}}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/zonas/"+id.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_GetByID_NotFound(t *testing.T) {
+	repo := &mockZonaRepoH{entity: nil}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/zonas/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_GetByID_InvalidID(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/zonas/bad-id", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_GetByID_ServiceError(t *testing.T) {
+	repo := &mockZonaRepoH{err: fmt.Errorf("db error")}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodGet, "/zonas/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}
+
+func TestZonaHandler_Update_Success(t *testing.T) {
+	id := uuid.New()
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"Zona Sul"}`)
+	req := httptest.NewRequest(http.MethodPut, "/zonas/"+id.String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_Update_InvalidID(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"Zona Sul"}`)
+	req := httptest.NewRequest(http.MethodPut, "/zonas/bad-id", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_Update_BadJSON(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`invalid json`)
+	req := httptest.NewRequest(http.MethodPut, "/zonas/"+uuid.New().String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_Update_Error(t *testing.T) {
+	repo := &mockZonaRepoH{err: fmt.Errorf("db error")}
+	r := setupZonaRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"Zona Sul"}`)
+	req := httptest.NewRequest(http.MethodPut, "/zonas/"+uuid.New().String(), body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}
+
+func TestZonaHandler_Delete_Success(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodDelete, "/zonas/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_Delete_InvalidID(t *testing.T) {
+	repo := &mockZonaRepoH{}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodDelete, "/zonas/bad-id", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestZonaHandler_Delete_Error(t *testing.T) {
+	repo := &mockZonaRepoH{err: fmt.Errorf("db error")}
+	r := setupZonaRouter(repo)
+	req := httptest.NewRequest(http.MethodDelete, "/zonas/"+uuid.New().String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Error("expected error status")
+	}
+}

--- a/internal/models/empregabilidade/candidatura_bloqueio.go
+++ b/internal/models/empregabilidade/candidatura_bloqueio.go
@@ -1,0 +1,23 @@
+package empregabilidade
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CandidaturaBloqueio registra a tentativa de candidatura de um CPF a uma vaga
+// que foi bloqueada por não atender a um ou mais critérios de elegibilidade
+// configurados na vaga. Não há Candidatura associada nesse fluxo (o candidato
+// nunca chega a se candidatar de fato), por isso IDVaga não possui FK.
+type CandidaturaBloqueio struct {
+	ID                    uuid.UUID `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	CPF                   string    `json:"cpf" gorm:"type:varchar(14);not null"`
+	IDVaga                uuid.UUID `json:"id_vaga" gorm:"type:uuid;not null"`
+	CriteriosNaoAtendidos []string  `json:"criterios_nao_atendidos" gorm:"type:jsonb;serializer:json"`
+	CreatedAt             time.Time `json:"created_at" gorm:"autoCreateTime"`
+}
+
+func (CandidaturaBloqueio) TableName() string {
+	return "emp_candidatura_bloqueios"
+}

--- a/internal/models/empregabilidade/escolaridade.go
+++ b/internal/models/empregabilidade/escolaridade.go
@@ -9,6 +9,7 @@ import (
 type Escolaridade struct {
 	ID        uuid.UUID `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
 	Descricao string    `json:"descricao" gorm:"type:varchar(255);not null;unique"`
+	Ordem     *int      `json:"ordem,omitempty" gorm:"column:ordem"`
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
 }

--- a/internal/models/empregabilidade/models_test.go
+++ b/internal/models/empregabilidade/models_test.go
@@ -1,8 +1,12 @@
 package empregabilidade
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // StatusVaga tests
@@ -190,6 +194,76 @@ func TestCurriculoFormacao_Validate_InvalidStatus(t *testing.T) {
 	}
 }
 
+// Escolaridade.Ordem tests
+
+func TestEscolaridade_Ordem_JSONRoundTrip(t *testing.T) {
+	ordem := 3
+	e := Escolaridade{ID: uuid.New(), Descricao: "Superior completo", Ordem: &ordem}
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling: %v", err)
+	}
+	if !strings.Contains(string(data), `"ordem":3`) {
+		t.Errorf("expected JSON to contain ordem key with value 3, got %s", data)
+	}
+
+	var decoded Escolaridade
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unexpected error unmarshaling: %v", err)
+	}
+	if decoded.Ordem == nil || *decoded.Ordem != 3 {
+		t.Errorf("expected decoded Ordem to be 3, got %v", decoded.Ordem)
+	}
+}
+
+func TestEscolaridade_Ordem_NilOmitted(t *testing.T) {
+	e := Escolaridade{ID: uuid.New(), Descricao: "Sem ordem"}
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling: %v", err)
+	}
+	if strings.Contains(string(data), `"ordem"`) {
+		t.Errorf("expected JSON to omit nil ordem key, got %s", data)
+	}
+}
+
+// NivelIdioma.Ordem tests
+
+func TestNivelIdioma_Ordem_JSONRoundTrip(t *testing.T) {
+	ordem := 2
+	n := NivelIdioma{ID: uuid.New(), Descricao: "Intermediário", Ordem: &ordem}
+
+	data, err := json.Marshal(n)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling: %v", err)
+	}
+	if !strings.Contains(string(data), `"ordem":2`) {
+		t.Errorf("expected JSON to contain ordem key with value 2, got %s", data)
+	}
+
+	var decoded NivelIdioma
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unexpected error unmarshaling: %v", err)
+	}
+	if decoded.Ordem == nil || *decoded.Ordem != 2 {
+		t.Errorf("expected decoded Ordem to be 2, got %v", decoded.Ordem)
+	}
+}
+
+func TestNivelIdioma_Ordem_NilOmitted(t *testing.T) {
+	n := NivelIdioma{ID: uuid.New(), Descricao: "Sem ordem"}
+
+	data, err := json.Marshal(n)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling: %v", err)
+	}
+	if strings.Contains(string(data), `"ordem"`) {
+		t.Errorf("expected JSON to omit nil ordem key, got %s", data)
+	}
+}
+
 // TableName tests (ensures they compile and return correct values)
 
 func TestTableNames(t *testing.T) {
@@ -220,6 +294,9 @@ func TestTableNames(t *testing.T) {
 		{"Empresa", Empresa{}.TableName(), "emp_empresas"},
 		{"Etapa", Etapa{}.TableName(), "emp_etapas"},
 		{"InformacaoComplementar", InformacaoComplementar{}.TableName(), "emp_informacoes_complementares"},
+		{"Zona", Zona{}.TableName(), "emp_zonas"},
+		{"VagaIdiomaRequisito", VagaIdiomaRequisito{}.TableName(), "emp_vagas_idiomas_requisitos"},
+		{"CandidaturaBloqueio", CandidaturaBloqueio{}.TableName(), "emp_candidatura_bloqueios"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/models/empregabilidade/vaga.go
+++ b/internal/models/empregabilidade/vaga.go
@@ -69,14 +69,24 @@ type Vaga struct {
 	CreatedAt                      time.Time          `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt                      time.Time          `json:"updated_at" gorm:"autoUpdateTime"`
 
+	// Critérios de elegibilidade
+	IdadeMinima                *int       `json:"idade_minima,omitempty" gorm:"type:integer"`
+	IdadeMaxima                *int       `json:"idade_maxima,omitempty" gorm:"type:integer"`
+	BairrosElegibilidade       []string   `json:"bairros_elegibilidade,omitempty" gorm:"type:jsonb;serializer:json"`
+	IDEscolaridadeMinima       *uuid.UUID `json:"id_escolaridade_minima,omitempty" gorm:"type:uuid"`
+	AreasFormacaoElegibilidade []string   `json:"areas_formacao_elegibilidade,omitempty" gorm:"type:jsonb;serializer:json"`
+
 	// Relationships
 	Contratante               *Empresa                 `json:"contratante,omitempty" gorm:"foreignKey:IDContratante;references:CNPJ"`
 	RegimeContratacao         *RegimeContratacao       `json:"regime_contratacao,omitempty" gorm:"foreignKey:IDRegimeContratacao"`
 	ModeloTrabalho            *ModeloTrabalho          `json:"modelo_trabalho,omitempty" gorm:"foreignKey:IDModeloTrabalho"`
 	OrgaoParceiro             *models.OrgaoSnapshot    `json:"orgao_parceiro,omitempty" gorm:"foreignKey:IDOrgaoParceiro;references:OrgaoID"`
 	TiposPCD                  []TipoPCD                `json:"tipos_pcd,omitempty" gorm:"many2many:emp_vagas_tipos_pcd;foreignKey:ID;joinForeignKey:id_vaga;References:ID;joinReferences:id_tipo_pcd"`
+	Zonas                     []Zona                   `json:"zonas,omitempty" gorm:"many2many:emp_vagas_zonas;foreignKey:ID;joinForeignKey:id_vaga;References:ID;joinReferences:id_zona"`
+	IdiomasRequisito          []VagaIdiomaRequisito    `json:"idiomas_requisito,omitempty" gorm:"foreignKey:IDVaga"`
 	Etapas                    []Etapa                  `json:"etapas,omitempty" gorm:"foreignKey:IDVaga"`
 	InformacoesComplementares []InformacaoComplementar `json:"informacoes_complementares,omitempty" gorm:"foreignKey:IDVaga"`
+	EscolaridadeMinima        *Escolaridade            `json:"escolaridade_minima,omitempty" gorm:"foreignKey:IDEscolaridadeMinima"`
 }
 
 func (Vaga) TableName() string {

--- a/internal/models/empregabilidade/vaga_idioma_requisito.go
+++ b/internal/models/empregabilidade/vaga_idioma_requisito.go
@@ -1,0 +1,27 @@
+package empregabilidade
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// VagaIdiomaRequisito representa um requisito de idioma + nível mínimo exigido
+// por uma vaga. É uma entidade própria (não um many2many simples) porque carrega
+// a coluna adicional id_nivel_minimo, análoga a CurriculoIdioma no lado do currículo.
+type VagaIdiomaRequisito struct {
+	IDVaga        uuid.UUID `json:"id_vaga" gorm:"type:uuid;primaryKey"`
+	IDIdioma      uuid.UUID `json:"id_idioma" gorm:"type:uuid;primaryKey"`
+	IDNivelMinimo uuid.UUID `json:"id_nivel_minimo" gorm:"type:uuid;not null"`
+	CreatedAt     time.Time `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt     time.Time `json:"updated_at" gorm:"autoUpdateTime"`
+
+	// Relationships
+	Vaga        *Vaga        `json:"vaga,omitempty" gorm:"foreignKey:IDVaga"`
+	Idioma      *Idioma      `json:"idioma,omitempty" gorm:"foreignKey:IDIdioma"`
+	NivelMinimo *NivelIdioma `json:"nivel_minimo,omitempty" gorm:"foreignKey:IDNivelMinimo"`
+}
+
+func (VagaIdiomaRequisito) TableName() string {
+	return "emp_vagas_idiomas_requisitos"
+}

--- a/internal/models/empregabilidade/zona.go
+++ b/internal/models/empregabilidade/zona.go
@@ -6,14 +6,13 @@ import (
 	"github.com/google/uuid"
 )
 
-type NivelIdioma struct {
+type Zona struct {
 	ID        uuid.UUID `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
 	Descricao string    `json:"descricao" gorm:"type:varchar(255);not null;unique"`
-	Ordem     *int      `json:"ordem,omitempty" gorm:"column:ordem"`
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
 }
 
-func (NivelIdioma) TableName() string {
-	return "emp_niveis_idioma"
+func (Zona) TableName() string {
+	return "emp_zonas"
 }

--- a/internal/repository/empregabilidade/candidatura_bloqueio_repository.go
+++ b/internal/repository/empregabilidade/candidatura_bloqueio_repository.go
@@ -1,0 +1,47 @@
+package empregabilidade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+)
+
+type CandidaturaBloqueioRepository struct {
+	db *gorm.DB
+}
+
+func NewCandidaturaBloqueioRepository(db *gorm.DB) *CandidaturaBloqueioRepository {
+	return &CandidaturaBloqueioRepository{db: db}
+}
+
+func (r *CandidaturaBloqueioRepository) Create(ctx context.Context, entity *empregabilidade.CandidaturaBloqueio) (uuid.UUID, error) {
+	result := r.db.WithContext(ctx).Create(entity)
+	if result.Error != nil {
+		return uuid.Nil, fmt.Errorf("erro ao criar bloqueio de candidatura: %w", result.Error)
+	}
+	return entity.ID, nil
+}
+
+func (r *CandidaturaBloqueioRepository) List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.CandidaturaBloqueio, int, error) {
+	var entities []*empregabilidade.CandidaturaBloqueio
+	var total int64
+
+	db := r.db.WithContext(ctx).Model(&empregabilidade.CandidaturaBloqueio{})
+
+	for key, value := range filter {
+		db = db.Where(key+" = ?", value)
+	}
+
+	db.Count(&total)
+
+	result := db.Order("created_at DESC").Limit(limit).Offset(offset).Find(&entities)
+	if result.Error != nil {
+		return nil, 0, fmt.Errorf("erro ao listar bloqueios de candidatura: %w", result.Error)
+	}
+
+	return entities, int(total), nil
+}

--- a/internal/repository/empregabilidade/candidatura_bloqueio_repository_test.go
+++ b/internal/repository/empregabilidade/candidatura_bloqueio_repository_test.go
@@ -1,0 +1,181 @@
+package empregabilidade
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	"github.com/prefeitura-rio/app-go-api/internal/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCandidaturaBloqueioRepository_Create(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewCandidaturaBloqueioRepository(db)
+	ctx := context.Background()
+
+	entity := &empregabilidade.CandidaturaBloqueio{
+		ID:                    uuid.New(),
+		CPF:                   "12345678900",
+		IDVaga:                uuid.New(),
+		CriteriosNaoAtendidos: []string{"idade_minima"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_candidatura_bloqueios"`)).
+		WithArgs(entity.CPF, entity.IDVaga, sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(entity.ID))
+	mock.ExpectCommit()
+
+	id, err := repo.Create(ctx, entity)
+
+	assert.NoError(t, err)
+	assert.Equal(t, entity.ID, id)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCandidaturaBloqueioRepository_Create_Error(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewCandidaturaBloqueioRepository(db)
+	ctx := context.Background()
+
+	entity := &empregabilidade.CandidaturaBloqueio{
+		ID:                    uuid.New(),
+		CPF:                   "12345678900",
+		IDVaga:                uuid.New(),
+		CriteriosNaoAtendidos: []string{"idade_minima"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_candidatura_bloqueios"`)).
+		WithArgs(entity.CPF, entity.IDVaga, sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
+		WillReturnError(errors.New("database error"))
+	mock.ExpectRollback()
+
+	id, err := repo.Create(ctx, entity)
+
+	assert.Error(t, err)
+	assert.Equal(t, uuid.Nil, id)
+	assert.Contains(t, err.Error(), "erro ao criar bloqueio de candidatura")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCandidaturaBloqueioRepository_List(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewCandidaturaBloqueioRepository(db)
+	ctx := context.Background()
+
+	expectedEntities := []*empregabilidade.CandidaturaBloqueio{
+		{ID: uuid.New(), CPF: "12345678900", IDVaga: uuid.New()},
+		{ID: uuid.New(), CPF: "98765432100", IDVaga: uuid.New()},
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "cpf", "id_vaga"})
+	for _, e := range expectedEntities {
+		rows.AddRow(e.ID, e.CPF, e.IDVaga)
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_candidatura_bloqueios"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_candidatura_bloqueios"`)).
+		WillReturnRows(rows)
+
+	results, total, err := repo.List(ctx, map[string]interface{}{}, 10, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, results, 2)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCandidaturaBloqueioRepository_List_Empty(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewCandidaturaBloqueioRepository(db)
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_candidatura_bloqueios"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_candidatura_bloqueios"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "cpf", "id_vaga"}))
+
+	results, total, err := repo.List(ctx, map[string]interface{}{}, 10, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Len(t, results, 0)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCandidaturaBloqueioRepository_List_WithFilter(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewCandidaturaBloqueioRepository(db)
+	ctx := context.Background()
+
+	vagaID := uuid.New()
+	filter := map[string]interface{}{
+		"id_vaga": vagaID,
+		"cpf":     "12345678900",
+	}
+
+	expectedEntity := &empregabilidade.CandidaturaBloqueio{
+		ID:     uuid.New(),
+		CPF:    "12345678900",
+		IDVaga: vagaID,
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "cpf", "id_vaga"}).
+		AddRow(expectedEntity.ID, expectedEntity.CPF, expectedEntity.IDVaga)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_candidatura_bloqueios" WHERE id_vaga = $1 AND cpf = $2`)).
+		WithArgs(vagaID, "12345678900").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_candidatura_bloqueios" WHERE id_vaga = $1 AND cpf = $2`)).
+		WillReturnRows(rows)
+
+	results, total, err := repo.List(ctx, filter, 10, 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, results, 1)
+	assert.Equal(t, expectedEntity.CPF, results[0].CPF)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCandidaturaBloqueioRepository_List_Error(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewCandidaturaBloqueioRepository(db)
+	ctx := context.Background()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_candidatura_bloqueios"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_candidatura_bloqueios"`)).
+		WillReturnError(errors.New("database error"))
+
+	results, total, err := repo.List(ctx, map[string]interface{}{}, 10, 0)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "erro ao listar bloqueios de candidatura")
+	assert.Equal(t, 0, total)
+	assert.Nil(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/repository/empregabilidade/nivel_idioma_repository_test.go
+++ b/internal/repository/empregabilidade/nivel_idioma_repository_test.go
@@ -28,7 +28,7 @@ func TestNivelIdiomaRepository_Create(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_niveis_idioma"`)).
-		WithArgs(entity.Descricao, sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
+		WithArgs(entity.Descricao, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(entity.ID))
 	mock.ExpectCommit()
 

--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -39,6 +39,8 @@ func (r *VagaRepository) GetByID(ctx context.Context, id uuid.UUID) (*empregabil
 		Preload("ModeloTrabalho").
 		Preload("OrgaoParceiro").
 		Preload("TiposPCD").
+		Preload("Zonas").
+		Preload("IdiomasRequisito").
 		Preload("Etapas", func(db *gorm.DB) *gorm.DB {
 			return db.Order("ordem ASC")
 		}).
@@ -71,6 +73,11 @@ func (r *VagaRepository) Update(ctx context.Context, entity *empregabilidade.Vag
 		"beneficios":                       entity.Beneficios,
 		"id_orgao_parceiro":                entity.IDOrgaoParceiro,
 		"status":                           entity.Status,
+		"idade_minima":                     entity.IdadeMinima,
+		"idade_maxima":                     entity.IdadeMaxima,
+		"bairros_elegibilidade":            entity.BairrosElegibilidade,
+		"id_escolaridade_minima":           entity.IDEscolaridadeMinima,
+		"areas_formacao_elegibilidade":     entity.AreasFormacaoElegibilidade,
 	}
 
 	result := r.db.WithContext(ctx).
@@ -102,6 +109,11 @@ func (r *VagaRepository) UpdateWithAssociations(ctx context.Context, entity *emp
 			"beneficios":                       entity.Beneficios,
 			"id_orgao_parceiro":                entity.IDOrgaoParceiro,
 			"status":                           entity.Status,
+			"idade_minima":                     entity.IdadeMinima,
+			"idade_maxima":                     entity.IdadeMaxima,
+			"bairros_elegibilidade":            entity.BairrosElegibilidade,
+			"id_escolaridade_minima":           entity.IDEscolaridadeMinima,
+			"areas_formacao_elegibilidade":     entity.AreasFormacaoElegibilidade,
 		}
 
 		if err := tx.Model(&empregabilidade.Vaga{}).Where("id = ?", entity.ID).Updates(updates).Error; err != nil {
@@ -159,6 +171,17 @@ func (r *VagaRepository) UpdateWithAssociations(ctx context.Context, entity *emp
 			for _, tipo := range entity.TiposPCD {
 				if err := tx.Exec("INSERT INTO emp_vagas_tipos_pcd (id_vaga, id_tipo_pcd) VALUES (?, ?)", entity.ID, tipo.ID).Error; err != nil {
 					return fmt.Errorf("erro ao inserir tipo PCD: %w", err)
+				}
+			}
+		}
+
+		if entity.Zonas != nil {
+			if err := tx.Exec("DELETE FROM emp_vagas_zonas WHERE id_vaga = ?", entity.ID).Error; err != nil {
+				return fmt.Errorf("erro ao remover zonas: %w", err)
+			}
+			for _, zona := range entity.Zonas {
+				if err := tx.Exec("INSERT INTO emp_vagas_zonas (id_vaga, id_zona) VALUES (?, ?)", entity.ID, zona.ID).Error; err != nil {
+					return fmt.Errorf("erro ao inserir zona: %w", err)
 				}
 			}
 		}
@@ -300,6 +323,41 @@ func (r *VagaRepository) UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, t
 		for _, tipoPCDID := range tiposPCDIDs {
 			if err := tx.Exec("INSERT INTO emp_vagas_tipos_pcd (id_vaga, id_tipo_pcd) VALUES (?, ?)", vagaID, tipoPCDID).Error; err != nil {
 				return fmt.Errorf("erro ao inserir tipo PCD: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func (r *VagaRepository) UpdateZonas(ctx context.Context, vagaID uuid.UUID, zonaIDs []uuid.UUID) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("DELETE FROM emp_vagas_zonas WHERE id_vaga = ?", vagaID).Error; err != nil {
+			return fmt.Errorf("erro ao remover zonas: %w", err)
+		}
+
+		for _, zonaID := range zonaIDs {
+			if err := tx.Exec("INSERT INTO emp_vagas_zonas (id_vaga, id_zona) VALUES (?, ?)", vagaID, zonaID).Error; err != nil {
+				return fmt.Errorf("erro ao inserir zona: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+func (r *VagaRepository) UpdateIdiomasRequisito(ctx context.Context, vagaID uuid.UUID, requisitos []empregabilidade.VagaIdiomaRequisito) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("DELETE FROM emp_vagas_idiomas_requisitos WHERE id_vaga = ?", vagaID).Error; err != nil {
+			return fmt.Errorf("erro ao remover requisitos de idioma: %w", err)
+		}
+
+		for _, requisito := range requisitos {
+			if err := tx.Exec(
+				"INSERT INTO emp_vagas_idiomas_requisitos (id_vaga, id_idioma, id_nivel_minimo) VALUES (?, ?, ?)",
+				vagaID, requisito.IDIdioma, requisito.IDNivelMinimo,
+			).Error; err != nil {
+				return fmt.Errorf("erro ao inserir requisito de idioma: %w", err)
 			}
 		}
 
@@ -460,6 +518,8 @@ func (r *VagaRepository) GetByIDPrefix(ctx context.Context, idPrefix string) (*e
 		Preload("ModeloTrabalho").
 		Preload("OrgaoParceiro").
 		Preload("TiposPCD").
+		Preload("Zonas").
+		Preload("IdiomasRequisito").
 		Preload("Etapas", func(db *gorm.DB) *gorm.DB {
 			return db.Order("ordem ASC")
 		}).

--- a/internal/repository/empregabilidade/vaga_repository_test.go
+++ b/internal/repository/empregabilidade/vaga_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -502,6 +503,13 @@ func TestVagaRepository_GetByID_Success(t *testing.T) {
 	mock.ExpectQuery(`SELECT \* FROM "emp_vagas_tipos_pcd"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id_vaga", "id_tipo_pcd"}))
 
+	// Zonas is a many2many relation, so it queries the junction table first
+	mock.ExpectQuery(`SELECT \* FROM "emp_vagas_zonas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id_vaga", "id_zona"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_vagas_idiomas_requisitos"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id_vaga", "id_idioma", "id_nivel_minimo"}))
+
 	mock.ExpectQuery(`SELECT \* FROM "emp_etapas"`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
@@ -530,6 +538,63 @@ func TestVagaRepository_GetByID_NotFound(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestVagaRepository_GetByIDPrefix_Success(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+	regimeID := uuid.New()
+	modeloID := uuid.New()
+
+	mock.MatchExpectationsInOrder(false)
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_vagas"`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "titulo", "descricao", "id_contratante", "id_regime_contratacao",
+			"id_modelo_trabalho", "status", "bairro", "requisitos", "diferenciais",
+			"responsabilidades", "beneficios", "id_orgao_parceiro",
+		}).AddRow(
+			vagaID, "Test Vaga", "Test Description", "12345678000190", regimeID,
+			modeloID, "em_edicao", "", "", "", "", "", "",
+		))
+
+	// id_orgao_parceiro is zero-value ("") for this row, so GORM skips the
+	// OrgaoParceiro preload query entirely (no rows to look up) - no mock needed.
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_empresas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"cnpj"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_regimes_contratacao"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_modelos_trabalho"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_vagas_tipos_pcd"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id_vaga", "id_tipo_pcd"}))
+
+	// Zonas is a many2many relation, so it queries the junction table first
+	mock.ExpectQuery(`SELECT \* FROM "emp_vagas_zonas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id_vaga", "id_zona"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_vagas_idiomas_requisitos"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id_vaga", "id_idioma", "id_nivel_minimo"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_etapas"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	mock.ExpectQuery(`SELECT \* FROM "emp_informacoes_complementares"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	result, err := repo.GetByIDPrefix(ctx, strings.ReplaceAll(vagaID.String(), "-", "")[:12])
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, vagaID, result.ID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestVagaRepository_Update_Success(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
@@ -549,6 +614,42 @@ func TestVagaRepository_Update_Success(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec(`UPDATE "emp_vagas"`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.Update(ctx, vaga)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestVagaRepository_Update_IncludesCriteriosElegibilidadeColumns(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	idadeMin := 18
+	idadeMax := 65
+	escolaridadeID := uuid.New()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                         uuid.New(),
+		Titulo:                     "Desenvolvedor Go",
+		Descricao:                  "Vaga para desenvolvedor Go",
+		IDContratante:              "12345678000190",
+		IDRegimeContratacao:        uuid.New(),
+		IDModeloTrabalho:           uuid.New(),
+		Status:                     empregabilidade.StatusVagaEmEdicao,
+		IdadeMinima:                &idadeMin,
+		IdadeMaxima:                &idadeMax,
+		BairrosElegibilidade:       []string{"Centro", "Tijuca"},
+		IDEscolaridadeMinima:       &escolaridadeID,
+		AreasFormacaoElegibilidade: []string{"Tecnologia"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE "emp_vagas" SET.*"areas_formacao_elegibilidade".*"bairros_elegibilidade".*"id_escolaridade_minima".*"idade_maxima".*"idade_minima".*WHERE`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -745,6 +846,133 @@ func TestVagaRepository_UpdateTiposPCD_EmptyList(t *testing.T) {
 	err := repo.UpdateTiposPCD(ctx, vagaID, []uuid.UUID{})
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestVagaRepository_UpdateZonas_Success(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+	zonaID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_zonas`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`INSERT INTO emp_vagas_zonas`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.UpdateZonas(ctx, vagaID, []uuid.UUID{zonaID})
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestVagaRepository_UpdateZonas_EmptyList(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_zonas`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := repo.UpdateZonas(ctx, vagaID, []uuid.UUID{})
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestVagaRepository_UpdateIdiomasRequisito_Success(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+	idiomaID := uuid.New()
+	nivelID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_idiomas_requisitos`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`INSERT INTO emp_vagas_idiomas_requisitos`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	requisitos := []empregabilidade.VagaIdiomaRequisito{
+		{IDIdioma: idiomaID, IDNivelMinimo: nivelID},
+	}
+
+	err := repo.UpdateIdiomasRequisito(ctx, vagaID, requisitos)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestVagaRepository_UpdateIdiomasRequisito_EmptyList(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_idiomas_requisitos`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := repo.UpdateIdiomasRequisito(ctx, vagaID, []empregabilidade.VagaIdiomaRequisito{})
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestVagaRepository_UpdateIdiomasRequisito_DeleteError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_idiomas_requisitos`).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	err := repo.UpdateIdiomasRequisito(ctx, vagaID, []empregabilidade.VagaIdiomaRequisito{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "erro ao remover requisitos de idioma")
+}
+
+func TestVagaRepository_UpdateIdiomasRequisito_InsertError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+	idiomaID := uuid.New()
+	nivelID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_idiomas_requisitos`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`INSERT INTO emp_vagas_idiomas_requisitos`).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	requisitos := []empregabilidade.VagaIdiomaRequisito{
+		{IDIdioma: idiomaID, IDNivelMinimo: nivelID},
+	}
+
+	err := repo.UpdateIdiomasRequisito(ctx, vagaID, requisitos)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "erro ao inserir requisito de idioma")
 }
 
 // Error path tests
@@ -1012,6 +1240,42 @@ func TestVagaRepository_ListByOrgaoParceiro_FindError(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Equal(t, 0, total)
 	assert.Contains(t, err.Error(), "erro ao listar vagas por órgão parceiro")
+}
+
+func TestVagaRepository_UpdateWithAssociations_IncludesCriteriosElegibilidadeColumns(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	idadeMin := 18
+	idadeMax := 65
+	escolaridadeID := uuid.New()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                         uuid.New(),
+		Titulo:                     "Desenvolvedor Go",
+		Descricao:                  "Vaga para desenvolvedor Go",
+		IDContratante:              "12345678000190",
+		IDRegimeContratacao:        uuid.New(),
+		IDModeloTrabalho:           uuid.New(),
+		Status:                     empregabilidade.StatusVagaEmEdicao,
+		IdadeMinima:                &idadeMin,
+		IdadeMaxima:                &idadeMax,
+		BairrosElegibilidade:       []string{"Centro"},
+		IDEscolaridadeMinima:       &escolaridadeID,
+		AreasFormacaoElegibilidade: []string{"Tecnologia"},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`(?s)UPDATE "emp_vagas" SET.*"areas_formacao_elegibilidade".*"bairros_elegibilidade".*"id_escolaridade_minima".*"idade_maxima".*"idade_minima".*WHERE`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.UpdateWithAssociations(ctx, vaga)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestVagaRepository_UpdateWithAssociations_UpdateError(t *testing.T) {
@@ -1305,6 +1569,45 @@ func TestVagaRepository_UpdateTiposPCD_InsertError(t *testing.T) {
 	err := repo.UpdateTiposPCD(ctx, vagaID, []uuid.UUID{tipoPCDID})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "erro ao inserir tipo PCD")
+}
+
+func TestVagaRepository_UpdateZonas_DeleteError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_zonas`).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	err := repo.UpdateZonas(ctx, vagaID, []uuid.UUID{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "erro ao remover zonas")
+}
+
+func TestVagaRepository_UpdateZonas_InsertError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+	vagaID := uuid.New()
+	zonaID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM emp_vagas_zonas`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`INSERT INTO emp_vagas_zonas`).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	err := repo.UpdateZonas(ctx, vagaID, []uuid.UUID{zonaID})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "erro ao inserir zona")
 }
 
 // ==================== Multi-Select Filter Query Generation Tests ====================

--- a/internal/repository/empregabilidade/zona_repository.go
+++ b/internal/repository/empregabilidade/zona_repository.go
@@ -1,0 +1,75 @@
+package empregabilidade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+)
+
+type ZonaRepository struct {
+	db *gorm.DB
+}
+
+func NewZonaRepository(db *gorm.DB) *ZonaRepository {
+	return &ZonaRepository{db: db}
+}
+
+func (r *ZonaRepository) Create(ctx context.Context, entity *empregabilidade.Zona) (uuid.UUID, error) {
+	result := r.db.WithContext(ctx).Create(entity)
+	if result.Error != nil {
+		return uuid.Nil, fmt.Errorf("erro ao criar zona: %w", result.Error)
+	}
+	return entity.ID, nil
+}
+
+func (r *ZonaRepository) GetByID(ctx context.Context, id uuid.UUID) (*empregabilidade.Zona, error) {
+	var entity empregabilidade.Zona
+	result := r.db.WithContext(ctx).First(&entity, "id = ?", id)
+	if result.Error != nil {
+		if result.Error == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("erro ao buscar zona: %w", result.Error)
+	}
+	return &entity, nil
+}
+
+func (r *ZonaRepository) Update(ctx context.Context, entity *empregabilidade.Zona) error {
+	result := r.db.WithContext(ctx).Model(entity).Where("id = ?", entity.ID).Updates(entity)
+	if result.Error != nil {
+		return fmt.Errorf("erro ao atualizar zona: %w", result.Error)
+	}
+	return nil
+}
+
+func (r *ZonaRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	result := r.db.WithContext(ctx).Delete(&empregabilidade.Zona{}, "id = ?", id)
+	if result.Error != nil {
+		return fmt.Errorf("erro ao excluir zona: %w", result.Error)
+	}
+	return nil
+}
+
+func (r *ZonaRepository) List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.Zona, int, error) {
+	var entities []*empregabilidade.Zona
+	var total int64
+
+	db := r.db.WithContext(ctx).Model(&empregabilidade.Zona{})
+
+	for key, value := range filter {
+		db = db.Where(key+" = ?", value)
+	}
+
+	db.Count(&total)
+
+	result := db.Order("descricao ASC").Limit(limit).Offset(offset).Find(&entities)
+	if result.Error != nil {
+		return nil, 0, fmt.Errorf("erro ao listar zonas: %w", result.Error)
+	}
+
+	return entities, int(total), nil
+}

--- a/internal/repository/empregabilidade/zona_repository_test.go
+++ b/internal/repository/empregabilidade/zona_repository_test.go
@@ -14,21 +14,21 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestEscolaridadeRepository_Create(t *testing.T) {
+func TestZonaRepository_Create(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	entity := &empregabilidade.Escolaridade{
+	entity := &empregabilidade.Zona{
 		ID:        uuid.New(),
-		Descricao: "Superior Completo",
+		Descricao: "Zona Norte",
 	}
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_escolaridades"`)).
-		WithArgs(entity.Descricao, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_zonas"`)).
+		WithArgs(entity.Descricao, sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(entity.ID))
 	mock.ExpectCommit()
 
@@ -39,21 +39,21 @@ func TestEscolaridadeRepository_Create(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_Create_Error(t *testing.T) {
+func TestZonaRepository_Create_Error(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	entity := &empregabilidade.Escolaridade{
+	entity := &empregabilidade.Zona{
 		ID:        uuid.New(),
-		Descricao: "Ensino Médio",
+		Descricao: "Zona Sul",
 	}
 
 	mock.ExpectBegin()
-	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_escolaridades"`)).
-		WithArgs(entity.Descricao, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "emp_zonas"`)).
+		WithArgs(entity.Descricao, sqlmock.AnyArg(), sqlmock.AnyArg(), entity.ID).
 		WillReturnError(errors.New("database error"))
 	mock.ExpectRollback()
 
@@ -61,27 +61,27 @@ func TestEscolaridadeRepository_Create_Error(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, uuid.Nil, id)
-	assert.Contains(t, err.Error(), "erro ao criar escolaridade")
+	assert.Contains(t, err.Error(), "erro ao criar zona")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_GetByID(t *testing.T) {
+func TestZonaRepository_GetByID(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	id := uuid.New()
-	expectedEntity := &empregabilidade.Escolaridade{
+	expectedEntity := &empregabilidade.Zona{
 		ID:        id,
-		Descricao: "Ensino Fundamental",
+		Descricao: "Zona Oeste",
 	}
 
 	rows := sqlmock.NewRows([]string{"id", "descricao"}).
 		AddRow(expectedEntity.ID, expectedEntity.Descricao)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas"`)).
 		WithArgs(id, 1).
 		WillReturnRows(rows)
 
@@ -94,16 +94,16 @@ func TestEscolaridadeRepository_GetByID(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_GetByID_NotFound(t *testing.T) {
+func TestZonaRepository_GetByID_NotFound(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	id := uuid.New()
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas"`)).
 		WithArgs(id, 1).
 		WillReturnError(gorm.ErrRecordNotFound)
 
@@ -114,16 +114,16 @@ func TestEscolaridadeRepository_GetByID_NotFound(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_GetByID_Error(t *testing.T) {
+func TestZonaRepository_GetByID_Error(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	id := uuid.New()
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas"`)).
 		WithArgs(id, 1).
 		WillReturnError(errors.New("database error"))
 
@@ -131,24 +131,24 @@ func TestEscolaridadeRepository_GetByID_Error(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "erro ao buscar escolaridade")
+	assert.Contains(t, err.Error(), "erro ao buscar zona")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_Update(t *testing.T) {
+func TestZonaRepository_Update(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	entity := &empregabilidade.Escolaridade{
+	entity := &empregabilidade.Zona{
 		ID:        uuid.New(),
-		Descricao: "Pós-Graduação",
+		Descricao: "Centro",
 	}
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "emp_escolaridades"`)).
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "emp_zonas"`)).
 		WithArgs(entity.Descricao, sqlmock.AnyArg(), entity.ID, entity.ID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
@@ -159,20 +159,20 @@ func TestEscolaridadeRepository_Update(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_Update_Error(t *testing.T) {
+func TestZonaRepository_Update_Error(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	entity := &empregabilidade.Escolaridade{
+	entity := &empregabilidade.Zona{
 		ID:        uuid.New(),
-		Descricao: "Mestrado",
+		Descricao: "Zona Norte",
 	}
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "emp_escolaridades"`)).
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "emp_zonas"`)).
 		WithArgs(entity.Descricao, sqlmock.AnyArg(), entity.ID, entity.ID).
 		WillReturnError(errors.New("database error"))
 	mock.ExpectRollback()
@@ -180,21 +180,21 @@ func TestEscolaridadeRepository_Update_Error(t *testing.T) {
 	err := repo.Update(ctx, entity)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "erro ao atualizar escolaridade")
+	assert.Contains(t, err.Error(), "erro ao atualizar zona")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_Delete(t *testing.T) {
+func TestZonaRepository_Delete(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	id := uuid.New()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "emp_escolaridades"`)).
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "emp_zonas"`)).
 		WithArgs(id).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
@@ -205,17 +205,17 @@ func TestEscolaridadeRepository_Delete(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_Delete_Error(t *testing.T) {
+func TestZonaRepository_Delete_Error(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	id := uuid.New()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "emp_escolaridades"`)).
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "emp_zonas"`)).
 		WithArgs(id).
 		WillReturnError(errors.New("database error"))
 	mock.ExpectRollback()
@@ -223,21 +223,22 @@ func TestEscolaridadeRepository_Delete_Error(t *testing.T) {
 	err := repo.Delete(ctx, id)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "erro ao excluir escolaridade")
+	assert.Contains(t, err.Error(), "erro ao excluir zona")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_List(t *testing.T) {
+func TestZonaRepository_List(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	expectedEntities := []*empregabilidade.Escolaridade{
-		{ID: uuid.New(), Descricao: "Ensino Fundamental"},
-		{ID: uuid.New(), Descricao: "Ensino Médio"},
-		{ID: uuid.New(), Descricao: "Superior Completo"},
+	expectedEntities := []*empregabilidade.Zona{
+		{ID: uuid.New(), Descricao: "Centro"},
+		{ID: uuid.New(), Descricao: "Zona Norte"},
+		{ID: uuid.New(), Descricao: "Zona Oeste"},
+		{ID: uuid.New(), Descricao: "Zona Sul"},
 	}
 
 	rows := sqlmock.NewRows([]string{"id", "descricao"})
@@ -245,31 +246,31 @@ func TestEscolaridadeRepository_List(t *testing.T) {
 		rows.AddRow(e.ID, e.Descricao)
 	}
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_escolaridades"`)).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_zonas"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(4))
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas"`)).
 		WillReturnRows(rows)
 
 	results, total, err := repo.List(ctx, map[string]interface{}{}, 10, 0)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 3, total)
-	assert.Len(t, results, 3)
+	assert.Equal(t, 4, total)
+	assert.Len(t, results, 4)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_List_Empty(t *testing.T) {
+func TestZonaRepository_List_Empty(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_zonas"`)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas"`)).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "descricao"}))
 
 	results, total, err := repo.List(ctx, map[string]interface{}{}, 10, 0)
@@ -280,30 +281,30 @@ func TestEscolaridadeRepository_List_Empty(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_List_WithFilter(t *testing.T) {
+func TestZonaRepository_List_WithFilter(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	filter := map[string]interface{}{
-		"descricao": "Superior Completo",
+		"descricao": "Centro",
 	}
 
-	expectedEntity := &empregabilidade.Escolaridade{
+	expectedEntity := &empregabilidade.Zona{
 		ID:        uuid.New(),
-		Descricao: "Superior Completo",
+		Descricao: "Centro",
 	}
 
 	rows := sqlmock.NewRows([]string{"id", "descricao"}).
 		AddRow(expectedEntity.ID, expectedEntity.Descricao)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_escolaridades" WHERE descricao = $1`)).
-		WithArgs("Superior Completo").
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_zonas" WHERE descricao = $1`)).
+		WithArgs("Centro").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades" WHERE descricao = $1 ORDER BY descricao ASC LIMIT`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas" WHERE descricao = $1 ORDER BY descricao ASC LIMIT`)).
 		WillReturnRows(rows)
 
 	results, total, err := repo.List(ctx, filter, 10, 0)
@@ -315,31 +316,30 @@ func TestEscolaridadeRepository_List_WithFilter(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_List_WithPagination(t *testing.T) {
+func TestZonaRepository_List_WithPagination(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
 	limit := 2
 	offset := 1
 
-	allEntities := []*empregabilidade.Escolaridade{
-		{ID: uuid.New(), Descricao: "Ensino Fundamental"},
-		{ID: uuid.New(), Descricao: "Ensino Médio"},
-		{ID: uuid.New(), Descricao: "Superior Completo"},
+	allEntities := []*empregabilidade.Zona{
+		{ID: uuid.New(), Descricao: "Centro"},
+		{ID: uuid.New(), Descricao: "Zona Norte"},
+		{ID: uuid.New(), Descricao: "Zona Oeste"},
 	}
 
-	// Return page 2 (offset 1, limit 2)
 	rows := sqlmock.NewRows([]string{"id", "descricao"}).
 		AddRow(allEntities[1].ID, allEntities[1].Descricao).
 		AddRow(allEntities[2].ID, allEntities[2].Descricao)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_zonas"`)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades" ORDER BY descricao ASC LIMIT`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas" ORDER BY descricao ASC LIMIT`)).
 		WillReturnRows(rows)
 
 	results, total, err := repo.List(ctx, map[string]interface{}{}, limit, offset)
@@ -350,23 +350,23 @@ func TestEscolaridadeRepository_List_WithPagination(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestEscolaridadeRepository_List_Error(t *testing.T) {
+func TestZonaRepository_List_Error(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()
 
-	repo := NewEscolaridadeRepository(db)
+	repo := NewZonaRepository(db)
 	ctx := context.Background()
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "emp_zonas"`)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_escolaridades"`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "emp_zonas"`)).
 		WillReturnError(errors.New("database error"))
 
 	results, total, err := repo.List(ctx, map[string]interface{}{}, 10, 0)
 
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "erro ao listar escolaridades")
+	assert.Contains(t, err.Error(), "erro ao listar zonas")
 	assert.Equal(t, 0, total)
 	assert.Nil(t, results)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/internal/router/routes_emp.go
+++ b/internal/router/routes_emp.go
@@ -21,6 +21,7 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 	registerLookup(emp.Group("/tipos-conquista"), app.EmpTipoConquistaHandler)
 	registerLookup(emp.Group("/situacoes-atual"), app.EmpSituacaoAtualHandler)
 	registerLookup(emp.Group("/disponibilidades"), app.EmpDisponibilidadeHandler)
+	registerLookup(emp.Group("/zonas"), app.EmpZonaHandler)
 
 	// Empresas
 	empEmpresas := emp.Group("/empresas")
@@ -66,6 +67,8 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		empVagas.PUT("/:id/discontinue", vagaAuth, app.EmpVagaHandler.Discontinue)
 		empVagas.PUT("/:id/reactivate", vagaAuth, app.EmpVagaHandler.Reactivate)
 		empVagas.PUT("/:id/tipos-pcd", vagaAuth, app.EmpVagaHandler.UpdateTiposPCD)
+		empVagas.PUT("/:id/zonas", vagaAuth, app.EmpVagaHandler.UpdateZonas)
+		empVagas.PUT("/:id/idiomas-requisito", vagaAuth, app.EmpVagaHandler.UpdateIdiomasRequisito)
 		empVagas.POST("/:id/etapas", vagaAuth, app.EmpEtapaHandler.Create)
 		empVagas.GET("/:id/etapas", app.EmpEtapaHandler.ListByVaga)
 		empVagas.GET("/:id/etapas/:etapaId", app.EmpEtapaHandler.GetByID)
@@ -88,6 +91,13 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		empCandidaturas.PUT("/:id/approve", vagaAuth, app.EmpCandidaturaHandler.Approve)
 		empCandidaturas.PUT("/:id/reject", vagaAuth, app.EmpCandidaturaHandler.Reject)
 		empCandidaturas.PUT("/:id/etapa", vagaAuth, app.EmpCandidaturaHandler.UpdateEtapa)
+	}
+
+	// Candidatura Bloqueios (tentativas de candidatura bloqueadas por critérios de elegibilidade)
+	empCandidaturaBloqueios := emp.Group("/candidatura-bloqueios")
+	{
+		empCandidaturaBloqueios.POST("", app.EmpCandidaturaBloqueioHandler.Create)
+		empCandidaturaBloqueios.GET("", vagaAuth, app.EmpCandidaturaBloqueioHandler.List)
 	}
 
 	// Curriculo

--- a/internal/services/empregabilidade/candidatura_bloqueio_service.go
+++ b/internal/services/empregabilidade/candidatura_bloqueio_service.go
@@ -1,0 +1,30 @@
+package empregabilidade
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	repository "github.com/prefeitura-rio/app-go-api/internal/repository/empregabilidade"
+)
+
+type CandidaturaBloqueioService struct {
+	repo CandidaturaBloqueioRepositoryInterface
+}
+
+func NewCandidaturaBloqueioService(repo *repository.CandidaturaBloqueioRepository) *CandidaturaBloqueioService {
+	return &CandidaturaBloqueioService{repo: repo}
+}
+
+func NewCandidaturaBloqueioServiceWithInterface(repo CandidaturaBloqueioRepositoryInterface) *CandidaturaBloqueioService {
+	return &CandidaturaBloqueioService{repo: repo}
+}
+
+func (s *CandidaturaBloqueioService) Create(ctx context.Context, entity *empregabilidade.CandidaturaBloqueio) (uuid.UUID, error) {
+	return s.repo.Create(ctx, entity)
+}
+
+func (s *CandidaturaBloqueioService) List(ctx context.Context, filter map[string]interface{}, page, pageSize int) ([]*empregabilidade.CandidaturaBloqueio, int, error) {
+	offset := (page - 1) * pageSize
+	return s.repo.List(ctx, filter, pageSize, offset)
+}

--- a/internal/services/empregabilidade/candidatura_bloqueio_service_test.go
+++ b/internal/services/empregabilidade/candidatura_bloqueio_service_test.go
@@ -1,0 +1,90 @@
+package empregabilidade_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	services "github.com/prefeitura-rio/app-go-api/internal/services/empregabilidade"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCandidaturaBloqueioRepository struct {
+	items     []*empregabilidade.CandidaturaBloqueio
+	total     int
+	createErr error
+	listErr   error
+}
+
+func (m *mockCandidaturaBloqueioRepository) Create(ctx context.Context, entity *empregabilidade.CandidaturaBloqueio) (uuid.UUID, error) {
+	if m.createErr != nil {
+		return uuid.Nil, m.createErr
+	}
+	return uuid.New(), nil
+}
+
+func (m *mockCandidaturaBloqueioRepository) List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.CandidaturaBloqueio, int, error) {
+	if m.listErr != nil {
+		return nil, 0, m.listErr
+	}
+	return m.items, m.total, nil
+}
+
+func TestNewCandidaturaBloqueioService(t *testing.T) {
+	mockRepo := &mockCandidaturaBloqueioRepository{}
+	service := services.NewCandidaturaBloqueioServiceWithInterface(mockRepo)
+	assert.NotNil(t, service)
+}
+
+func TestCandidaturaBloqueioService_Create(t *testing.T) {
+	mockRepo := &mockCandidaturaBloqueioRepository{}
+	service := services.NewCandidaturaBloqueioServiceWithInterface(mockRepo)
+
+	id, err := service.Create(context.Background(), &empregabilidade.CandidaturaBloqueio{
+		CPF:                   "12345678900",
+		IDVaga:                uuid.New(),
+		CriteriosNaoAtendidos: []string{"idade_minima"},
+	})
+
+	assert.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, id)
+}
+
+func TestCandidaturaBloqueioService_Create_RepoError(t *testing.T) {
+	mockRepo := &mockCandidaturaBloqueioRepository{createErr: errors.New("db error")}
+	service := services.NewCandidaturaBloqueioServiceWithInterface(mockRepo)
+
+	id, err := service.Create(context.Background(), &empregabilidade.CandidaturaBloqueio{CPF: "12345678900"})
+
+	assert.Error(t, err)
+	assert.Equal(t, uuid.Nil, id)
+}
+
+func TestCandidaturaBloqueioService_List(t *testing.T) {
+	vagaID := uuid.New()
+	mockItems := []*empregabilidade.CandidaturaBloqueio{
+		{ID: uuid.New(), CPF: "12345678900", IDVaga: vagaID},
+		{ID: uuid.New(), CPF: "98765432100", IDVaga: vagaID},
+	}
+	mockRepo := &mockCandidaturaBloqueioRepository{items: mockItems, total: 2}
+	service := services.NewCandidaturaBloqueioServiceWithInterface(mockRepo)
+
+	items, total, err := service.List(context.Background(), nil, 1, 10)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, items, 2)
+}
+
+func TestCandidaturaBloqueioService_List_RepoError(t *testing.T) {
+	mockRepo := &mockCandidaturaBloqueioRepository{listErr: errors.New("db error")}
+	service := services.NewCandidaturaBloqueioServiceWithInterface(mockRepo)
+
+	items, total, err := service.List(context.Background(), nil, 1, 10)
+
+	assert.Error(t, err)
+	assert.Equal(t, 0, total)
+	assert.Nil(t, items)
+}

--- a/internal/services/empregabilidade/interfaces.go
+++ b/internal/services/empregabilidade/interfaces.go
@@ -61,6 +61,21 @@ type EmpEscolaridadeRepositoryInterface interface {
 	List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.Escolaridade, int, error)
 }
 
+// ZonaRepositoryInterface defines the interface for Zona repository.
+type ZonaRepositoryInterface interface {
+	Create(ctx context.Context, entity *empregabilidade.Zona) (uuid.UUID, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*empregabilidade.Zona, error)
+	Update(ctx context.Context, entity *empregabilidade.Zona) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.Zona, int, error)
+}
+
+// CandidaturaBloqueioRepositoryInterface defines the interface for CandidaturaBloqueio repository.
+type CandidaturaBloqueioRepositoryInterface interface {
+	Create(ctx context.Context, entity *empregabilidade.CandidaturaBloqueio) (uuid.UUID, error)
+	List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.CandidaturaBloqueio, int, error)
+}
+
 // TipoConquistaRepositoryInterface defines the interface for TipoConquista repository.
 type TipoConquistaRepositoryInterface interface {
 	Create(ctx context.Context, entity *empregabilidade.TipoConquista) (uuid.UUID, error)

--- a/internal/services/empregabilidade/vaga_service.go
+++ b/internal/services/empregabilidade/vaga_service.go
@@ -22,6 +22,8 @@ type VagaRepoInterface interface {
 	ListPublicActive(ctx context.Context, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	ListPublic(ctx context.Context, filter empregabilidade.VagaPublicFilter, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, tiposPCDIDs []uuid.UUID) error
+	UpdateZonas(ctx context.Context, vagaID uuid.UUID, zonaIDs []uuid.UUID) error
+	UpdateIdiomasRequisito(ctx context.Context, vagaID uuid.UUID, requisitos []empregabilidade.VagaIdiomaRequisito) error
 	ListByContratante(ctx context.Context, cnpj string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 	ListByOrgaoParceiro(ctx context.Context, orgaoID string, limit, offset int) ([]*empregabilidade.Vaga, int, error)
 }
@@ -196,6 +198,14 @@ func (s *VagaService) ListPublic(ctx context.Context, filter empregabilidade.Vag
 
 func (s *VagaService) UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, tiposPCDIDs []uuid.UUID) error {
 	return s.repo.UpdateTiposPCD(ctx, vagaID, tiposPCDIDs)
+}
+
+func (s *VagaService) UpdateZonas(ctx context.Context, vagaID uuid.UUID, zonaIDs []uuid.UUID) error {
+	return s.repo.UpdateZonas(ctx, vagaID, zonaIDs)
+}
+
+func (s *VagaService) UpdateIdiomasRequisito(ctx context.Context, vagaID uuid.UUID, requisitos []empregabilidade.VagaIdiomaRequisito) error {
+	return s.repo.UpdateIdiomasRequisito(ctx, vagaID, requisitos)
 }
 
 func (s *VagaService) ListByContratante(ctx context.Context, cnpj string, page, pageSize int) ([]*empregabilidade.Vaga, int, error) {

--- a/internal/services/empregabilidade/vaga_service_test.go
+++ b/internal/services/empregabilidade/vaga_service_test.go
@@ -22,12 +22,26 @@ func TestNewVagaService(t *testing.T) {
 
 // Mock Vaga Repository for VagaService tests
 type MockVagaRepoForService struct {
-	vagas       map[uuid.UUID]*empregabilidade.Vaga
-	createError error
-	getError    error
-	updateError error
-	deleteError error
-	listError   error
+	vagas                       map[uuid.UUID]*empregabilidade.Vaga
+	createError                 error
+	getError                    error
+	updateError                 error
+	deleteError                 error
+	listError                   error
+	updateZonasError            error
+	updateZonasCalls            []updateZonasCall
+	updateIdiomasRequisitoError error
+	updateIdiomasRequisitoCalls []updateIdiomasRequisitoCall
+}
+
+type updateZonasCall struct {
+	vagaID  uuid.UUID
+	zonaIDs []uuid.UUID
+}
+
+type updateIdiomasRequisitoCall struct {
+	vagaID     uuid.UUID
+	requisitos []empregabilidade.VagaIdiomaRequisito
 }
 
 func NewMockVagaRepoForService() *MockVagaRepoForService {
@@ -106,6 +120,22 @@ func (m *MockVagaRepoForService) List(ctx context.Context, filter empregabilidad
 }
 
 func (m *MockVagaRepoForService) UpdateTiposPCD(ctx context.Context, vagaID uuid.UUID, tiposPCDIDs []uuid.UUID) error {
+	return nil
+}
+
+func (m *MockVagaRepoForService) UpdateZonas(ctx context.Context, vagaID uuid.UUID, zonaIDs []uuid.UUID) error {
+	m.updateZonasCalls = append(m.updateZonasCalls, updateZonasCall{vagaID: vagaID, zonaIDs: zonaIDs})
+	if m.updateZonasError != nil {
+		return m.updateZonasError
+	}
+	return nil
+}
+
+func (m *MockVagaRepoForService) UpdateIdiomasRequisito(ctx context.Context, vagaID uuid.UUID, requisitos []empregabilidade.VagaIdiomaRequisito) error {
+	m.updateIdiomasRequisitoCalls = append(m.updateIdiomasRequisitoCalls, updateIdiomasRequisitoCall{vagaID: vagaID, requisitos: requisitos})
+	if m.updateIdiomasRequisitoError != nil {
+		return m.updateIdiomasRequisitoError
+	}
 	return nil
 }
 
@@ -1457,6 +1487,58 @@ func TestVagaService_ListByOrgaoParceiro_RepoError(t *testing.T) {
 	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
 
 	_, _, err := service.ListByOrgaoParceiro(context.Background(), "ORG-001", 1, 10)
+
+	assert.Error(t, err)
+}
+
+func TestVagaService_UpdateZonas_Success(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagaID := uuid.New()
+	zonaID := uuid.New()
+
+	err := service.UpdateZonas(context.Background(), vagaID, []uuid.UUID{zonaID})
+
+	assert.NoError(t, err)
+	assert.Len(t, mockVagaRepo.updateZonasCalls, 1)
+	assert.Equal(t, vagaID, mockVagaRepo.updateZonasCalls[0].vagaID)
+	assert.Equal(t, []uuid.UUID{zonaID}, mockVagaRepo.updateZonasCalls[0].zonaIDs)
+}
+
+func TestVagaService_UpdateZonas_RepoError(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	mockVagaRepo.updateZonasError = errors.New("db error")
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	err := service.UpdateZonas(context.Background(), uuid.New(), []uuid.UUID{})
+
+	assert.Error(t, err)
+}
+
+func TestVagaService_UpdateIdiomasRequisito_Success(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	vagaID := uuid.New()
+	requisitos := []empregabilidade.VagaIdiomaRequisito{
+		{IDIdioma: uuid.New(), IDNivelMinimo: uuid.New()},
+	}
+
+	err := service.UpdateIdiomasRequisito(context.Background(), vagaID, requisitos)
+
+	assert.NoError(t, err)
+	assert.Len(t, mockVagaRepo.updateIdiomasRequisitoCalls, 1)
+	assert.Equal(t, vagaID, mockVagaRepo.updateIdiomasRequisitoCalls[0].vagaID)
+	assert.Equal(t, requisitos, mockVagaRepo.updateIdiomasRequisitoCalls[0].requisitos)
+}
+
+func TestVagaService_UpdateIdiomasRequisito_RepoError(t *testing.T) {
+	mockVagaRepo := NewMockVagaRepoForService()
+	mockVagaRepo.updateIdiomasRequisitoError = errors.New("db error")
+	service := services.NewVagaServiceWithInterfaces(mockVagaRepo, NewMockEmpresaRepoForService(), nil)
+
+	err := service.UpdateIdiomasRequisito(context.Background(), uuid.New(), []empregabilidade.VagaIdiomaRequisito{})
 
 	assert.Error(t, err)
 }

--- a/internal/services/empregabilidade/zona_service.go
+++ b/internal/services/empregabilidade/zona_service.go
@@ -1,0 +1,42 @@
+package empregabilidade
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	repository "github.com/prefeitura-rio/app-go-api/internal/repository/empregabilidade"
+)
+
+type ZonaService struct {
+	repo ZonaRepositoryInterface
+}
+
+func NewZonaService(repo *repository.ZonaRepository) *ZonaService {
+	return &ZonaService{repo: repo}
+}
+
+func NewZonaServiceWithInterface(repo ZonaRepositoryInterface) *ZonaService {
+	return &ZonaService{repo: repo}
+}
+
+func (s *ZonaService) Create(ctx context.Context, entity *empregabilidade.Zona) (uuid.UUID, error) {
+	return s.repo.Create(ctx, entity)
+}
+
+func (s *ZonaService) GetByID(ctx context.Context, id uuid.UUID) (*empregabilidade.Zona, error) {
+	return s.repo.GetByID(ctx, id)
+}
+
+func (s *ZonaService) Update(ctx context.Context, entity *empregabilidade.Zona) error {
+	return s.repo.Update(ctx, entity)
+}
+
+func (s *ZonaService) Delete(ctx context.Context, id uuid.UUID) error {
+	return s.repo.Delete(ctx, id)
+}
+
+func (s *ZonaService) List(ctx context.Context, filter map[string]interface{}, page, pageSize int) ([]*empregabilidade.Zona, int, error) {
+	offset := (page - 1) * pageSize
+	return s.repo.List(ctx, filter, pageSize, offset)
+}

--- a/internal/services/empregabilidade/zona_service_test.go
+++ b/internal/services/empregabilidade/zona_service_test.go
@@ -1,0 +1,114 @@
+package empregabilidade_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prefeitura-rio/app-go-api/internal/models/empregabilidade"
+	services "github.com/prefeitura-rio/app-go-api/internal/services/empregabilidade"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockZonaRepository struct {
+	items []*empregabilidade.Zona
+	total int
+}
+
+func (m *mockZonaRepository) Create(ctx context.Context, entity *empregabilidade.Zona) (uuid.UUID, error) {
+	return uuid.New(), nil
+}
+
+func (m *mockZonaRepository) GetByID(ctx context.Context, id uuid.UUID) (*empregabilidade.Zona, error) {
+	for _, item := range m.items {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockZonaRepository) Update(ctx context.Context, entity *empregabilidade.Zona) error {
+	return nil
+}
+
+func (m *mockZonaRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
+func (m *mockZonaRepository) List(ctx context.Context, filter map[string]interface{}, limit, offset int) ([]*empregabilidade.Zona, int, error) {
+	return m.items, m.total, nil
+}
+
+func TestNewZonaService(t *testing.T) {
+	mockRepo := &mockZonaRepository{}
+	service := services.NewZonaServiceWithInterface(mockRepo)
+	assert.NotNil(t, service)
+}
+
+func TestZonaService_List(t *testing.T) {
+	id1 := uuid.New()
+	id2 := uuid.New()
+	mockItems := []*empregabilidade.Zona{
+		{ID: id1, Descricao: "Centro", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: id2, Descricao: "Zona Sul", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+
+	mockRepo := &mockZonaRepository{
+		items: mockItems,
+		total: 2,
+	}
+	service := services.NewZonaServiceWithInterface(mockRepo)
+
+	items, total, err := service.List(context.Background(), nil, 1, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, items, 2)
+	assert.Equal(t, "Centro", items[0].Descricao)
+	assert.Equal(t, "Zona Sul", items[1].Descricao)
+}
+
+func TestZonaService_GetByID(t *testing.T) {
+	id := uuid.New()
+	mockItems := []*empregabilidade.Zona{
+		{ID: id, Descricao: "Zona Oeste", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+
+	mockRepo := &mockZonaRepository{
+		items: mockItems,
+		total: 1,
+	}
+	service := services.NewZonaServiceWithInterface(mockRepo)
+
+	item, err := service.GetByID(context.Background(), id)
+	assert.NoError(t, err)
+	assert.NotNil(t, item)
+	assert.Equal(t, id, item.ID)
+	assert.Equal(t, "Zona Oeste", item.Descricao)
+}
+
+func TestZonaService_Create(t *testing.T) {
+	mockRepo := &mockZonaRepository{}
+	service := services.NewZonaServiceWithInterface(mockRepo)
+
+	id, err := service.Create(context.Background(), &empregabilidade.Zona{Descricao: "Zona Norte"})
+	assert.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, id)
+}
+
+func TestZonaService_Update(t *testing.T) {
+	mockRepo := &mockZonaRepository{}
+	service := services.NewZonaServiceWithInterface(mockRepo)
+
+	err := service.Update(context.Background(), &empregabilidade.Zona{ID: uuid.New(), Descricao: "Centro"})
+	assert.NoError(t, err)
+}
+
+func TestZonaService_Delete(t *testing.T) {
+	mockRepo := &mockZonaRepository{}
+	service := services.NewZonaServiceWithInterface(mockRepo)
+
+	err := service.Delete(context.Background(), uuid.New())
+	assert.NoError(t, err)
+}

--- a/internal/wire/providers/handlers_emp.go
+++ b/internal/wire/providers/handlers_emp.go
@@ -84,3 +84,13 @@ func ProvideEmpOnboardingHandler(service *empServices.OnboardingService) *empHan
 func ProvideEmpTermosUsoHandler(service *empServices.TermosUsoService) *empHandlers.TermosUsoHandler {
 	return empHandlers.NewTermosUsoHandler(service)
 }
+
+// ProvideEmpZonaHandler creates empregabilidade ZonaHandler
+func ProvideEmpZonaHandler(service *empServices.ZonaService) *empHandlers.ZonaHandler {
+	return empHandlers.NewZonaHandler(service)
+}
+
+// ProvideEmpCandidaturaBloqueioHandler creates empregabilidade CandidaturaBloqueioHandler
+func ProvideEmpCandidaturaBloqueioHandler(service *empServices.CandidaturaBloqueioService) *empHandlers.CandidaturaBloqueioHandler {
+	return empHandlers.NewCandidaturaBloqueioHandler(service)
+}

--- a/internal/wire/providers/repositories_emp.go
+++ b/internal/wire/providers/repositories_emp.go
@@ -90,3 +90,13 @@ func ProvideEmpTermosUsoRepository(db *gorm.DB) *empRepository.TermosUsoReposito
 func ProvideEmpInformacaoComplementarRepository(db *gorm.DB) *empRepository.InformacaoComplementarRepository {
 	return empRepository.NewInformacaoComplementarRepository(db)
 }
+
+// ProvideEmpZonaRepository creates empregabilidade ZonaRepository
+func ProvideEmpZonaRepository(db *gorm.DB) *empRepository.ZonaRepository {
+	return empRepository.NewZonaRepository(db)
+}
+
+// ProvideEmpCandidaturaBloqueioRepository creates empregabilidade CandidaturaBloqueioRepository
+func ProvideEmpCandidaturaBloqueioRepository(db *gorm.DB) *empRepository.CandidaturaBloqueioRepository {
+	return empRepository.NewCandidaturaBloqueioRepository(db)
+}

--- a/internal/wire/providers/services_emp.go
+++ b/internal/wire/providers/services_emp.go
@@ -102,6 +102,16 @@ func ProvideEmpTermosUsoService(repo *empRepository.TermosUsoRepository) *empSer
 	return empServices.NewTermosUsoService(repo)
 }
 
+// ProvideEmpZonaService creates empregabilidade ZonaService
+func ProvideEmpZonaService(repo *empRepository.ZonaRepository) *empServices.ZonaService {
+	return empServices.NewZonaService(repo)
+}
+
+// ProvideEmpCandidaturaBloqueioService creates empregabilidade CandidaturaBloqueioService
+func ProvideEmpCandidaturaBloqueioService(repo *empRepository.CandidaturaBloqueioRepository) *empServices.CandidaturaBloqueioService {
+	return empServices.NewCandidaturaBloqueioService(repo)
+}
+
 // ProvideEmpCNPJConsultaService creates empregabilidade CNPJConsultaService.
 // Returns nil when the token manager is not configured (Keycloak not set up).
 func ProvideEmpCNPJConsultaService(rmiClient *clients.RMIClient, tokenManager *auth.ServiceAccountTokenManager) *empServices.CNPJConsultaService {

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -54,22 +54,24 @@ type ApplicationContainer struct {
 	CitizenSnapshotRepo *repository.CitizenSnapshotRepository
 
 	// Empregabilidade Repositories
-	EmpRegimeContratacaoRepo *empRepository.RegimeContratacaoRepository
-	EmpModeloTrabalhoRepo    *empRepository.ModeloTrabalhoRepository
-	EmpTipoPCDRepo           *empRepository.TipoPCDRepository
-	EmpIdiomaRepo            *empRepository.IdiomaRepository
-	EmpNivelIdiomaRepo       *empRepository.NivelIdiomaRepository
-	EmpEscolaridadeRepo      *empRepository.EscolaridadeRepository
-	EmpTipoConquistaRepo     *empRepository.TipoConquistaRepository
-	EmpSituacaoAtualRepo     *empRepository.SituacaoAtualRepository
-	EmpDisponibilidadeRepo   *empRepository.DisponibilidadeRepository
-	EmpEmpresaRepo           *empRepository.EmpresaRepository
-	EmpVagaRepo              *empRepository.VagaRepository
-	EmpEtapaRepo             *empRepository.EtapaRepository
-	EmpCandidaturaRepo       *empRepository.CandidaturaRepository
-	EmpCurriculoRepo         *empRepository.CurriculoRepository
-	EmpOnboardingRepo        *empRepository.OnboardingRepository
-	EmpTermosUsoRepo         *empRepository.TermosUsoRepository
+	EmpRegimeContratacaoRepo   *empRepository.RegimeContratacaoRepository
+	EmpModeloTrabalhoRepo      *empRepository.ModeloTrabalhoRepository
+	EmpTipoPCDRepo             *empRepository.TipoPCDRepository
+	EmpIdiomaRepo              *empRepository.IdiomaRepository
+	EmpNivelIdiomaRepo         *empRepository.NivelIdiomaRepository
+	EmpEscolaridadeRepo        *empRepository.EscolaridadeRepository
+	EmpTipoConquistaRepo       *empRepository.TipoConquistaRepository
+	EmpSituacaoAtualRepo       *empRepository.SituacaoAtualRepository
+	EmpDisponibilidadeRepo     *empRepository.DisponibilidadeRepository
+	EmpEmpresaRepo             *empRepository.EmpresaRepository
+	EmpVagaRepo                *empRepository.VagaRepository
+	EmpEtapaRepo               *empRepository.EtapaRepository
+	EmpCandidaturaRepo         *empRepository.CandidaturaRepository
+	EmpCurriculoRepo           *empRepository.CurriculoRepository
+	EmpOnboardingRepo          *empRepository.OnboardingRepository
+	EmpTermosUsoRepo           *empRepository.TermosUsoRepository
+	EmpZonaRepo                *empRepository.ZonaRepository
+	EmpCandidaturaBloqueioRepo *empRepository.CandidaturaBloqueioRepository
 
 	// Core Services
 	CursoService             *services.CursoService
@@ -89,23 +91,25 @@ type ApplicationContainer struct {
 	EmailWorker              *workers.EmailWorker
 
 	// Empregabilidade Services
-	EmpRegimeContratacaoService *empServices.RegimeContratacaoService
-	EmpModeloTrabalhoService    *empServices.ModeloTrabalhoService
-	EmpTipoPCDService           *empServices.TipoPCDService
-	EmpIdiomaService            *empServices.IdiomaService
-	EmpNivelIdiomaService       *empServices.NivelIdiomaService
-	EmpEscolaridadeService      *empServices.EscolaridadeService
-	EmpTipoConquistaService     *empServices.TipoConquistaService
-	EmpSituacaoAtualService     *empServices.SituacaoAtualService
-	EmpDisponibilidadeService   *empServices.DisponibilidadeService
-	EmpEmpresaService           *empServices.EmpresaService
-	EmpVagaService              *empServices.VagaService
-	EmpEtapaService             *empServices.EtapaService
-	EmpCurriculoService         *empServices.CurriculoService
-	EmpCandidaturaService       *empServices.CandidaturaService
-	EmpOnboardingService        *empServices.OnboardingService
-	EmpTermosUsoService         *empServices.TermosUsoService
-	EmpCNPJConsultaService      *empServices.CNPJConsultaService
+	EmpRegimeContratacaoService   *empServices.RegimeContratacaoService
+	EmpModeloTrabalhoService      *empServices.ModeloTrabalhoService
+	EmpTipoPCDService             *empServices.TipoPCDService
+	EmpIdiomaService              *empServices.IdiomaService
+	EmpNivelIdiomaService         *empServices.NivelIdiomaService
+	EmpEscolaridadeService        *empServices.EscolaridadeService
+	EmpTipoConquistaService       *empServices.TipoConquistaService
+	EmpSituacaoAtualService       *empServices.SituacaoAtualService
+	EmpDisponibilidadeService     *empServices.DisponibilidadeService
+	EmpEmpresaService             *empServices.EmpresaService
+	EmpVagaService                *empServices.VagaService
+	EmpEtapaService               *empServices.EtapaService
+	EmpCurriculoService           *empServices.CurriculoService
+	EmpCandidaturaService         *empServices.CandidaturaService
+	EmpOnboardingService          *empServices.OnboardingService
+	EmpTermosUsoService           *empServices.TermosUsoService
+	EmpZonaService                *empServices.ZonaService
+	EmpCandidaturaBloqueioService *empServices.CandidaturaBloqueioService
+	EmpCNPJConsultaService        *empServices.CNPJConsultaService
 
 	// Core Handlers
 	EmpregoHandler         *v1.EmpregoHandler
@@ -122,22 +126,24 @@ type ApplicationContainer struct {
 	TypesenseHandler       *v1.TypesenseHandler
 
 	// Empregabilidade Handlers
-	EmpRegimeContratacaoHandler *empHandlers.RegimeContratacaoHandler
-	EmpModeloTrabalhoHandler    *empHandlers.ModeloTrabalhoHandler
-	EmpTipoPCDHandler           *empHandlers.TipoPCDHandler
-	EmpIdiomaHandler            *empHandlers.IdiomaHandler
-	EmpNivelIdiomaHandler       *empHandlers.NivelIdiomaHandler
-	EmpEscolaridadeHandler      *empHandlers.EscolaridadeHandler
-	EmpTipoConquistaHandler     *empHandlers.TipoConquistaHandler
-	EmpSituacaoAtualHandler     *empHandlers.SituacaoAtualHandler
-	EmpDisponibilidadeHandler   *empHandlers.DisponibilidadeHandler
-	EmpEmpresaHandler           *empHandlers.EmpresaHandler
-	EmpVagaHandler              *empHandlers.VagaHandler
-	EmpEtapaHandler             *empHandlers.EtapaHandler
-	EmpCandidaturaHandler       *empHandlers.CandidaturaHandler
-	EmpCurriculoHandler         *empHandlers.CurriculoHandler
-	EmpOnboardingHandler        *empHandlers.OnboardingHandler
-	EmpTermosUsoHandler         *empHandlers.TermosUsoHandler
+	EmpRegimeContratacaoHandler   *empHandlers.RegimeContratacaoHandler
+	EmpModeloTrabalhoHandler      *empHandlers.ModeloTrabalhoHandler
+	EmpTipoPCDHandler             *empHandlers.TipoPCDHandler
+	EmpIdiomaHandler              *empHandlers.IdiomaHandler
+	EmpNivelIdiomaHandler         *empHandlers.NivelIdiomaHandler
+	EmpEscolaridadeHandler        *empHandlers.EscolaridadeHandler
+	EmpTipoConquistaHandler       *empHandlers.TipoConquistaHandler
+	EmpSituacaoAtualHandler       *empHandlers.SituacaoAtualHandler
+	EmpDisponibilidadeHandler     *empHandlers.DisponibilidadeHandler
+	EmpEmpresaHandler             *empHandlers.EmpresaHandler
+	EmpVagaHandler                *empHandlers.VagaHandler
+	EmpEtapaHandler               *empHandlers.EtapaHandler
+	EmpCandidaturaHandler         *empHandlers.CandidaturaHandler
+	EmpCurriculoHandler           *empHandlers.CurriculoHandler
+	EmpOnboardingHandler          *empHandlers.OnboardingHandler
+	EmpTermosUsoHandler           *empHandlers.TermosUsoHandler
+	EmpZonaHandler                *empHandlers.ZonaHandler
+	EmpCandidaturaBloqueioHandler *empHandlers.CandidaturaBloqueioHandler
 }
 
 // CategoriaContainer holds wired components for Categorias proof-of-concept
@@ -200,6 +206,8 @@ var EmpRepositorySet = wire.NewSet(
 	providers.ProvideEmpCurriculoRepository,
 	providers.ProvideEmpOnboardingRepository,
 	providers.ProvideEmpTermosUsoRepository,
+	providers.ProvideEmpZonaRepository,
+	providers.ProvideEmpCandidaturaBloqueioRepository,
 )
 
 var CoreServiceSet = wire.NewSet(
@@ -239,6 +247,8 @@ var EmpServiceSet = wire.NewSet(
 	providers.ProvideEmpOnboardingService,
 	providers.ProvideEmpTermosUsoService,
 	providers.ProvideEmpCNPJConsultaService,
+	providers.ProvideEmpZonaService,
+	providers.ProvideEmpCandidaturaBloqueioService,
 )
 
 var CoreHandlerSet = wire.NewSet(
@@ -273,6 +283,8 @@ var EmpHandlerSet = wire.NewSet(
 	providers.ProvideEmpCurriculoHandler,
 	providers.ProvideEmpOnboardingHandler,
 	providers.ProvideEmpTermosUsoHandler,
+	providers.ProvideEmpZonaHandler,
+	providers.ProvideEmpCandidaturaBloqueioHandler,
 )
 
 // Legacy set kept for backward compatibility with the Categorias POC

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -85,6 +85,8 @@ func InitializeApplication(cfg *config.AppConfig) (*ApplicationContainer, error)
 	curriculoRepository := providers.ProvideEmpCurriculoRepository(db)
 	onboardingRepository := providers.ProvideEmpOnboardingRepository(db)
 	termosUsoRepository := providers.ProvideEmpTermosUsoRepository(db)
+	zonaRepository := providers.ProvideEmpZonaRepository(db)
+	candidaturaBloqueioRepository := providers.ProvideEmpCandidaturaBloqueioRepository(db)
 	cursoService := providers.ProvideCursoService(cursoRepository)
 	emailNotificationService := providers.ProvideEmailNotificationService(dataRelayClient, cursoRepository, orgaoSnapshotRepository, citizenSnapshotRepository, cfg)
 	emailWorker := providers.ProvideEmailWorker(client, emailNotificationService)
@@ -116,6 +118,8 @@ func InitializeApplication(cfg *config.AppConfig) (*ApplicationContainer, error)
 	candidaturaService := providers.ProvideEmpCandidaturaService(candidaturaRepository, vagaRepository, curriculoService, citizenSnapshotRepository, emailWorker)
 	onboardingService := providers.ProvideEmpOnboardingService(onboardingRepository)
 	termosUsoService := providers.ProvideEmpTermosUsoService(termosUsoRepository)
+	zonaService := providers.ProvideEmpZonaService(zonaRepository)
+	candidaturaBloqueioService := providers.ProvideEmpCandidaturaBloqueioService(candidaturaBloqueioRepository)
 	cnpjConsultaService := providers.ProvideEmpCNPJConsultaService(rmiClient, serviceAccountTokenManager)
 	empregoHandler := providers.ProvideEmpregoHandler(empregoService)
 	acessibilidadeHandler := providers.ProvideAcessibilidadeHandler(acessibilidadeService, referenceCaches)
@@ -145,105 +149,113 @@ func InitializeApplication(cfg *config.AppConfig) (*ApplicationContainer, error)
 	curriculoHandler := providers.ProvideEmpCurriculoHandler(curriculoService)
 	onboardingHandler := providers.ProvideEmpOnboardingHandler(onboardingService)
 	termosUsoHandler := providers.ProvideEmpTermosUsoHandler(termosUsoService)
+	zonaHandler := providers.ProvideEmpZonaHandler(zonaService)
+	candidaturaBloqueioHandler := providers.ProvideEmpCandidaturaBloqueioHandler(candidaturaBloqueioService)
 	applicationContainer := &ApplicationContainer{
-		DB:                          db,
-		Config:                      cfg,
-		RedisClient:                 client,
-		RMIClient:                   rmiClient,
-		TokenManager:                serviceAccountTokenManager,
-		DataRelayClient:             dataRelayClient,
-		ReferenceCaches:             referenceCaches,
-		LegalEntitiesCache:          legalEntitiesCache,
-		CourseCache:                 courseCache,
-		CursoRepo:                   cursoRepository,
-		InscricaoRepo:               inscricaoRepository,
-		EmpregoRepo:                 empregoRepository,
-		AcessibilidadeRepo:          acessibilidadeRepository,
-		CategoriaRepo:               categoriaRepositoryInterface,
-		EscolaridadeRepo:            escolaridadeRepository,
-		EmpresaRepo:                 empresaRepository,
-		InstituicaoRepo:             instituicaoRepository,
-		JobRepo:                     jobRepository,
-		OportunidadeMEIRepo:         oportunidadeMEIRepository,
-		PropostaMEIRepo:             propostaMEIRepository,
-		OrgaoSnapshotRepo:           orgaoSnapshotRepository,
-		CitizenSnapshotRepo:         citizenSnapshotRepository,
-		EmpRegimeContratacaoRepo:    regimeContratacaoRepository,
-		EmpModeloTrabalhoRepo:       modeloTrabalhoRepository,
-		EmpTipoPCDRepo:              tipoPCDRepository,
-		EmpIdiomaRepo:               idiomaRepository,
-		EmpNivelIdiomaRepo:          nivelIdiomaRepository,
-		EmpEscolaridadeRepo:         empregabilidadeEscolaridadeRepository,
-		EmpTipoConquistaRepo:        tipoConquistaRepository,
-		EmpSituacaoAtualRepo:        situacaoAtualRepository,
-		EmpDisponibilidadeRepo:      disponibilidadeRepository,
-		EmpEmpresaRepo:              empregabilidadeEmpresaRepository,
-		EmpVagaRepo:                 vagaRepository,
-		EmpEtapaRepo:                etapaRepository,
-		EmpCandidaturaRepo:          candidaturaRepository,
-		EmpCurriculoRepo:            curriculoRepository,
-		EmpOnboardingRepo:           onboardingRepository,
-		EmpTermosUsoRepo:            termosUsoRepository,
-		CursoService:                cursoService,
-		InscricaoService:            inscricaoService,
-		EmpregoService:              empregoService,
-		AcessibilidadeService:       acessibilidadeService,
-		CategoriaService:            categoriaService,
-		EscolaridadeService:         escolaridadeService,
-		EmpresaService:              empresaService,
-		InstituicaoService:          instituicaoService,
-		JobService:                  jobService,
-		OportunidadeMEIService:      oportunidadeMEIService,
-		PropostaMEIService:          propostaMEIService,
-		CNAEValidationService:       cnaeValidationService,
-		ContactInfoService:          contactInfoService,
-		EmailNotificationService:    emailNotificationService,
-		EmailWorker:                 emailWorker,
-		EmpRegimeContratacaoService: regimeContratacaoService,
-		EmpModeloTrabalhoService:    modeloTrabalhoService,
-		EmpTipoPCDService:           tipoPCDService,
-		EmpIdiomaService:            idiomaService,
-		EmpNivelIdiomaService:       nivelIdiomaService,
-		EmpEscolaridadeService:      empregabilidadeEscolaridadeService,
-		EmpTipoConquistaService:     tipoConquistaService,
-		EmpSituacaoAtualService:     situacaoAtualService,
-		EmpDisponibilidadeService:   disponibilidadeService,
-		EmpEmpresaService:           empregabilidadeEmpresaService,
-		EmpVagaService:              vagaService,
-		EmpEtapaService:             etapaService,
-		EmpCurriculoService:         curriculoService,
-		EmpCandidaturaService:       candidaturaService,
-		EmpOnboardingService:        onboardingService,
-		EmpTermosUsoService:         termosUsoService,
-		EmpCNPJConsultaService:      cnpjConsultaService,
-		EmpregoHandler:              empregoHandler,
-		AcessibilidadeHandler:       acessibilidadeHandler,
-		CategoriaHandler:            categoriaHandler,
-		EmpresaHandler:              empresaHandler,
-		EscolaridadeHandler:         escolaridadeHandler,
-		InstituicaoHandler:          instituicaoHandler,
-		InscricaoHandler:            inscricaoHandler,
-		CourseHandler:               courseHandler,
-		JobHandler:                  jobHandler,
-		OportunidadeMEIHandler:      oportunidadeMEIHandler,
-		PropostaMEIHandler:          propostaMEIHandler,
-		TypesenseHandler:            typesenseHandler,
-		EmpRegimeContratacaoHandler: regimeContratacaoHandler,
-		EmpModeloTrabalhoHandler:    modeloTrabalhoHandler,
-		EmpTipoPCDHandler:           tipoPCDHandler,
-		EmpIdiomaHandler:            idiomaHandler,
-		EmpNivelIdiomaHandler:       nivelIdiomaHandler,
-		EmpEscolaridadeHandler:      empregabilidadeEscolaridadeHandler,
-		EmpTipoConquistaHandler:     tipoConquistaHandler,
-		EmpSituacaoAtualHandler:     situacaoAtualHandler,
-		EmpDisponibilidadeHandler:   disponibilidadeHandler,
-		EmpEmpresaHandler:           empregabilidadeEmpresaHandler,
-		EmpVagaHandler:              vagaHandler,
-		EmpEtapaHandler:             etapaHandler,
-		EmpCandidaturaHandler:       candidaturaHandler,
-		EmpCurriculoHandler:         curriculoHandler,
-		EmpOnboardingHandler:        onboardingHandler,
-		EmpTermosUsoHandler:         termosUsoHandler,
+		DB:                            db,
+		Config:                        cfg,
+		RedisClient:                   client,
+		RMIClient:                     rmiClient,
+		TokenManager:                  serviceAccountTokenManager,
+		DataRelayClient:               dataRelayClient,
+		ReferenceCaches:               referenceCaches,
+		LegalEntitiesCache:            legalEntitiesCache,
+		CourseCache:                   courseCache,
+		CursoRepo:                     cursoRepository,
+		InscricaoRepo:                 inscricaoRepository,
+		EmpregoRepo:                   empregoRepository,
+		AcessibilidadeRepo:            acessibilidadeRepository,
+		CategoriaRepo:                 categoriaRepositoryInterface,
+		EscolaridadeRepo:              escolaridadeRepository,
+		EmpresaRepo:                   empresaRepository,
+		InstituicaoRepo:               instituicaoRepository,
+		JobRepo:                       jobRepository,
+		OportunidadeMEIRepo:           oportunidadeMEIRepository,
+		PropostaMEIRepo:               propostaMEIRepository,
+		OrgaoSnapshotRepo:             orgaoSnapshotRepository,
+		CitizenSnapshotRepo:           citizenSnapshotRepository,
+		EmpRegimeContratacaoRepo:      regimeContratacaoRepository,
+		EmpModeloTrabalhoRepo:         modeloTrabalhoRepository,
+		EmpTipoPCDRepo:                tipoPCDRepository,
+		EmpIdiomaRepo:                 idiomaRepository,
+		EmpNivelIdiomaRepo:            nivelIdiomaRepository,
+		EmpEscolaridadeRepo:           empregabilidadeEscolaridadeRepository,
+		EmpTipoConquistaRepo:          tipoConquistaRepository,
+		EmpSituacaoAtualRepo:          situacaoAtualRepository,
+		EmpDisponibilidadeRepo:        disponibilidadeRepository,
+		EmpEmpresaRepo:                empregabilidadeEmpresaRepository,
+		EmpVagaRepo:                   vagaRepository,
+		EmpEtapaRepo:                  etapaRepository,
+		EmpCandidaturaRepo:            candidaturaRepository,
+		EmpCurriculoRepo:              curriculoRepository,
+		EmpOnboardingRepo:             onboardingRepository,
+		EmpTermosUsoRepo:              termosUsoRepository,
+		EmpZonaRepo:                   zonaRepository,
+		EmpCandidaturaBloqueioRepo:    candidaturaBloqueioRepository,
+		CursoService:                  cursoService,
+		InscricaoService:              inscricaoService,
+		EmpregoService:                empregoService,
+		AcessibilidadeService:         acessibilidadeService,
+		CategoriaService:              categoriaService,
+		EscolaridadeService:           escolaridadeService,
+		EmpresaService:                empresaService,
+		InstituicaoService:            instituicaoService,
+		JobService:                    jobService,
+		OportunidadeMEIService:        oportunidadeMEIService,
+		PropostaMEIService:            propostaMEIService,
+		CNAEValidationService:         cnaeValidationService,
+		ContactInfoService:            contactInfoService,
+		EmailNotificationService:      emailNotificationService,
+		EmailWorker:                   emailWorker,
+		EmpRegimeContratacaoService:   regimeContratacaoService,
+		EmpModeloTrabalhoService:      modeloTrabalhoService,
+		EmpTipoPCDService:             tipoPCDService,
+		EmpIdiomaService:              idiomaService,
+		EmpNivelIdiomaService:         nivelIdiomaService,
+		EmpEscolaridadeService:        empregabilidadeEscolaridadeService,
+		EmpTipoConquistaService:       tipoConquistaService,
+		EmpSituacaoAtualService:       situacaoAtualService,
+		EmpDisponibilidadeService:     disponibilidadeService,
+		EmpEmpresaService:             empregabilidadeEmpresaService,
+		EmpVagaService:                vagaService,
+		EmpEtapaService:               etapaService,
+		EmpCurriculoService:           curriculoService,
+		EmpCandidaturaService:         candidaturaService,
+		EmpOnboardingService:          onboardingService,
+		EmpTermosUsoService:           termosUsoService,
+		EmpZonaService:                zonaService,
+		EmpCandidaturaBloqueioService: candidaturaBloqueioService,
+		EmpCNPJConsultaService:        cnpjConsultaService,
+		EmpregoHandler:                empregoHandler,
+		AcessibilidadeHandler:         acessibilidadeHandler,
+		CategoriaHandler:              categoriaHandler,
+		EmpresaHandler:                empresaHandler,
+		EscolaridadeHandler:           escolaridadeHandler,
+		InstituicaoHandler:            instituicaoHandler,
+		InscricaoHandler:              inscricaoHandler,
+		CourseHandler:                 courseHandler,
+		JobHandler:                    jobHandler,
+		OportunidadeMEIHandler:        oportunidadeMEIHandler,
+		PropostaMEIHandler:            propostaMEIHandler,
+		TypesenseHandler:              typesenseHandler,
+		EmpRegimeContratacaoHandler:   regimeContratacaoHandler,
+		EmpModeloTrabalhoHandler:      modeloTrabalhoHandler,
+		EmpTipoPCDHandler:             tipoPCDHandler,
+		EmpIdiomaHandler:              idiomaHandler,
+		EmpNivelIdiomaHandler:         nivelIdiomaHandler,
+		EmpEscolaridadeHandler:        empregabilidadeEscolaridadeHandler,
+		EmpTipoConquistaHandler:       tipoConquistaHandler,
+		EmpSituacaoAtualHandler:       situacaoAtualHandler,
+		EmpDisponibilidadeHandler:     disponibilidadeHandler,
+		EmpEmpresaHandler:             empregabilidadeEmpresaHandler,
+		EmpVagaHandler:                vagaHandler,
+		EmpEtapaHandler:               etapaHandler,
+		EmpCandidaturaHandler:         candidaturaHandler,
+		EmpCurriculoHandler:           curriculoHandler,
+		EmpOnboardingHandler:          onboardingHandler,
+		EmpTermosUsoHandler:           termosUsoHandler,
+		EmpZonaHandler:                zonaHandler,
+		EmpCandidaturaBloqueioHandler: candidaturaBloqueioHandler,
 	}
 	return applicationContainer, nil
 }
@@ -282,22 +294,24 @@ type ApplicationContainer struct {
 	CitizenSnapshotRepo *repository.CitizenSnapshotRepository
 
 	// Empregabilidade Repositories
-	EmpRegimeContratacaoRepo *empregabilidade.RegimeContratacaoRepository
-	EmpModeloTrabalhoRepo    *empregabilidade.ModeloTrabalhoRepository
-	EmpTipoPCDRepo           *empregabilidade.TipoPCDRepository
-	EmpIdiomaRepo            *empregabilidade.IdiomaRepository
-	EmpNivelIdiomaRepo       *empregabilidade.NivelIdiomaRepository
-	EmpEscolaridadeRepo      *empregabilidade.EscolaridadeRepository
-	EmpTipoConquistaRepo     *empregabilidade.TipoConquistaRepository
-	EmpSituacaoAtualRepo     *empregabilidade.SituacaoAtualRepository
-	EmpDisponibilidadeRepo   *empregabilidade.DisponibilidadeRepository
-	EmpEmpresaRepo           *empregabilidade.EmpresaRepository
-	EmpVagaRepo              *empregabilidade.VagaRepository
-	EmpEtapaRepo             *empregabilidade.EtapaRepository
-	EmpCandidaturaRepo       *empregabilidade.CandidaturaRepository
-	EmpCurriculoRepo         *empregabilidade.CurriculoRepository
-	EmpOnboardingRepo        *empregabilidade.OnboardingRepository
-	EmpTermosUsoRepo         *empregabilidade.TermosUsoRepository
+	EmpRegimeContratacaoRepo   *empregabilidade.RegimeContratacaoRepository
+	EmpModeloTrabalhoRepo      *empregabilidade.ModeloTrabalhoRepository
+	EmpTipoPCDRepo             *empregabilidade.TipoPCDRepository
+	EmpIdiomaRepo              *empregabilidade.IdiomaRepository
+	EmpNivelIdiomaRepo         *empregabilidade.NivelIdiomaRepository
+	EmpEscolaridadeRepo        *empregabilidade.EscolaridadeRepository
+	EmpTipoConquistaRepo       *empregabilidade.TipoConquistaRepository
+	EmpSituacaoAtualRepo       *empregabilidade.SituacaoAtualRepository
+	EmpDisponibilidadeRepo     *empregabilidade.DisponibilidadeRepository
+	EmpEmpresaRepo             *empregabilidade.EmpresaRepository
+	EmpVagaRepo                *empregabilidade.VagaRepository
+	EmpEtapaRepo               *empregabilidade.EtapaRepository
+	EmpCandidaturaRepo         *empregabilidade.CandidaturaRepository
+	EmpCurriculoRepo           *empregabilidade.CurriculoRepository
+	EmpOnboardingRepo          *empregabilidade.OnboardingRepository
+	EmpTermosUsoRepo           *empregabilidade.TermosUsoRepository
+	EmpZonaRepo                *empregabilidade.ZonaRepository
+	EmpCandidaturaBloqueioRepo *empregabilidade.CandidaturaBloqueioRepository
 
 	// Core Services
 	CursoService             *services.CursoService
@@ -317,23 +331,25 @@ type ApplicationContainer struct {
 	EmailWorker              *workers.EmailWorker
 
 	// Empregabilidade Services
-	EmpRegimeContratacaoService *empregabilidade2.RegimeContratacaoService
-	EmpModeloTrabalhoService    *empregabilidade2.ModeloTrabalhoService
-	EmpTipoPCDService           *empregabilidade2.TipoPCDService
-	EmpIdiomaService            *empregabilidade2.IdiomaService
-	EmpNivelIdiomaService       *empregabilidade2.NivelIdiomaService
-	EmpEscolaridadeService      *empregabilidade2.EscolaridadeService
-	EmpTipoConquistaService     *empregabilidade2.TipoConquistaService
-	EmpSituacaoAtualService     *empregabilidade2.SituacaoAtualService
-	EmpDisponibilidadeService   *empregabilidade2.DisponibilidadeService
-	EmpEmpresaService           *empregabilidade2.EmpresaService
-	EmpVagaService              *empregabilidade2.VagaService
-	EmpEtapaService             *empregabilidade2.EtapaService
-	EmpCurriculoService         *empregabilidade2.CurriculoService
-	EmpCandidaturaService       *empregabilidade2.CandidaturaService
-	EmpOnboardingService        *empregabilidade2.OnboardingService
-	EmpTermosUsoService         *empregabilidade2.TermosUsoService
-	EmpCNPJConsultaService      *empregabilidade2.CNPJConsultaService
+	EmpRegimeContratacaoService   *empregabilidade2.RegimeContratacaoService
+	EmpModeloTrabalhoService      *empregabilidade2.ModeloTrabalhoService
+	EmpTipoPCDService             *empregabilidade2.TipoPCDService
+	EmpIdiomaService              *empregabilidade2.IdiomaService
+	EmpNivelIdiomaService         *empregabilidade2.NivelIdiomaService
+	EmpEscolaridadeService        *empregabilidade2.EscolaridadeService
+	EmpTipoConquistaService       *empregabilidade2.TipoConquistaService
+	EmpSituacaoAtualService       *empregabilidade2.SituacaoAtualService
+	EmpDisponibilidadeService     *empregabilidade2.DisponibilidadeService
+	EmpEmpresaService             *empregabilidade2.EmpresaService
+	EmpVagaService                *empregabilidade2.VagaService
+	EmpEtapaService               *empregabilidade2.EtapaService
+	EmpCurriculoService           *empregabilidade2.CurriculoService
+	EmpCandidaturaService         *empregabilidade2.CandidaturaService
+	EmpOnboardingService          *empregabilidade2.OnboardingService
+	EmpTermosUsoService           *empregabilidade2.TermosUsoService
+	EmpZonaService                *empregabilidade2.ZonaService
+	EmpCandidaturaBloqueioService *empregabilidade2.CandidaturaBloqueioService
+	EmpCNPJConsultaService        *empregabilidade2.CNPJConsultaService
 
 	// Core Handlers
 	EmpregoHandler         *v1.EmpregoHandler
@@ -350,22 +366,24 @@ type ApplicationContainer struct {
 	TypesenseHandler       *v1.TypesenseHandler
 
 	// Empregabilidade Handlers
-	EmpRegimeContratacaoHandler *empregabilidade3.RegimeContratacaoHandler
-	EmpModeloTrabalhoHandler    *empregabilidade3.ModeloTrabalhoHandler
-	EmpTipoPCDHandler           *empregabilidade3.TipoPCDHandler
-	EmpIdiomaHandler            *empregabilidade3.IdiomaHandler
-	EmpNivelIdiomaHandler       *empregabilidade3.NivelIdiomaHandler
-	EmpEscolaridadeHandler      *empregabilidade3.EscolaridadeHandler
-	EmpTipoConquistaHandler     *empregabilidade3.TipoConquistaHandler
-	EmpSituacaoAtualHandler     *empregabilidade3.SituacaoAtualHandler
-	EmpDisponibilidadeHandler   *empregabilidade3.DisponibilidadeHandler
-	EmpEmpresaHandler           *empregabilidade3.EmpresaHandler
-	EmpVagaHandler              *empregabilidade3.VagaHandler
-	EmpEtapaHandler             *empregabilidade3.EtapaHandler
-	EmpCandidaturaHandler       *empregabilidade3.CandidaturaHandler
-	EmpCurriculoHandler         *empregabilidade3.CurriculoHandler
-	EmpOnboardingHandler        *empregabilidade3.OnboardingHandler
-	EmpTermosUsoHandler         *empregabilidade3.TermosUsoHandler
+	EmpRegimeContratacaoHandler   *empregabilidade3.RegimeContratacaoHandler
+	EmpModeloTrabalhoHandler      *empregabilidade3.ModeloTrabalhoHandler
+	EmpTipoPCDHandler             *empregabilidade3.TipoPCDHandler
+	EmpIdiomaHandler              *empregabilidade3.IdiomaHandler
+	EmpNivelIdiomaHandler         *empregabilidade3.NivelIdiomaHandler
+	EmpEscolaridadeHandler        *empregabilidade3.EscolaridadeHandler
+	EmpTipoConquistaHandler       *empregabilidade3.TipoConquistaHandler
+	EmpSituacaoAtualHandler       *empregabilidade3.SituacaoAtualHandler
+	EmpDisponibilidadeHandler     *empregabilidade3.DisponibilidadeHandler
+	EmpEmpresaHandler             *empregabilidade3.EmpresaHandler
+	EmpVagaHandler                *empregabilidade3.VagaHandler
+	EmpEtapaHandler               *empregabilidade3.EtapaHandler
+	EmpCandidaturaHandler         *empregabilidade3.CandidaturaHandler
+	EmpCurriculoHandler           *empregabilidade3.CurriculoHandler
+	EmpOnboardingHandler          *empregabilidade3.OnboardingHandler
+	EmpTermosUsoHandler           *empregabilidade3.TermosUsoHandler
+	EmpZonaHandler                *empregabilidade3.ZonaHandler
+	EmpCandidaturaBloqueioHandler *empregabilidade3.CandidaturaBloqueioHandler
 }
 
 // CategoriaContainer holds wired components for Categorias proof-of-concept
@@ -383,15 +401,15 @@ var CacheSet = wire.NewSet(providers.ProvideLegalEntitiesCache, providers.Provid
 
 var CoreRepositorySet = wire.NewSet(providers.ProvideCategoriaRepository, providers.ProvideCursoRepository, providers.ProvideInscricaoRepository, providers.ProvideEmpregoRepository, providers.ProvideAcessibilidadeRepository, providers.ProvideEscolaridadeRepository, providers.ProvideEmpresaRepository, providers.ProvideInstituicaoRepository, providers.ProvideJobRepository, providers.ProvideOportunidadeMEIRepository, providers.ProvidePropostaMEIRepository, providers.ProvideOrgaoSnapshotRepository, providers.ProvideCitizenSnapshotRepository)
 
-var EmpRepositorySet = wire.NewSet(providers.ProvideEmpRegimeContratacaoRepository, providers.ProvideEmpModeloTrabalhoRepository, providers.ProvideEmpTipoPCDRepository, providers.ProvideEmpIdiomaRepository, providers.ProvideEmpNivelIdiomaRepository, providers.ProvideEmpEscolaridadeRepository, providers.ProvideEmpTipoConquistaRepository, providers.ProvideEmpSituacaoAtualRepository, providers.ProvideEmpDisponibilidadeRepository, providers.ProvideEmpEmpresaRepository, providers.ProvideEmpVagaRepository, providers.ProvideEmpEtapaRepository, providers.ProvideEmpCandidaturaRepository, providers.ProvideEmpCurriculoRepository, providers.ProvideEmpOnboardingRepository, providers.ProvideEmpTermosUsoRepository)
+var EmpRepositorySet = wire.NewSet(providers.ProvideEmpRegimeContratacaoRepository, providers.ProvideEmpModeloTrabalhoRepository, providers.ProvideEmpTipoPCDRepository, providers.ProvideEmpIdiomaRepository, providers.ProvideEmpNivelIdiomaRepository, providers.ProvideEmpEscolaridadeRepository, providers.ProvideEmpTipoConquistaRepository, providers.ProvideEmpSituacaoAtualRepository, providers.ProvideEmpDisponibilidadeRepository, providers.ProvideEmpEmpresaRepository, providers.ProvideEmpVagaRepository, providers.ProvideEmpEtapaRepository, providers.ProvideEmpCandidaturaRepository, providers.ProvideEmpCurriculoRepository, providers.ProvideEmpOnboardingRepository, providers.ProvideEmpTermosUsoRepository, providers.ProvideEmpZonaRepository, providers.ProvideEmpCandidaturaBloqueioRepository)
 
 var CoreServiceSet = wire.NewSet(providers.ProvideCategoriaService, providers.ProvideCursoService, providers.ProvideEmpregoService, providers.ProvideAcessibilidadeService, providers.ProvideEscolaridadeService, providers.ProvideEmpresaService, providers.ProvideInstituicaoService, providers.ProvideJobService, providers.ProvideOportunidadeMEIService, providers.ProvideCNAEValidationService, providers.ProvideContactInfoService, providers.ProvideEmailNotificationService, providers.ProvideEmailWorker, wire.Bind(new(services.EmailNotifier), new(*workers.EmailWorker)), providers.ProvideInscricaoService, providers.ProvidePropostaMEIService)
 
-var EmpServiceSet = wire.NewSet(providers.ProvideEmpRegimeContratacaoService, providers.ProvideEmpModeloTrabalhoService, providers.ProvideEmpTipoPCDService, providers.ProvideEmpIdiomaService, providers.ProvideEmpNivelIdiomaService, providers.ProvideEmpEscolaridadeService, providers.ProvideEmpTipoConquistaService, providers.ProvideEmpSituacaoAtualService, providers.ProvideEmpDisponibilidadeService, providers.ProvideEmpEmpresaService, providers.ProvideEmpVagaService, providers.ProvideEmpEtapaService, providers.ProvideEmpCurriculoService, providers.ProvideEmpCandidaturaService, providers.ProvideEmpOnboardingService, providers.ProvideEmpTermosUsoService, providers.ProvideEmpCNPJConsultaService)
+var EmpServiceSet = wire.NewSet(providers.ProvideEmpRegimeContratacaoService, providers.ProvideEmpModeloTrabalhoService, providers.ProvideEmpTipoPCDService, providers.ProvideEmpIdiomaService, providers.ProvideEmpNivelIdiomaService, providers.ProvideEmpEscolaridadeService, providers.ProvideEmpTipoConquistaService, providers.ProvideEmpSituacaoAtualService, providers.ProvideEmpDisponibilidadeService, providers.ProvideEmpEmpresaService, providers.ProvideEmpVagaService, providers.ProvideEmpEtapaService, providers.ProvideEmpCurriculoService, providers.ProvideEmpCandidaturaService, providers.ProvideEmpOnboardingService, providers.ProvideEmpTermosUsoService, providers.ProvideEmpCNPJConsultaService, providers.ProvideEmpZonaService, providers.ProvideEmpCandidaturaBloqueioService)
 
 var CoreHandlerSet = wire.NewSet(providers.ProvideEmpregoHandler, providers.ProvideAcessibilidadeHandler, providers.ProvideCategoriaHandlerWithCache, providers.ProvideEmpresaHandler, providers.ProvideEscolaridadeHandler, providers.ProvideInstituicaoHandler, providers.ProvideInscricaoHandler, providers.ProvideCourseHandler, providers.ProvideJobHandler, providers.ProvideOportunidadeMEIHandler, providers.ProvidePropostaMEIHandler, providers.ProvideTypesenseHandler)
 
-var EmpHandlerSet = wire.NewSet(providers.ProvideEmpRegimeContratacaoHandler, providers.ProvideEmpModeloTrabalhoHandler, providers.ProvideEmpTipoPCDHandler, providers.ProvideEmpIdiomaHandler, providers.ProvideEmpNivelIdiomaHandler, providers.ProvideEmpEscolaridadeHandler, providers.ProvideEmpTipoConquistaHandler, providers.ProvideEmpSituacaoAtualHandler, providers.ProvideEmpDisponibilidadeHandler, providers.ProvideEmpEmpresaHandler, providers.ProvideEmpVagaHandler, providers.ProvideEmpEtapaHandler, providers.ProvideEmpCandidaturaHandler, providers.ProvideEmpCurriculoHandler, providers.ProvideEmpOnboardingHandler, providers.ProvideEmpTermosUsoHandler)
+var EmpHandlerSet = wire.NewSet(providers.ProvideEmpRegimeContratacaoHandler, providers.ProvideEmpModeloTrabalhoHandler, providers.ProvideEmpTipoPCDHandler, providers.ProvideEmpIdiomaHandler, providers.ProvideEmpNivelIdiomaHandler, providers.ProvideEmpEscolaridadeHandler, providers.ProvideEmpTipoConquistaHandler, providers.ProvideEmpSituacaoAtualHandler, providers.ProvideEmpDisponibilidadeHandler, providers.ProvideEmpEmpresaHandler, providers.ProvideEmpVagaHandler, providers.ProvideEmpEtapaHandler, providers.ProvideEmpCandidaturaHandler, providers.ProvideEmpCurriculoHandler, providers.ProvideEmpOnboardingHandler, providers.ProvideEmpTermosUsoHandler, providers.ProvideEmpZonaHandler, providers.ProvideEmpCandidaturaBloqueioHandler)
 
 // Legacy set kept for backward compatibility with the Categorias POC
 var CategoriaSet = wire.NewSet(providers.ProvideCategoriaRepository, providers.ProvideCategoriaService, wire.Bind(new(services.CategoriaServiceInterface), new(*services.CategoriaService)), v1.NewCategoriaHandler)


### PR DESCRIPTION
## Objetivo
Disponibiliza no backend a estrutura necessária para que cada vaga possua critérios obrigatórios de elegibilidade configuráveis pela secretaria, conforme **PREF-369**.

## O que foi feito
- **Idade**: `idade_minima` / `idade_maxima` (int nullable) em `Vaga`.
- **Zona**: nova tabela `emp_zonas` (seed: Zona Norte/Sul/Oeste/Centro) + relação many2many `emp_vagas_zonas`. CRUD completo em `/empregabilidade/zonas` e `PUT /vagas/:id/zonas`.
- **Bairro (elegibilidade)**: novo campo `bairros_elegibilidade` (jsonb, multi-valor, texto livre) — **não confundir** com o campo `bairro` já existente na Vaga, que segue servindo à exibição/filtro e não foi alterado.
- **Escolaridade mínima**: FK `id_escolaridade_minima` reaproveitando a tabela `emp_escolaridades` já existente (usada hoje só no currículo do candidato).
- **Área de formação**: `areas_formacao_elegibilidade` (jsonb, texto livre) — não há taxonomia oficial hoje, então ficou como texto livre.
- **Idioma + nível mínimo**: nova entidade `emp_vagas_idiomas_requisitos` (não é many2many simples por carregar `id_nivel_minimo`). `PUT /vagas/:id/idiomas-requisito`.
- **Ordenação de níveis**: coluna `ordem` adicionada e populada em `emp_escolaridades` e `emp_niveis_idioma`, para viabilizar a comparação "nível mínimo exigido" na validação futura (PREF-371), sem a qual seria impossível implementar depois.
- **Registro de bloqueios**: nova tabela `emp_candidatura_bloqueios` (sem FK para `emp_vagas`/`emp_candidaturas` — candidato bloqueado nunca chega a se candidatar). `POST`/`GET /empregabilidade/candidatura-bloqueios`.

## Fora de escopo (conforme o ticket)
Interface administrativa, validação da candidatura contra os critérios, exibição de mensagens ao cidadão, regras de UX — tudo isso fica para PREF-370/371.

## Notas de implementação
- `VagaRepository.Update`/`UpdateWithAssociations` usam allowlist manual de colunas — todos os campos novos foram adicionados nos dois maps.
- DI via `google/wire`: providers + `wire_gen.go` regenerados e confirmados idempotentes.
- TDD em todas as camadas (repository/service/handler), incluindo caminhos de erro.

## Verificação
- `just fmt` ✅
- `just lint` → 0 issues ✅
- `just build` (wire-gen + binário) ✅
- `go test -race -count=1 ./...` → todos os pacotes do repo, 0 falhas ✅
- `just swagger` regenerado, novos endpoints/schemas confirmados no swagger.json

Refs: PREF-369 (parent: PREF-339)