### PR TITLE
fix(rbac): corrige regressões de autorização de vaga e curso (follow-up do #143)

### DIFF
--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -227,15 +227,6 @@ func (h *CourseHandler) calculateRemainingVacanciesForCourses(c *gin.Context, cu
 	return nil
 }
 
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}
-
 // @Summary      Criar curso
 // @Description  Cria um novo curso no sistema (status: "opened")
 // @Tags         courses
@@ -256,13 +247,10 @@ func (h *CourseHandler) Create(c *gin.Context) {
 	// Set status to opened for published course
 	curso.Status = models.StatusCursoOpened
 
-	allowedOrgaos := middlewares.GetUserAllowedOrgaos(c)
-	// Se allowedOrgaos for nil, significa que é admin/casa_civil – permite qualquer um
-	if allowedOrgaos != nil && !contains(allowedOrgaos, curso.OrgaoID) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "Você não tem permissão para criar cursos neste órgão"})
-		return
-	}
-
+	// A criação de curso é restrita a admin / go:cursos:casa_civil pelo
+	// CourseOrgaoInjector (dev/test) e, em produção, pelo gateway Heimdall — e
+	// esses papéis podem criar em qualquer órgão. Não há, portanto, filtro de
+	// órgão adicional a aplicar aqui.
 	id, err := h.cursoService.Create(c.Request.Context(), &curso)
 	if err != nil {
 		// Check if it's a validation error (not a database error)
@@ -321,13 +309,10 @@ func (h *CourseHandler) CreateDraft(c *gin.Context) {
 	// Set status to draft
 	curso.Status = models.StatusCursoDraft
 
-	allowedOrgaos := middlewares.GetUserAllowedOrgaos(c)
-	// Se allowedOrgaos for nil, significa que é admin/casa_civil – permite qualquer um
-	if allowedOrgaos != nil && !contains(allowedOrgaos, curso.OrgaoID) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "Você não tem permissão para criar cursos neste órgão"})
-		return
-	}
-
+	// A criação de curso é restrita a admin / go:cursos:casa_civil pelo
+	// CourseOrgaoInjector (dev/test) e, em produção, pelo gateway Heimdall — e
+	// esses papéis podem criar em qualquer órgão. Não há, portanto, filtro de
+	// órgão adicional a aplicar aqui.
 	id, err := h.cursoService.Create(c.Request.Context(), &curso)
 	if err != nil {
 		// Check if it's a validation error (not a database error)
@@ -815,7 +800,7 @@ func (h *CourseHandler) ListDrafts(c *gin.Context) {
 // @Failure      500      {object}  models.ErrorResponse
 // @Router       /api/public/courses/{courseId} [get]
 func (h *CourseHandler) GetByIDPublic(c *gin.Context) {
-	h.GetByID(c)
+	h.getByID(c, true)
 }
 
 // @Summary      Buscar curso específico
@@ -829,6 +814,13 @@ func (h *CourseHandler) GetByIDPublic(c *gin.Context) {
 // @Failure      500      {object}  models.ErrorResponse
 // @Router       /api/v1/courses/{courseId} [get]
 func (h *CourseHandler) GetByID(c *gin.Context) {
+	h.getByID(c, false)
+}
+
+// getByID busca um curso por ID. Quando publicOnly é true (rota /api/public),
+// cursos em rascunho não são expostos — retornam 404 —, mantendo o mesmo
+// contrato da listagem pública, que já esconde rascunhos (status NOT draft).
+func (h *CourseHandler) getByID(c *gin.Context, publicOnly bool) {
 	id, err := strconv.Atoi(c.Param("courseId"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "ID do curso inválido"})
@@ -842,6 +834,11 @@ func (h *CourseHandler) GetByID(c *gin.Context) {
 	}
 
 	if curso == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Curso não encontrado"})
+		return
+	}
+
+	if publicOnly && curso.Status.Normalize() == models.StatusCursoDraft {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Curso não encontrado"})
 		return
 	}

--- a/internal/handlers/v1/course_handler_test.go
+++ b/internal/handlers/v1/course_handler_test.go
@@ -733,6 +733,56 @@ func TestCourseHandler_GetByID_Success(t *testing.T) {
 	mockService.AssertExpectations(t)
 }
 
+// A rota pública não deve expor cursos em rascunho: retorna 404 mesmo quando o
+// curso existe, mantendo o mesmo contrato da listagem pública (status NOT draft).
+func TestCourseHandler_GetByIDPublic_Draft_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+
+	r := gin.New()
+	r.GET("/api/public/courses/:courseId", handler.GetByIDPublic)
+
+	curso := &models.Curso{ID: 1, Titulo: "Rascunho", Status: models.StatusCursoDraft}
+	mockService.On("GetByID", mock.Anything, 1).Return(curso, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/public/courses/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "Curso não encontrado")
+	mockService.AssertExpectations(t)
+}
+
+// A rota autenticada (GetByID) continua expondo rascunhos para quem já passou
+// pela autorização de rota.
+func TestCourseHandler_GetByID_Draft_Visible(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+
+	r := gin.New()
+	r.GET("/api/v1/courses/:courseId", handler.GetByID)
+
+	curso := &models.Curso{ID: 1, Titulo: "Rascunho", Status: models.StatusCursoDraft}
+	mockService.On("GetByID", mock.Anything, 1).Return(curso, nil)
+	mockRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).Return(make(map[uuid.UUID]int64), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
 // Test GetByID - Not Found
 func TestCourseHandler_GetByID_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/handlers/v1/empregabilidade/vaga_handler.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler.go
@@ -22,10 +22,6 @@ func containsString(slice []string, item string) bool {
 	return false
 }
 
-func isPublishedStatus(status empregabilidade.StatusVaga) bool {
-	return status.IsPublished()
-}
-
 func parseCSVParam(param string) []string {
 	if param == "" {
 		return nil
@@ -258,8 +254,17 @@ func (h *VagaHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// A autorização por órgão/secretaria e a regra de edição de vaga publicada
-	// ficam em VagaOwnershipCheck (middleware), que só é ativo em dev/test.
+	// A autorização por órgão/secretaria fica em VagaOwnershipCheck (middleware,
+	// só ativo em dev/test). Já a regra de "quem pode editar vaga publicada"
+	// depende do status da vaga — algo que o gateway Heimdall não conhece —, então
+	// precisa ser aplicada aqui no handler, em qualquer ambiente.
+	canEditPublished := middlewares.IsAdmin(c) ||
+		middlewares.HasRole(c, "go:empregabilidade:admin") ||
+		middlewares.HasRole(c, "go:empregabilidade:editor_sem_curadoria")
+	if existing.Status.IsPublished() && !canEditPublished {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Apenas administradores, empregabilidade:admin ou editor_sem_curadoria podem editar vagas publicadas"})
+		return
+	}
 
 	var entity empregabilidade.Vaga
 	if err := c.ShouldBindJSON(&entity); err != nil {
@@ -632,7 +637,7 @@ func (h *VagaHandler) PublicList(c *gin.Context) {
 	}
 
 	status := c.Query("status")
-	if status != "" && !isPublishedStatus(empregabilidade.StatusVaga(status)) {
+	if status != "" && !empregabilidade.StatusVaga(status).IsPublished() {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "status inválido: deve ser publicado_ativo, publicado_expirado, vaga_congelada ou vaga_descontinuada"})
 		return
 	}
@@ -696,7 +701,7 @@ func (h *VagaHandler) PublicGetBySlug(c *gin.Context) {
 		return
 	}
 
-	if entity == nil || !isPublishedStatus(entity.Status) {
+	if entity == nil || !entity.Status.IsPublished() {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Vaga não encontrada"})
 		return
 	}
@@ -737,7 +742,7 @@ func (h *VagaHandler) PublicGetByID(c *gin.Context) {
 		return
 	}
 
-	if entity == nil || !isPublishedStatus(entity.Status) {
+	if entity == nil || !entity.Status.IsPublished() {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Vaga não encontrada"})
 		return
 	}

--- a/internal/handlers/v1/empregabilidade/vaga_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/vaga_handler_test.go
@@ -286,8 +286,10 @@ func TestVagaHandler_GetByID_ServiceError(t *testing.T) {
 
 func TestVagaHandler_Update_Success(t *testing.T) {
 	id := uuid.MustParse(validUUID)
-	// O handler não faz mais RBAC (isso vive em VagaOwnershipCheck); aqui só
-	// exercitamos o caminho feliz do handler.
+	// Vaga em edição (não publicada): o handler libera para qualquer chamador que
+	// tenha passado pela autorização de rota. O escopo por órgão vive em
+	// VagaOwnershipCheck; a única regra RBAC que permanece no handler é a de vaga
+	// publicada (coberta nos testes abaixo).
 	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaEmEdicao}}
 	empresaRepo := &mockEmpresaRepoForVaga{}
 	r := setupVagaRouter(vagaRepo, empresaRepo, false)
@@ -298,6 +300,89 @@ func TestVagaHandler_Update_Success(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// setupVagaRouterWithRoles monta um router de vaga cujo contexto carrega as roles
+// Heimdall informadas (não-admin). Usado para exercitar a regra de "quem pode
+// editar vaga publicada", que roda no handler em qualquer ambiente.
+func setupVagaRouterWithRoles(vagaRepo services.VagaRepoInterface, empresaRepo services.EmpresaRepoInterface, roles []string) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserRolesKey, roles)
+		c.Next()
+	})
+	candidaturaRepo := &mockCandidaturaRepoForVaga{}
+	svc := services.NewVagaServiceWithInterfaces(vagaRepo, empresaRepo, candidaturaRepo)
+	h := handlers.NewVagaHandler(svc)
+	r.PUT("/vagas/:id", h.Update)
+	return r
+}
+
+// updatePublishedVaga dispara um PUT de edição sobre uma vaga já publicada.
+func updatePublishedVaga(r *gin.Engine) *httptest.ResponseRecorder {
+	body := bodyOf(`{"titulo":"Nova versão"}`)
+	req := httptest.NewRequest(http.MethodPut, "/vagas/"+validUUID, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestVagaHandler_Update_Published_Admin_Allowed(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaPublicadoAtivo}}
+	r := setupVagaRouter(vagaRepo, &mockEmpresaRepoForVaga{}, true) // admin
+	w := updatePublishedVaga(r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for admin, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_Update_Published_EmpAdmin_Allowed(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaPublicadoAtivo}}
+	r := setupVagaRouterWithRoles(vagaRepo, &mockEmpresaRepoForVaga{}, []string{"go:empregabilidade:admin"})
+	w := updatePublishedVaga(r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for empregabilidade:admin, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_Update_Published_EditorSemCuradoria_Allowed(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaPublicadoAtivo}}
+	r := setupVagaRouterWithRoles(vagaRepo, &mockEmpresaRepoForVaga{}, []string{"go:empregabilidade:editor_sem_curadoria"})
+	w := updatePublishedVaga(r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for editor_sem_curadoria, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestVagaHandler_Update_Published_EditorComCuradoria_Forbidden(t *testing.T) {
+	id := uuid.MustParse(validUUID)
+	vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: empmodels.StatusVagaPublicadoAtivo}}
+	r := setupVagaRouterWithRoles(vagaRepo, &mockEmpresaRepoForVaga{}, []string{"go:empregabilidade:editor_com_curadoria"})
+	w := updatePublishedVaga(r)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for editor_com_curadoria on published vaga, got %d", w.Code)
+	}
+}
+
+// A regra vale para todos os status pós-publicação, não só publicado_ativo.
+func TestVagaHandler_Update_PublishedStates_NonPrivileged_Forbidden(t *testing.T) {
+	for _, status := range []empmodels.StatusVaga{
+		empmodels.StatusVagaPublicadoExpirado,
+		empmodels.StatusVagaCongelada,
+		empmodels.StatusVagaDescontinuada,
+	} {
+		id := uuid.MustParse(validUUID)
+		vagaRepo := &mockVagaRepoH{entity: &empmodels.Vaga{ID: id, Status: status}}
+		r := setupVagaRouterWithRoles(vagaRepo, &mockEmpresaRepoForVaga{}, []string{"go:empregabilidade:editor_com_curadoria"})
+		w := updatePublishedVaga(r)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status %s: expected 403, got %d", status, w.Code)
+		}
 	}
 }
 

--- a/internal/handlers/v1/inscricao_handler.go
+++ b/internal/handlers/v1/inscricao_handler.go
@@ -489,7 +489,7 @@ func (h *InscricaoHandler) GetByID(c *gin.Context) {
 
 	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
 		if inscricao.CPF != middlewares.GetUserCPF(c) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "acesso negado"})
+			c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: você só pode visualizar suas próprias inscrições"})
 			return
 		}
 	}
