### PR TITLE
fix(rbac): libera ListByUser para go:cursos:casa_civil

### DIFF
--- a/internal/handlers/v1/inscricao_handler.go
+++ b/internal/handlers/v1/inscricao_handler.go
@@ -808,15 +808,14 @@ func (h *InscricaoHandler) ListByUser(c *gin.Context) {
 		return
 	}
 
-	// Verificar se o usuário tem permissão para ver estas inscrições
-	userCPF := c.GetString("user_cpf")
-	userRole := c.GetString("user_role")
-
-	// Admin pode ver inscrições de qualquer pessoa
-	// Usuário comum só pode ver suas próprias inscrições
-	if userRole != "ADMIN" && userCPF != "" && cpf != userCPF {
-		c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: você só pode visualizar suas próprias inscrições"})
-		return
+	// Admin / casa_civil podem ver inscrições de qualquer CPF.
+	// Cidadão só pode ver as próprias.
+	if !middlewares.IsAdmin(c) && !middlewares.HasRole(c, "go:cursos:casa_civil") {
+		userCPF := middlewares.GetUserCPF(c)
+		if userCPF != "" && cpf != userCPF {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Acesso negado: você só pode visualizar suas próprias inscrições"})
+			return
+		}
 	}
 
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
@@ -917,7 +916,7 @@ func (h *InscricaoHandler) ChangeSchedule(c *gin.Context) {
 	}
 
 	// Get user CPF from token
-	userCPF := c.GetString("user_cpf")
+	userCPF := middlewares.GetUserCPF(c)
 	if userCPF == "" {
 		c.JSON(http.StatusForbidden, gin.H{"error": "CPF do usuário não encontrado no token"})
 		return

--- a/internal/handlers/v1/inscricao_handler_mock_test.go
+++ b/internal/handlers/v1/inscricao_handler_mock_test.go
@@ -1100,6 +1100,43 @@ func TestInscricaoHandler_ListByUser_Forbidden(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
+func TestInscricaoHandler_ListByUser_CasaCivil_CanViewOtherUser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockInscricaoService)
+	mockJobService := new(MockJobService)
+	mockCursoRepo := new(MockCursoRepository)
+
+	handler := v1.NewInscricaoHandler(mockService, mockJobService, mockCursoRepo)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserCPFKey, "02929367024")
+		c.Set(middlewares.UserRoleKey, "USER")
+		c.Set(middlewares.UserRolesKey, []string{"go:cursos:casa_civil"})
+		c.Next()
+	})
+	r.GET("/api/v1/enrollments/user/:cpf", handler.ListByUser)
+
+	targetCPF := "49806617090"
+	inscricoes := []*models.Inscricao{
+		{ID: uuid.New(), CursoID: 2746, CPF: targetCPF},
+	}
+
+	mockService.On("ListByCPF", mock.Anything, targetCPF, mock.Anything, 0, 10).
+		Return(inscricoes, 1, nil)
+	mockCursoRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).
+		Return(make(map[uuid.UUID]int64), nil)
+	mockService.On("EnrichMultipleWithPersonalInfo", mock.Anything, inscricoes).
+		Return()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/enrollments/user/"+targetCPF, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	mockService.AssertExpectations(t)
+}
+
 // --- Import Tests ---
 
 // Test Import with CSV file - validates request and creates job


### PR DESCRIPTION
Alinha o bypass de ListByUser com GetByID (IsAdmin/casa_civil) em vez de checar só user_role == ADMIN.