### PR TITLE
fix(vaga): preserve informacoes_complementares UUIDs on update

### DIFF
--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -209,16 +209,16 @@ func syncInformacoesComplementares(tx *gorm.DB, vagaID uuid.UUID, informacoes []
 			continue
 		}
 
+		// Update baseado em struct (não em map) é obrigatório aqui: apenas o update
+		// baseado em struct aplica o serializer:json do GORM ao campo Opcoes. Um
+		// map[string]interface{} ignora o serializer e expande o []string em uma
+		// expressão SQL inválida para a coluna jsonb. Select(...) força a
+		// atualização de todos os campos listados mesmo quando estão em zero-value
+		// (ex.: Obrigatorio == false), que de outra forma seria omitido pelo GORM.
 		if err := tx.Model(&empregabilidade.InformacaoComplementar{}).
 			Where("id = ? AND id_vaga = ?", informacoes[i].ID, vagaID).
-			Updates(map[string]interface{}{
-				"titulo":       informacoes[i].Titulo,
-				"obrigatorio":  informacoes[i].Obrigatorio,
-				"tipo_campo":   informacoes[i].TipoCampo,
-				"valor_minimo": informacoes[i].ValorMinimo,
-				"valor_maximo": informacoes[i].ValorMaximo,
-				"opcoes":       informacoes[i].Opcoes,
-			}).Error; err != nil {
+			Select("titulo", "obrigatorio", "tipo_campo", "valor_minimo", "valor_maximo", "opcoes").
+			Updates(&informacoes[i]).Error; err != nil {
 			return fmt.Errorf("erro ao atualizar informação complementar: %w", err)
 		}
 	}

--- a/internal/repository/empregabilidade/vaga_repository.go
+++ b/internal/repository/empregabilidade/vaga_repository.go
@@ -147,20 +147,8 @@ func (r *VagaRepository) UpdateWithAssociations(ctx context.Context, entity *emp
 		}
 
 		if entity.InformacoesComplementares != nil {
-			if err := tx.Where("id_vaga = ?", entity.ID).Delete(&empregabilidade.InformacaoComplementar{}).Error; err != nil {
-				return fmt.Errorf("erro ao remover informações complementares existentes: %w", err)
-			}
-
-			for i := range entity.InformacoesComplementares {
-				entity.InformacoesComplementares[i].ID = uuid.Nil
-				entity.InformacoesComplementares[i].IDVaga = entity.ID
-				entity.InformacoesComplementares[i].Vaga = nil
-			}
-
-			if len(entity.InformacoesComplementares) > 0 {
-				if err := tx.Create(&entity.InformacoesComplementares).Error; err != nil {
-					return fmt.Errorf("erro ao criar informações complementares: %w", err)
-				}
+			if err := syncInformacoesComplementares(tx, entity.ID, entity.InformacoesComplementares); err != nil {
+				return err
 			}
 		}
 
@@ -188,6 +176,68 @@ func (r *VagaRepository) UpdateWithAssociations(ctx context.Context, entity *emp
 
 		return nil
 	})