@@ -502,17 +502,6 @@ func (h *InscricaoHandler) GetByID(c *gin.Context) {
 
 	// Enrich enrollment with personal info from citizen snapshot
 	h.service.EnrichWithPersonalInfo(c.Request.Context(), inscricao)
-
-	// Verificar se o usuário tem permissão para ver esta inscrição
-	userCPF := c.GetString("user_cpf")
-	userRole := c.GetString("user_role")
-
-	// Admin pode ver todas as inscrições
-	// Usuário comum só pode ver suas próprias inscrições
-	if userRole != "ADMIN" && userCPF != "" && inscricao.CPF != userCPF {
-		c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: você só pode visualizar suas próprias inscrições"})
-		return
-	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,

--- a/internal/handlers/v1/inscricao_handler_mock_test.go
+++ b/internal/handlers/v1/inscricao_handler_mock_test.go
@@ -612,6 +612,79 @@ func TestInscricaoHandler_GetByID_Success(t *testing.T) {
 	mockService.AssertExpectations(t)
 }
 
+// casa_civil may view any enrollment (not only their own CPF), even without ADMIN role.
+func TestInscricaoHandler_GetByID_CasaCivil_CanViewOthersEnrollment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockInscricaoService)
+	mockJobService := new(MockJobService)
+	mockCursoRepo := new(MockCursoRepository)
+
+	handler := v1.NewInscricaoHandler(mockService, mockJobService, mockCursoRepo)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserCPFKey, "02929367024")
+		c.Set(middlewares.UserRoleKey, "USER")
+		c.Set(middlewares.UserRolesKey, []string{"go:cursos:casa_civil"})
+		c.Next()
+	})
+	r.GET("/api/v1/courses/:courseId/enrollments/:enrollmentId", handler.GetByID)
+
+	enrollmentID := uuid.New()
+	inscricao := &models.Inscricao{
+		ID:      enrollmentID,
+		CursoID: 2746,
+		CPF:     "11122233344", // different from caller CPF
+	}
+
+	mockService.On("GetByID", mock.Anything, enrollmentID).
+		Return(inscricao, nil)
+	mockService.On("EnrichWithPersonalInfo", mock.Anything, inscricao).
+		Return()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/2746/enrollments/"+enrollmentID.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
+func TestInscricaoHandler_GetByID_Citizen_CannotViewOthersEnrollment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockInscricaoService)
+	mockJobService := new(MockJobService)
+	mockCursoRepo := new(MockCursoRepository)
+
+	handler := v1.NewInscricaoHandler(mockService, mockJobService, mockCursoRepo)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserCPFKey, "99988877766")
+		c.Set(middlewares.UserRoleKey, "USER")
+		c.Next()
+	})
+	r.GET("/api/v1/courses/:courseId/enrollments/:enrollmentId", handler.GetByID)
+
+	enrollmentID := uuid.New()
+	inscricao := &models.Inscricao{
+		ID:      enrollmentID,
+		CursoID: 2746,
+		CPF:     "11122233344",
+	}
+
+	mockService.On("GetByID", mock.Anything, enrollmentID).
+		Return(inscricao, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/2746/enrollments/"+enrollmentID.String(), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "você só pode visualizar suas próprias inscrições")
+	mockService.AssertExpectations(t)
+}
+
 // Test GetByID with not found
 func TestInscricaoHandler_GetByID_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/middlewares/course_auth.go
+++ b/internal/middlewares/course_auth.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	courseLoadedCursoKey   = "course_loaded_curso"
-	courseAllowedOrgaosKey = "course_allowed_orgaos"
+	courseLoadedCursoKey = "course_loaded_curso"
 )
 
 func isCursosEditor(c *gin.Context) bool {
@@ -20,6 +19,19 @@ func isCursosEditor(c *gin.Context) bool {
 
 func hasCourseOrgaoScope(c *gin.Context) bool {
 	return len(GetUserSecretariaOrgaoIDs(c)) > 0 || GetUserOrgaoID(c) != ""
+}
+
+// courseOrgaoInScope reports whether orgaoID is within the caller's authorized
+// scope, considering both the CPF→secretaria mapping and a single go:orgao role.
+// This mirrors hasCourseOrgaoScope (either source grants access) so that a caller
+// authorized by CourseAuthorization is never denied by CourseOwnershipCheck for a
+// course in the other source's scope.
+func courseOrgaoInScope(c *gin.Context, orgaoID string) bool {
+	if slices.Contains(GetUserSecretariaOrgaoIDs(c), orgaoID) {
+		return true
+	}
+	userOrgao := GetUserOrgaoID(c)
+	return userOrgao != "" && userOrgao == orgaoID
 }
 
 // CourseAuthorization allows only total admins, go:cursos:casa_civil, or go:cursos:editor
@@ -94,15 +106,6 @@ func CourseOrgaoInjector() gin.HandlerFunc {
 	}
 }
 
-func GetUserAllowedOrgaos(c *gin.Context) []string {
-	if v, exists := c.Get(courseAllowedOrgaosKey); exists {
-		if id, ok := v.([]string); ok {
-			return id
-		}
-	}
-	return nil
-}
-
 type courseLoaderFunc func(ctx context.Context, id int) (orgaoID string, found bool, err error)
 
 func CourseOwnershipCheck(loader courseLoaderFunc) gin.HandlerFunc {
@@ -137,19 +140,7 @@ func CourseOwnershipCheck(loader courseLoaderFunc) gin.HandlerFunc {
 		}
 
 		if isCursosEditor(c) {
-			secretariaIDs := GetUserSecretariaOrgaoIDs(c)
-			if len(secretariaIDs) > 0 {
-				if slices.Contains(secretariaIDs, orgaoID) {
-					c.Next()
-					return
-				}
-				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: curso não pertence à sua secretaria"})
-				c.Abort()
-				return
-			}
-
-			userOrgao := GetUserOrgaoID(c)
-			if userOrgao != "" && userOrgao == orgaoID {
+			if courseOrgaoInScope(c, orgaoID) {
 				c.Next()
 				return
 			}

--- a/internal/middlewares/course_auth_test.go
+++ b/internal/middlewares/course_auth_test.go
@@ -366,7 +366,7 @@ func TestGetCourseFilters_KeyExistsWithWrongType_ReturnsEmptyMap(t *testing.T) {
 
 // ============ CourseOrgaoInjector Tests ============
 
-func TestCourseOrgaoInjector_Admin_SetsNilAllowed(t *testing.T) {
+func TestCourseOrgaoInjector_Admin_Passes(t *testing.T) {
 	r := setupCourseTestRouter(
 		func(c *gin.Context) {
 			c.Set(middlewares.UserRoleKey, "ADMIN")
@@ -374,37 +374,23 @@ func TestCourseOrgaoInjector_Admin_SetsNilAllowed(t *testing.T) {
 		},
 		middlewares.CourseOrgaoInjector(),
 	)
-	r.GET("/test", func(c *gin.Context) {
-		allowed := middlewares.GetUserAllowedOrgaos(c)
-		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
-	})
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	assert.Nil(t, response["allowed"])
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestCourseOrgaoInjector_CasaCivil_SetsAllowedOrgaosNil(t *testing.T) {
+func TestCourseOrgaoInjector_CasaCivil_Passes(t *testing.T) {
 	r := setupCourseTestRouter(
 		injectCourseRoles("go:cursos:casa_civil", "", nil),
 		middlewares.CourseOrgaoInjector(),
 	)
-	r.GET("/test", func(c *gin.Context) {
-		allowed := middlewares.GetUserAllowedOrgaos(c)
-		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
-	})
+	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	assert.Nil(t, response["allowed"])
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestCourseOrgaoInjector_SecretariaOnly_Forbidden(t *testing.T) {
@@ -479,60 +465,6 @@ func TestCourseOrgaoInjector_NoRole_Forbidden(t *testing.T) {
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
 	assert.Equal(t, http.StatusForbidden, w.Code)
 	assert.Contains(t, w.Body.String(), "Sem permissão para criar: órgão não identificado")
-}
-
-// ============ GetUserAllowedOrgaos Tests ============
-
-func TestGetUserAllowedOrgaos_KeyNotSet_ReturnsNil(t *testing.T) {
-	r := setupCourseTestRouter()
-	r.GET("/test", func(c *gin.Context) {
-		allowed := middlewares.GetUserAllowedOrgaos(c)
-		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
-	})
-
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	assert.Nil(t, response["allowed"])
-}
-
-func TestGetUserAllowedOrgaos_KeyExists_ReturnsList(t *testing.T) {
-	r := setupCourseTestRouter()
-	r.GET("/test", func(c *gin.Context) {
-		c.Set("course_allowed_orgaos", []string{"a", "b"})
-		allowed := middlewares.GetUserAllowedOrgaos(c)
-		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
-	})
-
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	allowed, ok := response["allowed"].([]interface{})
-	assert.True(t, ok)
-	assert.ElementsMatch(t, []interface{}{"a", "b"}, allowed)
-}
-
-func TestGetUserAllowedOrgaos_KeyExistsWithWrongType_ReturnsNil(t *testing.T) {
-	r := setupCourseTestRouter()
-	r.GET("/test", func(c *gin.Context) {
-		c.Set("course_allowed_orgaos", 123) // tipo errado
-		allowed := middlewares.GetUserAllowedOrgaos(c)
-		c.JSON(http.StatusOK, gin.H{"allowed": allowed})
-	})
-
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/test", nil))
-
-	var response map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	assert.Nil(t, response["allowed"])
 }
 
 // ============ CourseOwnershipCheck Tests ============

--- a/internal/middlewares/vaga_auth.go
+++ b/internal/middlewares/vaga_auth.go
@@ -24,6 +24,19 @@ func hasVagaOrgaoScope(c *gin.Context) bool {
 	return len(GetUserSecretariaOrgaoIDs(c)) > 0 || GetUserOrgaoID(c) != ""
 }
 
+// vagaOrgaoInScope reports whether orgaoID is within the caller's authorized
+// scope, considering both the CPF→secretaria mapping and a single go:orgao role.
+// This mirrors hasVagaOrgaoScope (either source grants access) so that a caller
+// authorized by VagaAuthorization is never denied by VagaOwnershipCheck for a
+// vaga in the other source's scope.
+func vagaOrgaoInScope(c *gin.Context, orgaoID string) bool {
+	if slices.Contains(GetUserSecretariaOrgaoIDs(c), orgaoID) {
+		return true
+	}
+	userOrgao := GetUserOrgaoID(c)
+	return userOrgao != "" && userOrgao == orgaoID
+}
+
 // VagaAuthorization allows only total admins, go:empregabilidade:admin, or emp editors
 // with secretaria/orgao scope. Secretaria alone is not enough.
 func VagaAuthorization() gin.HandlerFunc {
@@ -44,7 +57,14 @@ func VagaAuthorization() gin.HandlerFunc {
 }
 
 // VagaListFilter injects orgao_parceiro_id restrictions into the context.
-// Without an empregabilidade editor/admin role, injects an empty list (no results).
+//
+// admin / go:empregabilidade:admin: sem restrição (nada injetado, veem tudo).
+// editor com escopo (secretaria ou órgão): restrito aos seus orgaos.
+// Qualquer outro caso — inclusive quem tem apenas secretaria mapeada mas NENHUMA
+// role de empregabilidade — recebe lista vazia ([]string{}), resultando em zero
+// resultados no handler. Isso é intencional: secretaria sozinha não libera acesso
+// (mesma regra da VagaAuthorization); listar tudo aqui vazaria vagas de todos os
+// órgãos para quem não deveria enxergá-las.
 func VagaListFilter() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !IsAdmin(c) && !HasRole(c, "go:empregabilidade:admin") {
@@ -121,7 +141,6 @@ func GetVagaAllowedOrgaos(c *gin.Context) []string {
 // VagaOwnershipInfo carries the vaga fields VagaOwnershipCheck needs.
 type VagaOwnershipInfo struct {
 	OrgaoParceiroID string
-	IsPublished     bool
 }
 
 // VagaLoaderFunc loads ownership info for a vaga. Returns nil when the vaga does
@@ -132,12 +151,14 @@ type VagaLoaderFunc func(ctx context.Context, id uuid.UUID) (*VagaOwnershipInfo,
 //
 // admin / go:empregabilidade:admin bypass every check. Any other caller must be
 // an empregabilidade editor whose secretaria/orgao scope contains the vaga's
-// orgao_parceiro. When enforcePublishedEdit is true, an already-published vaga
-// may only be edited by admin / go:empregabilidade:admin / editor_sem_curadoria.
+// orgao_parceiro.
 //
-// Like the other vaga/course authorization middlewares, this is wired only in
-// development/test (no-op in prod — see routes_emp.go / noOpHandler).
-func VagaOwnershipCheck(loader VagaLoaderFunc, enforcePublishedEdit bool) gin.HandlerFunc {
+// A regra de "quem pode editar vaga já publicada" NÃO fica aqui: ela depende do
+// status da vaga (que o gateway Heimdall não conhece) e por isso é aplicada no
+// handler (VagaHandler.Update), ativa em qualquer ambiente. Este middleware,
+// como os demais de autorização, roda só em development/test (no-op em prod —
+// ver routes_emp.go / noOpHandler).
+func VagaOwnershipCheck(loader VagaLoaderFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if IsAdmin(c) || HasRole(c, "go:empregabilidade:admin") {
 			c.Next()
@@ -169,23 +190,8 @@ func VagaOwnershipCheck(loader VagaLoaderFunc, enforcePublishedEdit bool) gin.Ha
 			return
 		}
 
-		if secretariaIDs := GetUserSecretariaOrgaoIDs(c); len(secretariaIDs) > 0 {
-			if !slices.Contains(secretariaIDs, info.OrgaoParceiroID) {
-				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: vaga não pertence à sua secretaria"})
-				c.Abort()
-				return
-			}
-		} else {
-			userOrgao := GetUserOrgaoID(c)
-			if userOrgao == "" || userOrgao != info.OrgaoParceiroID {
-				c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: vaga não pertence ao seu órgão"})
-				c.Abort()
-				return
-			}
-		}
-
-		if enforcePublishedEdit && info.IsPublished && !HasRole(c, "go:empregabilidade:editor_sem_curadoria") {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Apenas administradores, empregabilidade:admin ou editor_sem_curadoria podem editar vagas publicadas"})
+		if !vagaOrgaoInScope(c, info.OrgaoParceiroID) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: vaga não pertence à sua secretaria"})
 			c.Abort()
 			return
 		}

--- a/internal/middlewares/vaga_auth_test.go
+++ b/internal/middlewares/vaga_auth_test.go
@@ -492,7 +492,11 @@ const ownershipVagaUUID = "550e8400-e29b-41d4-a716-446655440000"
 
 // vagaLoaderStub returns a loader that always yields the given ownership info
 // (or nil / error to simulate not-found / failure).
-func vagaLoaderStub(orgaoID string, published, notFound bool, err error) middlewares.VagaLoaderFunc {
+//
+// A regra de "quem pode editar vaga publicada" NÃO é responsabilidade deste
+// middleware (fica no VagaHandler.Update, coberto em vaga_handler_test.go), por
+// isso o stub não carrega mais o status de publicação.
+func vagaLoaderStub(orgaoID string, notFound bool, err error) middlewares.VagaLoaderFunc {
 	return func(_ context.Context, _ uuid.UUID) (*middlewares.VagaOwnershipInfo, error) {
 		if err != nil {
 			return nil, err
@@ -500,17 +504,17 @@ func vagaLoaderStub(orgaoID string, published, notFound bool, err error) middlew
 		if notFound {
 			return nil, nil
 		}
-		return &middlewares.VagaOwnershipInfo{OrgaoParceiroID: orgaoID, IsPublished: published}, nil
+		return &middlewares.VagaOwnershipInfo{OrgaoParceiroID: orgaoID}, nil
 	}
 }
 
-func runVagaOwnership(inject gin.HandlerFunc, loader middlewares.VagaLoaderFunc, enforcePublishedEdit bool, id string) int {
+func runVagaOwnership(inject gin.HandlerFunc, loader middlewares.VagaLoaderFunc, id string) int {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	if inject != nil {
 		r.Use(inject)
 	}
-	r.PUT("/vagas/:id", middlewares.VagaOwnershipCheck(loader, enforcePublishedEdit),
+	r.PUT("/vagas/:id", middlewares.VagaOwnershipCheck(loader),
 		func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	w := httptest.NewRecorder()
@@ -525,90 +529,79 @@ func injectAdminRole() gin.HandlerFunc {
 	}
 }
 
-func TestVagaOwnershipCheck_Admin_BypassesEvenCrossOrgPublished(t *testing.T) {
+func TestVagaOwnershipCheck_Admin_BypassesEvenCrossOrg(t *testing.T) {
 	code := runVagaOwnership(injectAdminRole(),
-		vagaLoaderStub("orgao-b", true, false, nil), true, ownershipVagaUUID)
+		vagaLoaderStub("orgao-b", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusOK, code)
 }
 
 func TestVagaOwnershipCheck_EmpAdmin_Bypasses(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:admin", "", nil),
-		vagaLoaderStub("orgao-b", true, false, nil), true, ownershipVagaUUID)
+		vagaLoaderStub("orgao-b", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusOK, code)
 }
 
-// Non-admin editor updating a non-published, same-org vaga (via go:orgao group).
-func TestVagaOwnershipCheck_Editor_SameOrgUnpublished_Passes(t *testing.T) {
+// Non-admin editor acting on a same-org vaga (scope via go:orgao role).
+func TestVagaOwnershipCheck_Editor_SameOrg_Passes(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor_com_curadoria", "orgao-a", nil),
-		vagaLoaderStub("orgao-a", false, false, nil), true, ownershipVagaUUID)
+		vagaLoaderStub("orgao-a", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusOK, code)
 }
 
 // Same as above, but scope comes from the CPF→secretaria mapping.
-func TestVagaOwnershipCheck_Editor_SameSecretariaUnpublished_Passes(t *testing.T) {
+func TestVagaOwnershipCheck_Editor_SameSecretaria_Passes(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "", []string{"orgao-a", "orgao-x"}),
-		vagaLoaderStub("orgao-a", false, false, nil), true, ownershipVagaUUID)
+		vagaLoaderStub("orgao-a", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusOK, code)
 }
 
-func TestVagaOwnershipCheck_EditorSemCuradoria_SameOrgPublished_Passes(t *testing.T) {
-	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor_sem_curadoria", "orgao-a", nil),
-		vagaLoaderStub("orgao-a", true, false, nil), true, ownershipVagaUUID)
-	assert.Equal(t, http.StatusOK, code)
-}
-
-func TestVagaOwnershipCheck_EditorComCuradoria_SameOrgPublished_Forbidden(t *testing.T) {
-	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor_com_curadoria", "orgao-a", nil),
-		vagaLoaderStub("orgao-a", true, false, nil), true, ownershipVagaUUID)
-	assert.Equal(t, http.StatusForbidden, code)
-}
-
-// When published-edit is not enforced (e.g. Delete/status transitions), an
-// editor_com_curadoria may still act on a same-org published vaga.
-func TestVagaOwnershipCheck_EditorComCuradoria_SameOrgPublished_NoEnforce_Passes(t *testing.T) {
-	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor_com_curadoria", "orgao-a", nil),
-		vagaLoaderStub("orgao-a", true, false, nil), false, ownershipVagaUUID)
+// Escopo por secretaria e por órgão (role go:orgao) coexistem: uma vaga que casa
+// apenas com o órgão do usuário (fora da lista de secretarias) ainda deve passar,
+// alinhado ao que a VagaAuthorization autoriza (F4).
+func TestVagaOwnershipCheck_Editor_MatchesOrgaoNotSecretaria_Passes(t *testing.T) {
+	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "orgao-a", []string{"orgao-x", "orgao-y"}),
+		vagaLoaderStub("orgao-a", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusOK, code)
 }
 
 func TestVagaOwnershipCheck_Editor_CrossOrg_Forbidden(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor_sem_curadoria", "orgao-a", nil),
-		vagaLoaderStub("orgao-b", false, false, nil), false, ownershipVagaUUID)
+		vagaLoaderStub("orgao-b", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusForbidden, code)
 }
 
 func TestVagaOwnershipCheck_Editor_CrossSecretaria_Forbidden(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "", []string{"orgao-a", "orgao-x"}),
-		vagaLoaderStub("orgao-b", false, false, nil), false, ownershipVagaUUID)
+		vagaLoaderStub("orgao-b", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusForbidden, code)
 }
 
 func TestVagaOwnershipCheck_UnrelatedRole_Forbidden(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:cursos:editor", "orgao-a", nil),
-		vagaLoaderStub("orgao-a", false, false, nil), false, ownershipVagaUUID)
+		vagaLoaderStub("orgao-a", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusForbidden, code)
 }
 
 func TestVagaOwnershipCheck_Editor_NoScope_Forbidden(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "", nil),
-		vagaLoaderStub("orgao-a", false, false, nil), false, ownershipVagaUUID)
+		vagaLoaderStub("orgao-a", false, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusForbidden, code)
 }
 
 func TestVagaOwnershipCheck_NotFound(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "orgao-a", nil),
-		vagaLoaderStub("", false, true, nil), false, ownershipVagaUUID)
+		vagaLoaderStub("", true, nil), ownershipVagaUUID)
 	assert.Equal(t, http.StatusNotFound, code)
 }
 
 func TestVagaOwnershipCheck_InvalidID(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "orgao-a", nil),
-		vagaLoaderStub("orgao-a", false, false, nil), false, "not-a-uuid")
+		vagaLoaderStub("orgao-a", false, nil), "not-a-uuid")
 	assert.Equal(t, http.StatusBadRequest, code)
 }
 
 func TestVagaOwnershipCheck_LoaderError(t *testing.T) {
 	code := runVagaOwnership(injectVagaRoles("go:empregabilidade:editor", "orgao-a", nil),
-		vagaLoaderStub("", false, false, errors.New("boom")), false, ownershipVagaUUID)
+		vagaLoaderStub("", false, errors.New("boom")), ownershipVagaUUID)
 	assert.Equal(t, http.StatusInternalServerError, code)
 }

--- a/internal/router/routes_emp.go
+++ b/internal/router/routes_emp.go
@@ -47,15 +47,13 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		}
 		return &middlewares.VagaOwnershipInfo{
 			OrgaoParceiroID: vaga.IDOrgaoParceiro,
-			IsPublished:     vaga.Status.IsPublished(),
 		}, nil
 	}
 
 	var vagaAuth gin.HandlerFunc
 	var vagaOrgaoInjector gin.HandlerFunc
 	var vagaListFilter gin.HandlerFunc
-	var vagaOwnership gin.HandlerFunc     // ownership por órgão (mutações)
-	var vagaOwnershipEdit gin.HandlerFunc // ownership + regra de vaga publicada (Update)
+	var vagaOwnership gin.HandlerFunc // ownership por órgão (mutações)
 
 	// "development" cobre local + staging (ver comentário de noOpHandler em router.go).
 	// vagaAuth também protege o grupo /candidaturas mais abaixo nesta função.
@@ -63,14 +61,12 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		vagaAuth = middlewares.VagaAuthorization()
 		vagaOrgaoInjector = middlewares.VagaOrgaoInjector()
 		vagaListFilter = middlewares.VagaListFilter()
-		vagaOwnership = middlewares.VagaOwnershipCheck(vagaLoader, false)
-		vagaOwnershipEdit = middlewares.VagaOwnershipCheck(vagaLoader, true)
+		vagaOwnership = middlewares.VagaOwnershipCheck(vagaLoader)
 	} else {
 		vagaAuth = noOpHandler
 		vagaOrgaoInjector = noOpHandler
 		vagaListFilter = noOpHandler
 		vagaOwnership = noOpHandler
-		vagaOwnershipEdit = noOpHandler
 	}
 
 	// Vagas
@@ -80,7 +76,7 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		empVagas.POST("/draft", vagaAuth, vagaOrgaoInjector, app.EmpVagaHandler.Create)
 		empVagas.GET("", vagaAuth, vagaListFilter, app.EmpVagaHandler.List)
 		empVagas.GET("/:id", app.EmpVagaHandler.GetByID)
-		empVagas.PUT("/:id", vagaAuth, vagaOwnershipEdit, app.EmpVagaHandler.Update)
+		empVagas.PUT("/:id", vagaAuth, vagaOwnership, app.EmpVagaHandler.Update)
 		empVagas.DELETE("/:id", vagaAuth, vagaOwnership, app.EmpVagaHandler.Delete)
 		empVagas.PUT("/:id/send-to-draft", vagaAuth, vagaOwnership, app.EmpVagaHandler.SendToDraft)
 		empVagas.PUT("/:id/send-to-approval", vagaAuth, vagaOwnership, app.EmpVagaHandler.SendToApproval)

--- a/internal/services/empregabilidade/vaga_service.go
+++ b/internal/services/empregabilidade/vaga_service.go
@@ -147,6 +147,11 @@ func (s *VagaService) Update(ctx context.Context, entity *empregabilidade.Vaga) 
 
 	entity.Status = existing.Status
 
+	// O órgão parceiro define o escopo de autorização da vaga e nunca é
+	// reatribuído por um Update: preserva sempre o valor existente para evitar
+	// que um editor mova a vaga para fora da sua secretaria/órgão via body.
+	entity.IDOrgaoParceiro = existing.IDOrgaoParceiro
+
 	// Preserve required FK fields when not provided in the request body
 	if entity.IDContratante == "" {
 		entity.IDContratante = existing.IDContratante

--- a/internal/services/empregabilidade/vaga_service_test.go
+++ b/internal/services/empregabilidade/vaga_service_test.go
@@ -788,6 +788,37 @@ func TestVagaService_Update_Success(t *testing.T) {
 	})
 }
 
+func TestVagaService_Update_PreservesOrgaoParceiro(t *testing.T) {
+	t.Run("Update ignora reatribuição de órgão via body", func(t *testing.T) {
+		mockVagaRepo := NewMockVagaRepoForService()
+		mockEmpresaRepo := NewMockEmpresaRepoForService()
+		service := services.NewVagaServiceWithInterfaces(mockVagaRepo, mockEmpresaRepo, nil)
+
+		vagaID := uuid.New()
+		mockVagaRepo.vagas[vagaID] = &empregabilidade.Vaga{
+			ID:              vagaID,
+			Titulo:          "Desenvolvedor Go",
+			Status:          empregabilidade.StatusVagaEmEdicao,
+			IDOrgaoParceiro: "orgao-original",
+		}
+
+		// Um editor tenta mover a vaga para outro órgão pelo corpo do PUT.
+		updated := &empregabilidade.Vaga{
+			ID:              vagaID,
+			Titulo:          "Desenvolvedor Go Senior",
+			IDOrgaoParceiro: "orgao-invasor",
+		}
+
+		if err := service.Update(context.Background(), updated); err != nil {
+			t.Fatalf("Expected successful update, got error: %v", err)
+		}
+
+		if got := mockVagaRepo.vagas[vagaID].IDOrgaoParceiro; got != "orgao-original" {
+			t.Errorf("Expected orgao parceiro preserved as orgao-original, got %s", got)
+		}
+	})
+}
+
 func TestVagaService_Update_VagaNotFound(t *testing.T) {
 	t.Run("Error when vaga not found", func(t *testing.T) {
 		mockVagaRepo := NewMockVagaRepoForService()


### PR DESCRIPTION
## Contexto

Follow-up do #143 (já mergeado). O code review daquele PR apontou uma **regressão de segurança em produção** e outros itens. Este PR corrige todos eles. Cada correção tem teste.

## Correções

### 🔴 F1 — Regra de edição de vaga publicada voltou a valer em produção
O #143 removeu do `VagaHandler.Update` o check de "quem pode editar vaga publicada" e o moveu para o `VagaOwnershipCheck`, que é **no-op em prod** (só roda em dev/test). Como essa regra depende do *status* da vaga — algo que o gateway Heimdall não conhece —, ela ficou inativa em produção: qualquer chamador que passasse o gateway (ex.: `editor_com_curadoria`) podia editar vaga publicada.

**Fix:** a regra volta para o handler (`admin` / `empregabilidade:admin` / `editor_sem_curadoria`), onde roda em qualquer ambiente. O escopo por órgão permanece no middleware (dev/test).

### 🟠 F3 — Bloqueio de reatribuição de órgão (cross-org) no Update
`VagaOwnershipCheck` valida o órgão **existente**, mas o `Update` fazia bind de `id_orgao_parceiro` e o service não o preservava — um editor podia mover a vaga para outra secretaria via body.

**Fix:** `VagaService.Update` passa a preservar sempre `IDOrgaoParceiro` do registro existente.

### 🟡 F5 — GET público de curso não expõe mais rascunho
`GetByIDPublic` chamava `GetByID` cru, sem filtrar status, enquanto a listagem pública esconde `draft`. Rascunhos vazavam por ID.

**Fix:** a rota pública retorna 404 para cursos em rascunho (via `Status.Normalize()`, cobrindo o alias legado `CRIADO`). A rota autenticada segue inalterada.

### 🟡 F4 — Escopo de secretaria + órgão alinhado
Em `CourseOwnershipCheck`/`VagaOwnershipCheck`, quando havia secretarias mapeadas o ramo de `orgaoID` (role `go:orgao`) ficava inalcançável, podendo negar 403 num recurso que a autorização de rota já havia liberado.

**Fix:** helper `*OrgaoInScope` que checa ambos os conjuntos, espelhando `*Authorization`.

### 🔵 F2 / F7 — Limpeza
- Remove o guard de `allowedOrgaos` no `Create`/`CreateDraft` de curso e o getter `GetUserAllowedOrgaos` (dead code: o `courseAllowedOrgaosKey` nunca mais é populado).
- Remove o wrapper redundante `isPublishedStatus` (usa `Status.IsPublished()` direto).
- Simplifica `VagaOwnershipCheck` removendo o parâmetro `enforcePublishedEdit` (regra agora é fonte única no handler).

### 📝 F6 — Documentação
Comentário explícito no `VagaListFilter` sobre o comportamento **intencional** de lista vazia para quem tem apenas secretaria mapeada (secretaria sozinha não libera).

## Validação
- `just fmt` ✅
- `just lint` ✅ (0 issues)
- `just build` ✅
- `just test` ✅ (suíte completa com race detection, verde)