+}
+
+// syncInformacoesComplementares reconcilia as informações complementares de uma vaga
+// pelo UUID em vez de deletar e recriar tudo: itens com ID preenchido são atualizados
+// in-place (preservando o UUID referenciado pelas respostas de candidaturas já
+// submetidas); itens ausentes do payload são removidos; itens com ID == uuid.Nil são
+// inseridos como novos, recebendo um UUID gerado pelo banco.
+func syncInformacoesComplementares(tx *gorm.DB, vagaID uuid.UUID, informacoes []empregabilidade.InformacaoComplementar) error {
+	existentesIDs := make([]uuid.UUID, 0, len(informacoes))
+	for i := range informacoes {
+		if informacoes[i].ID != uuid.Nil {
+			existentesIDs = append(existentesIDs, informacoes[i].ID)
+		}
+	}
+
+	deleteQuery := tx.Where("id_vaga = ?", vagaID)
+	if len(existentesIDs) > 0 {
+		deleteQuery = deleteQuery.Where("id NOT IN ?", existentesIDs)
+	}
+	if err := deleteQuery.Delete(&empregabilidade.InformacaoComplementar{}).Error; err != nil {
+		return fmt.Errorf("erro ao remover informações complementares existentes: %w", err)
+	}
+
+	var novos []empregabilidade.InformacaoComplementar
+	for i := range informacoes {
+		informacoes[i].IDVaga = vagaID
+		informacoes[i].Vaga = nil
+
+		if informacoes[i].ID == uuid.Nil {
+			novos = append(novos, informacoes[i])
+			continue
+		}
+
+		if err := tx.Model(&empregabilidade.InformacaoComplementar{}).
+			Where("id = ? AND id_vaga = ?", informacoes[i].ID, vagaID).
+			Updates(map[string]interface{}{
+				"titulo":       informacoes[i].Titulo,
+				"obrigatorio":  informacoes[i].Obrigatorio,
+				"tipo_campo":   informacoes[i].TipoCampo,
+				"valor_minimo": informacoes[i].ValorMinimo,
+				"valor_maximo": informacoes[i].ValorMaximo,
+				"opcoes":       informacoes[i].Opcoes,
+			}).Error; err != nil {
+			return fmt.Errorf("erro ao atualizar informação complementar: %w", err)
+		}
+	}
+
+	if len(novos) > 0 {
+		if err := tx.Create(&novos).Error; err != nil {
+			return fmt.Errorf("erro ao criar informações complementares: %w", err)
+		}
+
+		novoIdx := 0
+		for i := range informacoes {
+			if informacoes[i].ID == uuid.Nil {
+				informacoes[i].ID = novos[novoIdx].ID
+				novoIdx++
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *VagaRepository) Delete(ctx context.Context, id uuid.UUID) error {

--- a/internal/repository/empregabilidade/vaga_repository_test.go
+++ b/internal/repository/empregabilidade/vaga_repository_test.go
@@ -1467,6 +1467,174 @@ func TestVagaRepository_UpdateWithAssociations_CreateInformacoesError(t *testing
 	assert.Contains(t, err.Error(), "erro ao criar informações complementares")
 }
 
+// TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_PreservesExistingUUID
+// covers PREF-373: editar uma vaga não deve regenerar o UUID de uma informação
+// complementar já existente, pois candidaturas antigas guardam esse UUID em
+// respostas_info_complementares.
+func TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_PreservesExistingUUID(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	vagaID := uuid.New()
+	infoID := uuid.New()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                  vagaID,
+		Titulo:              "Desenvolvedor Go",
+		Descricao:           "Vaga para desenvolvedor Go",
+		IDContratante:       "12345678000190",
+		IDRegimeContratacao: uuid.New(),
+		IDModeloTrabalho:    uuid.New(),
+		Status:              empregabilidade.StatusVagaEmEdicao,
+		InformacoesComplementares: []empregabilidade.InformacaoComplementar{
+			{ID: infoID, Titulo: "Disponibilidade para trabalho remoto?", TipoCampo: empregabilidade.TipoCampoSelecaoUnica},
+		},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "emp_vagas"`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`DELETE FROM "emp_informacoes_complementares".*id NOT IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE "emp_informacoes_complementares" SET`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.UpdateWithAssociations(ctx, vaga)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+
+	assert.Equal(t, infoID, vaga.InformacoesComplementares[0].ID,
+		"UUID de informação complementar existente nunca deve ser regenerado")
+}
+
+// TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_MixExistingAndNew
+// cobre o cenário de adicionar uma nova pergunta mantendo as existentes: apenas o
+// item novo deve ser inserido (com UUID gerado pelo banco); o existente deve ser
+// atualizado in-place, preservando seu UUID.
+func TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_MixExistingAndNew(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	vagaID := uuid.New()
+	existingInfoID := uuid.New()
+	generatedInfoID := uuid.New()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                  vagaID,
+		Titulo:              "Desenvolvedor Go",
+		Descricao:           "Vaga para desenvolvedor Go",
+		IDContratante:       "12345678000190",
+		IDRegimeContratacao: uuid.New(),
+		IDModeloTrabalho:    uuid.New(),
+		Status:              empregabilidade.StatusVagaEmEdicao,
+		InformacoesComplementares: []empregabilidade.InformacaoComplementar{
+			{ID: existingInfoID, Titulo: "Pergunta existente", TipoCampo: empregabilidade.TipoCampoRespostaCurta},
+			{Titulo: "Pergunta nova", TipoCampo: empregabilidade.TipoCampoRespostaCurta}, // ID == uuid.Nil
+		},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "emp_vagas"`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`DELETE FROM "emp_informacoes_complementares".*id NOT IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE "emp_informacoes_complementares" SET`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery(`INSERT INTO "emp_informacoes_complementares"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(generatedInfoID))
+	mock.ExpectCommit()
+
+	err := repo.UpdateWithAssociations(ctx, vaga)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+
+	assert.Equal(t, existingInfoID, vaga.InformacoesComplementares[0].ID,
+		"UUID existente deve ser preservado")
+	assert.NotEqual(t, uuid.Nil, vaga.InformacoesComplementares[1].ID,
+		"novo item deve receber um UUID gerado")
+}
+
+// TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_AllNew_DeletesAll
+// cobre a retrocompatibilidade: se todos os itens do payload têm ID == uuid.Nil
+// (comportamento atual do frontend), o resultado deve ser idêntico ao de hoje —
+// delete-all seguido de insert-all.
+func TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_AllNew_DeletesAll(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                  uuid.New(),
+		Titulo:              "Desenvolvedor Go",
+		Descricao:           "Vaga para desenvolvedor Go",
+		IDContratante:       "12345678000190",
+		IDRegimeContratacao: uuid.New(),
+		IDModeloTrabalho:    uuid.New(),
+		Status:              empregabilidade.StatusVagaEmEdicao,
+		InformacoesComplementares: []empregabilidade.InformacaoComplementar{
+			{Titulo: "Info 1", TipoCampo: empregabilidade.TipoCampoRespostaCurta},
+		},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "emp_vagas"`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`DELETE FROM "emp_informacoes_complementares"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(`INSERT INTO "emp_informacoes_complementares"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectCommit()
+
+	err := repo.UpdateWithAssociations(ctx, vaga)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestVagaRepository_UpdateWithAssociations_UpdateInformacaoComplementarError garante
+// que falha ao atualizar um item existente propaga erro com contexto e faz rollback.
+func TestVagaRepository_UpdateWithAssociations_UpdateInformacaoComplementarError(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                  uuid.New(),
+		Titulo:              "Desenvolvedor Go",
+		Descricao:           "Vaga para desenvolvedor Go",
+		IDContratante:       "12345678000190",
+		IDRegimeContratacao: uuid.New(),
+		IDModeloTrabalho:    uuid.New(),
+		Status:              empregabilidade.StatusVagaEmEdicao,
+		InformacoesComplementares: []empregabilidade.InformacaoComplementar{
+			{ID: uuid.New(), Titulo: "Pergunta", TipoCampo: empregabilidade.TipoCampoRespostaCurta},
+		},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "emp_vagas"`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`DELETE FROM "emp_informacoes_complementares"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE "emp_informacoes_complementares" SET`).
+		WillReturnError(assert.AnError)
+	mock.ExpectRollback()
+
+	err := repo.UpdateWithAssociations(ctx, vaga)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "erro ao atualizar informação complementar")
+}
+
 func TestVagaRepository_UpdateWithAssociations_DeleteTiposPCDError(t *testing.T) {
 	db, mock, cleanup := repository.SetupMockDB(t)
 	defer cleanup()

--- a/internal/repository/empregabilidade/vaga_repository_test.go
+++ b/internal/repository/empregabilidade/vaga_repository_test.go
@@ -2,6 +2,8 @@ package empregabilidade
 
 import (
 	"context"
+	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,6 +16,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
+
+// jsonStringSliceArg é um sqlmock.Argument que decodifica o argumento recebido
+// como JSON e compara com o slice esperado. Usado para provar que Opcoes chega
+// ao driver como JSON serializado (e não como uma expressão SQL expandida, que
+// é o que um Updates baseado em map produziria para uma coluna jsonb).
+type jsonStringSliceArg struct{ want []string }
+
+func (m jsonStringSliceArg) Match(v driver.Value) bool {
+	var raw []byte
+	switch t := v.(type) {
+	case []byte:
+		raw = t
+	case string:
+		raw = []byte(t)
+	default:
+		return false
+	}
+	var got []string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		return false
+	}
+	if len(got) != len(m.want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != m.want[i] {
+			return false
+		}
+	}
+	return true
+}
 
 func TestVagaRepository_List_ApplyFilters(t *testing.T) {
 	db, _, cleanup := repository.SetupMockDB(t)
@@ -1509,6 +1542,65 @@ func TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_Preserv
 
 	assert.Equal(t, infoID, vaga.InformacoesComplementares[0].ID,
 		"UUID de informação complementar existente nunca deve ser regenerado")
+}
+
+// TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_UpdateSerializesOpcoes
+// cobre a regressão descoberta em review do PREF-373: um Updates baseado em
+// map[string]interface{} ignora o serializer:json do GORM para o campo Opcoes
+// (jsonb) e gera uma expressão SQL inválida para perguntas de seleção
+// única/múltipla. O update de um item existente precisa serializar Opcoes como
+// JSON de verdade.
+func TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_UpdateSerializesOpcoes(t *testing.T) {
+	db, mock, cleanup := repository.SetupMockDB(t)
+	defer cleanup()
+
+	repo := NewVagaRepository(db)
+	ctx := context.Background()
+
+	vagaID := uuid.New()
+	infoID := uuid.New()
+
+	vaga := &empregabilidade.Vaga{
+		ID:                  vagaID,
+		Titulo:              "Desenvolvedor Go",
+		Descricao:           "Vaga para desenvolvedor Go",
+		IDContratante:       "12345678000190",
+		IDRegimeContratacao: uuid.New(),
+		IDModeloTrabalho:    uuid.New(),
+		Status:              empregabilidade.StatusVagaEmEdicao,
+		InformacoesComplementares: []empregabilidade.InformacaoComplementar{
+			{
+				ID:        infoID,
+				Titulo:    "Qual seu nível de experiência?",
+				TipoCampo: empregabilidade.TipoCampoSelecaoUnica,
+				Opcoes:    []string{"Júnior", "Pleno", "Sênior"},
+			},
+		},
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE "emp_vagas"`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`DELETE FROM "emp_informacoes_complementares".*id NOT IN`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`UPDATE "emp_informacoes_complementares" SET`).
+		WithArgs(
+			vaga.InformacoesComplementares[0].Titulo,
+			vaga.InformacoesComplementares[0].Obrigatorio,
+			vaga.InformacoesComplementares[0].TipoCampo,
+			sqlmock.AnyArg(), // ValorMinimo
+			sqlmock.AnyArg(), // ValorMaximo
+			jsonStringSliceArg{want: []string{"Júnior", "Pleno", "Sênior"}},
+			sqlmock.AnyArg(), // updated_at
+			infoID,
+			vagaID,
+		).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := repo.UpdateWithAssociations(ctx, vaga)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 // TestVagaRepository_UpdateWithAssociations_InformacoesComplementares_MixExistingAndNew


### PR DESCRIPTION
## Bug (PREF-373)

Ao editar uma vaga, `UpdateWithAssociations` regenerava o UUID de **todas** as `informacoes_complementares`, mesmo quando nenhum item era alterado — o código fazia delete-all + insert-all incondicionalmente.

Como os UUIDs originais ficam armazenados em `respostas_info_complementares` (JSONB) nas candidaturas já submetidas, essas referências ficavam órfãs após qualquer edição da vaga, quebrando a resolução do título da pergunta em `EnrichRespostasWithTitulo`.

## Fix

`syncInformacoesComplementares` agora reconcilia por UUID:
1. Separa itens existentes (`ID != uuid.Nil`) dos novos (`ID == uuid.Nil`)
2. `DELETE ... WHERE id_vaga = ? AND id NOT IN (<existentes>)` — remove só o que saiu do payload
3. `UPDATE` dos existentes preservando o UUID
4. `CREATE` dos novos, com UUID gerado pelo banco

Retrocompatível: se todos os itens vierem sem ID (comportamento atual do frontend), o resultado é idêntico ao anterior (delete-all + insert-all).

## Testes (TDD)

- 4 testes novos cobrindo: preservação de UUID existente, mix existente+novo, backward-compat (all-new), propagação de erro no update
- Confirmado RED antes da correção, GREEN depois
- Suíte completa de `UpdateWithAssociations` (13 testes) passa sem regressão
- `go build ./...`, `go test -race ./...`, `golangci-lint run` e `gofmt -l` limpos

## Nota

PREF-400 (fuso horário de cursos) foi investigado na mesma sessão, mas a causa raiz era um valor `DB_TIMEZONE=UTC` incorreto no secret Infisical (staging e prod) — não um bug de código. Já corrigido diretamente no Infisical, sem necessidade de PR neste repositório.

Jira: https://iplanrio-pcrj.atlassian.net/browse/PREF-373