### PR TITLE
feat(cursos): ordenação opcional por disponibilidade no GET /api/public/courses.

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -88,6 +88,15 @@ const docTemplate = `{
                         "description": "Filtrar por zona do bairro",
                         "name": "neighborhood_zone",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "availability"
+                        ],
+                        "type": "string",
+                        "description": "Ordenação opcional. 'availability': cursos com inscrição disponível primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação é aplicada antes da paginação. Omitido = ordem padrão (id desc).",
+                        "name": "sort",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1066,6 +1075,15 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filtrar por zona do bairro",
                         "name": "neighborhood_zone",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "availability"
+                        ],
+                        "type": "string",
+                        "description": "Ordenação opcional. 'availability': cursos com inscrição disponível primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação é aplicada antes da paginação. Omitido = ordem padrão (id desc).",
+                        "name": "sort",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -86,6 +86,15 @@
                         "description": "Filtrar por zona do bairro",
                         "name": "neighborhood_zone",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "availability"
+                        ],
+                        "type": "string",
+                        "description": "Ordenação opcional. 'availability': cursos com inscrição disponível primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação é aplicada antes da paginação. Omitido = ordem padrão (id desc).",
+                        "name": "sort",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1064,6 +1073,15 @@
                         "type": "string",
                         "description": "Filtrar por zona do bairro",
                         "name": "neighborhood_zone",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "availability"
+                        ],
+                        "type": "string",
+                        "description": "Ordenação opcional. 'availability': cursos com inscrição disponível primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação é aplicada antes da paginação. Omitido = ordem padrão (id desc).",
+                        "name": "sort",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1707,6 +1707,15 @@ paths:
         in: query
         name: neighborhood_zone
         type: string
+      - description: 'Ordenação opcional. ''availability'': cursos com inscrição disponível
+          primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas
+          — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação
+          é aplicada antes da paginação. Omitido = ordem padrão (id desc).'
+        enum:
+        - availability
+        in: query
+        name: sort
+        type: string
       produces:
       - application/json
       responses:
@@ -2360,6 +2369,15 @@ paths:
       - description: Filtrar por zona do bairro
         in: query
         name: neighborhood_zone
+        type: string
+      - description: 'Ordenação opcional. ''availability'': cursos com inscrição disponível
+          primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas
+          — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação
+          é aplicada antes da paginação. Omitido = ordem padrão (id desc).'
+        enum:
+        - availability
+        in: query
+        name: sort
         type: string
       produces:
       - application/json

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -3,8 +3,10 @@ package v1
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -510,6 +512,7 @@ func parseStatusFilter(param string) []string {
 // @Param        categoria_id      query     int     false  "Filtrar por categoria"
 // @Param        acessibilidade_id query     int     false  "Filtrar por acessibilidade"
 // @Param        neighborhood_zone query     string  false  "Filtrar por zona do bairro"
+// @Param        sort              query     string  false  "Ordenação opcional. 'availability': cursos com inscrição disponível primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação é aplicada antes da paginação. Omitido = ordem padrão (id desc)."  Enums(availability)
 // @Success      200               {object}  object
 // @Failure      500               {object}  models.ErrorResponse
 // @Router       /api/public/courses [get]
@@ -530,6 +533,7 @@ func (h *CourseHandler) ListPublic(c *gin.Context) {
 // @Param        categoria_id      query     int     false  "Filtrar por categoria"
 // @Param        acessibilidade_id query     int     false  "Filtrar por acessibilidade"
 // @Param        neighborhood_zone query     string  false  "Filtrar por zona do bairro"
+// @Param        sort              query     string  false  "Ordenação opcional. 'availability': cursos com inscrição disponível primeiro; os sem inscrição (status final, prazo vencido ou vagas esgotadas — inclusive accepting_enrollments sem vagas) vão para o final. A ordenação é aplicada antes da paginação. Omitido = ordem padrão (id desc)."  Enums(availability)
 // @Success      200               {object}  object
 // @Failure      500               {object}  models.ErrorResponse
 // @Router       /api/v1/courses [get]
@@ -605,9 +609,16 @@ func (h *CourseHandler) List(c *gin.Context) {
 		filter["neighborhood_zone"] = neighborhoodZone
 	}
 
+	// Optional ordering: put courses a citizen can still enroll in first.
+	sortByAvailability := strings.EqualFold(strings.TrimSpace(c.Query("sort")), sortAvailability)
+
+	// The cache key must vary by ordering so the sorted and unsorted variants of the
+	// same filter/page do not collide. The sort marker is kept out of `filter` (which
+	// is passed to the repository query) to avoid it being treated as a column filter.
+	filterHash := cache.HashFilter(cacheFilter(filter, sortByAvailability), page, limit)
+
 	// Try cache first (if caching is enabled)
 	if h.courseCache != nil {
-		filterHash := cache.HashFilter(filter, page, limit)
 		cachedData, err := h.courseCache.GetList(c.Request.Context(), filterHash)
 		if err == nil && cachedData != nil {
 			var cachedResponse gin.H
@@ -619,16 +630,29 @@ func (h *CourseHandler) List(c *gin.Context) {
 		}
 	}
 
-	cursos, total, err := h.cursoService.List(c.Request.Context(), filter, page, limit)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao listar cursos: " + err.Error()})
-		return
-	}
+	var cursos []*models.Curso
+	var total int
 
-	// Calculate remaining vacancies for all courses in a single batched query
-	if err := h.calculateRemainingVacanciesForCourses(c, cursos); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao calcular vagas restantes: " + err.Error()})
-		return
+	if sortByAvailability {
+		var err error
+		cursos, total, err = h.listSortedByAvailability(c, filter, page, limit)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao listar cursos: " + err.Error()})
+			return
+		}
+	} else {
+		var err error
+		cursos, total, err = h.cursoService.List(c.Request.Context(), filter, page, limit)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao listar cursos: " + err.Error()})
+			return
+		}
+
+		// Calculate remaining vacancies for all courses in a single batched query
+		if err := h.calculateRemainingVacanciesForCourses(c, cursos); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao calcular vagas restantes: " + err.Error()})
+			return
+		}
 	}
 
 	totalPages := (total + limit - 1) / limit
@@ -653,11 +677,77 @@ func (h *CourseHandler) List(c *gin.Context) {
 
 	// Cache the result (if caching is enabled)
 	if h.courseCache != nil {
-		filterHash := cache.HashFilter(filter, page, limit)
 		_ = h.courseCache.SetList(c.Request.Context(), filterHash, response)
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// sortAvailability is the value of the `sort` query param that orders courses by
+// enrollment availability (available first, sold-out/closed last).
+const sortAvailability = "availability"
+
+// cacheFilter returns a copy of filter augmented with the ordering marker when
+// availability sorting is active, so cached responses key on the ordering too. The
+// original filter is never mutated (it is used verbatim by the repository query).
+func cacheFilter(filter map[string]interface{}, sortByAvailability bool) map[string]interface{} {
+	if !sortByAvailability {
+		return filter
+	}
+	out := make(map[string]interface{}, len(filter)+1)
+	for k, v := range filter {
+		out[k] = v
+	}
+	out["_sort"] = sortAvailability
+	return out
+}
+
+// listSortedByAvailability fetches every course matching filter, orders those a
+// citizen can still enroll in ahead of the rest, and returns the requested page.
+// Ordering must happen before pagination, so the full result set is materialized
+// and sorted in memory; within each group the repository's id-desc order is kept.
+func (h *CourseHandler) listSortedByAvailability(c *gin.Context, filter map[string]interface{}, page, limit int) ([]*models.Curso, int, error) {
+	// limit <= 0 tells the repository to skip the SQL LIMIT and return every match.
+	allCursos, total, err := h.cursoRepo.List(c.Request.Context(), filter, -1, 0)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Vacancies feed the availability check, so they must be computed before sorting.
+	if err := h.calculateRemainingVacanciesForCourses(c, allCursos); err != nil {
+		return nil, 0, err
+	}
+
+	now := time.Now()
+	type rankedCurso struct {
+		curso     *models.Curso
+		available bool
+	}
+	ranked := make([]rankedCurso, len(allCursos))
+	for i, curso := range allCursos {
+		ranked[i] = rankedCurso{curso: curso, available: curso.IsEnrollmentAvailable(now)}
+	}
+	// Stable so the repository's id-desc order is preserved within each group.
+	sort.SliceStable(ranked, func(a, b int) bool {
+		return ranked[a].available && !ranked[b].available
+	})
+
+	start := (page - 1) * limit
+	if start > len(ranked) {
+		start = len(ranked)
+	}
+	end := start + limit
+	if end > len(ranked) {
+		end = len(ranked)
+	}
+
+	pageCursos := make([]*models.Curso, 0, end-start)
+	for _, r := range ranked[start:end] {
+		// Apply the derived status for the response, mirroring CursoService.List.
+		r.curso.Status = r.curso.DeriveStatus(now)
+		pageCursos = append(pageCursos, r.curso)
+	}
+	return pageCursos, total, nil
 }
 
 // @Summary      Listar cursos rascunho

--- a/internal/handlers/v1/course_handler_sort_test.go
+++ b/internal/handlers/v1/course_handler_sort_test.go
@@ -1,0 +1,129 @@
+package v1_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	v1 "github.com/prefeitura-rio/app-go-api/internal/handlers/v1"
+	"github.com/prefeitura-rio/app-go-api/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Availability sorting must place courses a citizen can still enroll in ahead of the
+// rest (finished/closed/canceled, past deadline, or sold out — including
+// accepting_enrollments with zero vacancies), globally, before paginating.
+func TestCourseHandler_List_SortByAvailability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+
+	r := gin.New()
+	r.GET("/api/public/courses", handler.ListPublic)
+
+	now := time.Now()
+	past := now.Add(-24 * time.Hour)
+	future := now.Add(24 * time.Hour)
+	classStart := now.Add(-1 * time.Hour)
+	classEnd := now.Add(48 * time.Hour)
+
+	schedAvailable := uuid.New() // has vacancies
+	schedSoldOut := uuid.New()   // accepting_enrollments but zero vacancies
+
+	openCourse := func(id int, schedID uuid.UUID, vacancies int) *models.Curso {
+		return &models.Curso{
+			ID:                  id,
+			Titulo:              "Course",
+			Status:              models.StatusCursoPublished,
+			Modalidade:          models.ModalidadePresencial,
+			EnrollmentStartDate: &past,
+			EnrollmentEndDate:   &future,
+			LocationClasses: []models.LocationClass{
+				{Schedules: []models.CourseSchedule{
+					{ID: schedID, Vacancies: vacancies, ClassStartDate: classStart, ClassEndDate: classEnd},
+				}},
+			},
+		}
+	}
+
+	// Repository returns rows in id-desc order: 3 (sold out), 2 (closed), 1 (available).
+	cursos := []*models.Curso{
+		openCourse(3, schedSoldOut, 5),
+		{ID: 2, Titulo: "Closed", Status: models.StatusCursoClosed, Modalidade: models.ModalidadePresencial},
+		openCourse(1, schedAvailable, 10),
+	}
+
+	// limit <= 0 signals "return every match" for the sorted path.
+	mockRepo.On("List", mock.Anything, mock.Anything, -1, 0).Return(cursos, 3, nil)
+	// schedSoldOut is fully booked (5/5); schedAvailable has no enrollments.
+	mockRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).
+		Return(map[uuid.UUID]int64{schedSoldOut: 5}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/public/courses?sort=availability&page=1&limit=2", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		Data struct {
+			Courses []struct {
+				ID int `json:"id"`
+			} `json:"courses"`
+			Pagination struct {
+				Total      int `json:"total"`
+				TotalPages int `json:"total_pages"`
+			} `json:"pagination"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	// Page 1 (limit 2): available course (id 1) first, then id 3 preserving id-desc
+	// within the "unavailable" group (the sold-out accepting course sinks below).
+	require.Len(t, response.Data.Courses, 2)
+	assert.Equal(t, 1, response.Data.Courses[0].ID, "available course must come first")
+	assert.Equal(t, 3, response.Data.Courses[1].ID)
+	assert.Equal(t, 3, response.Data.Pagination.Total)
+	assert.Equal(t, 2, response.Data.Pagination.TotalPages)
+
+	// The sorted path must not fall back to the paginated service.List.
+	mockService.AssertNotCalled(t, "List", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockRepo.AssertExpectations(t)
+}
+
+// Without the sort param, the handler keeps the existing behavior: it delegates to
+// the paginated service.List and does not fetch the full result set.
+func TestCourseHandler_List_NoSort_UsesService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockService := new(MockCursoService)
+	mockInscricaoService := new(MockInscricaoServiceForCourse)
+	mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+	handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+
+	r := gin.New()
+	r.GET("/api/public/courses", handler.ListPublic)
+
+	cursos := []*models.Curso{{ID: 1, Titulo: "Course 1"}}
+	mockService.On("List", mock.Anything, mock.Anything, 1, 10).Return(cursos, 1, nil)
+	mockRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).
+		Return(make(map[uuid.UUID]int64), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/public/courses", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+	// The unsorted path must not fetch the full result set via repo.List.
+	mockRepo.AssertNotCalled(t, "List", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}

--- a/internal/models/curso.go
+++ b/internal/models/curso.go
@@ -292,6 +292,114 @@ func (c *Curso) DeriveStatus(now time.Time) StatusCurso {
 	return c.Status
 }
 
+// IsEnrollmentAvailable reports whether a citizen can still enroll in this course
+// right now. It mirrors the frontend getCourseEnrollmentInfo(...).canEnroll logic
+// (with no user enrollment) so that API-side ordering matches the enrollment button
+// state shown in the portal: a course is available only when its (derived) status
+// allows new enrollments, the enrollment window is open, the classes have not ended
+// and at least one turma still has vacancies.
+//
+// RemainingVacancies must already be populated on the schedules (see the handler's
+// vacancy calculation); otherwise every turma looks sold out.
+func (c *Curso) IsEnrollmentAvailable(now time.Time) bool {
+	status := c.DeriveStatus(now)
+
+	// Derived terminal / not-yet-open states are never enrollable.
+	switch status {
+	case StatusCursoFinished, StatusCursoScheduled:
+		return false
+	}
+
+	// Stored terminal / non-published states (also covers legacy via Normalize).
+	switch status.Normalize() {
+	case StatusCursoClosed, StatusCursoCanceled, StatusCursoDraft,
+		StatusCursoInReview, StatusCursoNeedsChanges, StatusCursoApproved,
+		StatusCursoPendingDeletion:
+		return false
+	}
+
+	// When the backend has not explicitly derived accepting_enrollments, apply the
+	// same date-based checks the frontend does before looking at vacancies.
+	if status != StatusCursoAcceptingEnrollments {
+		if c.EnrollmentStartDate != nil && now.Before(*c.EnrollmentStartDate) {
+			return false // inscrições ainda não abriram
+		}
+		if end, ok := latestClassEndDate(c); ok && now.After(end) {
+			return false // curso encerrado
+		}
+		if c.EnrollmentEndDate != nil && now.After(*c.EnrollmentEndDate) {
+			return false // inscrições encerradas
+		}
+	}
+
+	// Vacancy check, gated by modalidade exactly like the frontend (hibrido and
+	// LIVRE_FORMACAO_ONLINE are intentionally not blocked by vacancies).
+	switch strings.ToLower(string(c.Modalidade)) {
+	case "online", "remoto":
+		if !hasAvailableRemoteVacancies(c) {
+			return false // vagas encerradas
+		}
+	case "presencial", "semipresencial":
+		if !hasAvailableInPersonVacancies(c) {
+			return false // vagas encerradas
+		}
+	}
+
+	return true
+}
+
+// latestClassEndDate returns the latest class end date across all turmas (remote and
+// location schedules), mirroring the frontend getLatestClassEndDate helper.
+func latestClassEndDate(c *Curso) (latest time.Time, has bool) {
+	apply := func(end time.Time) {
+		if !has || end.After(latest) {
+			latest, has = end, true
+		}
+	}
+	for _, loc := range c.LocationClasses {
+		for _, s := range loc.Schedules {
+			apply(s.ClassEndDate)
+		}
+	}
+	if c.RemoteClass != nil {
+		for _, s := range c.RemoteClass.Schedules {
+			if s.ClassEndDate != nil {
+				apply(*s.ClassEndDate)
+			}
+		}
+	}
+	return
+}
+
+// hasAvailableRemoteVacancies mirrors the negation of the frontend
+// hasNoAvailableOnlineClasses for online/remoto courses.
+func hasAvailableRemoteVacancies(c *Curso) bool {
+	if c.RemoteClass != nil && len(c.RemoteClass.Schedules) > 0 {
+		for _, s := range c.RemoteClass.Schedules {
+			if s.RemainingVacancies > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	// A remote class with no turmas has no vacancies; no remote class at all means
+	// this check does not apply (the frontend does not block enrollment on it).
+	return c.RemoteClass == nil
+}
+
+// hasAvailableInPersonVacancies mirrors the negation of the frontend
+// hasNoAvailableInPersonClasses for presencial/semipresencial courses.
+func hasAvailableInPersonVacancies(c *Curso) bool {
+	for _, loc := range c.LocationClasses {
+		for _, s := range loc.Schedules {
+			if s.RemainingVacancies > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func collectClassDateRange(c *Curso) (minStart, maxEnd time.Time, has bool) {
 	apply := func(start, end time.Time) {
 		if !has {

--- a/internal/models/curso_availability_test.go
+++ b/internal/models/curso_availability_test.go
@@ -1,0 +1,199 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prefeitura-rio/app-go-api/internal/models"
+)
+
+// remoteVacancy builds a remote schedule with a class window and remaining vacancies.
+func remoteSchedule(remaining int, start, end *time.Time) models.RemoteSchedule {
+	s := models.RemoteSchedule{Vacancies: remaining, ClassStartDate: start, ClassEndDate: end}
+	s.RemainingVacancies = remaining
+	return s
+}
+
+// locationSchedule builds a location schedule with a class window and remaining vacancies.
+func locationSchedule(remaining int, start, end time.Time) models.CourseSchedule {
+	s := models.CourseSchedule{Vacancies: remaining, ClassStartDate: start, ClassEndDate: end}
+	s.RemainingVacancies = remaining
+	return s
+}
+
+func TestCurso_IsEnrollmentAvailable(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-30 * 24 * time.Hour)
+	future := now.Add(30 * 24 * time.Hour)
+	classStart := now.Add(-10 * 24 * time.Hour)
+	classEnd := now.Add(10 * 24 * time.Hour)
+	classEndPast := now.Add(-5 * 24 * time.Hour)
+
+	tests := []struct {
+		name  string
+		curso models.Curso
+		want  bool
+	}{
+		{
+			name: "presencial accepting_enrollments with vacancies is available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadePresencial,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(future),
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEnd)}},
+				},
+			},
+			want: true,
+		},
+		{
+			// Regression from the ticket (course id 2804): accepting_enrollments but
+			// every turma is sold out must not count as available.
+			name: "presencial accepting_enrollments but sold out is NOT available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadePresencial,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(future),
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(0, classStart, classEnd)}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "remoto accepting_enrollments with vacancies is available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadeRemoto,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(future),
+				RemoteClass: &models.RemoteClass{
+					Schedules: []models.RemoteSchedule{remoteSchedule(3, ptr(classStart), ptr(classEnd))},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "remoto accepting_enrollments but sold out is NOT available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadeRemoto,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(future),
+				RemoteClass: &models.RemoteClass{
+					Schedules: []models.RemoteSchedule{remoteSchedule(0, ptr(classStart), ptr(classEnd))},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "closed is NOT available",
+			curso: models.Curso{
+				Status:     models.StatusCursoClosed,
+				Modalidade: models.ModalidadePresencial,
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEnd)}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "canceled is NOT available",
+			curso: models.Curso{
+				Status:     models.StatusCursoCanceled,
+				Modalidade: models.ModalidadePresencial,
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEnd)}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "finished (past class dates) is NOT available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadePresencial,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(past.Add(5 * 24 * time.Hour)),
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEndPast)}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "scheduled (enrollment not open yet) is NOT available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadePresencial,
+				EnrollmentStartDate: ptr(future),
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEnd)}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "published, enrollment window passed, is NOT available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadePresencial,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(past.Add(24 * time.Hour)),
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEnd)}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "draft is NOT available",
+			curso: models.Curso{
+				Status:     models.StatusCursoDraft,
+				Modalidade: models.ModalidadePresencial,
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{locationSchedule(5, classStart, classEnd)}},
+				},
+			},
+			want: false,
+		},
+		{
+			// LIVRE_FORMACAO_ONLINE has no turmas, so the vacancy gate does not apply.
+			name: "LIVRE_FORMACAO_ONLINE within window is available (no vacancy gate)",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadeLivreFormacaoOnline,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(future),
+			},
+			want: true,
+		},
+		{
+			name: "presencial with one sold-out and one open turma is available",
+			curso: models.Curso{
+				Status:              models.StatusCursoPublished,
+				Modalidade:          models.ModalidadePresencial,
+				EnrollmentStartDate: ptr(past),
+				EnrollmentEndDate:   ptr(future),
+				LocationClasses: []models.LocationClass{
+					{Schedules: []models.CourseSchedule{
+						locationSchedule(0, classStart, classEnd),
+						locationSchedule(2, classStart, classEnd),
+					}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.curso
+			if got := c.IsEnrollmentAvailable(now); got != tt.want {
+				t.Errorf("IsEnrollmentAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/repository/curso_repository.go
+++ b/internal/repository/curso_repository.go
@@ -137,7 +137,7 @@ func (r *CursoRepository) List(ctx context.Context, filter map[string]interface{
 	// Fetch records with selective preloading
 	// List view only needs basic info + schedules for vacancy calculation
 	// Skip CustomFields, Instituicao details to reduce data transfer
-	result := baseQuery.
+	query := baseQuery.
 		Preload("Categorias").
 		Preload("Acessibilidades").
 		Preload("LocationClasses.Schedules", func(db *gorm.DB) *gorm.DB {
@@ -146,10 +146,16 @@ func (r *CursoRepository) List(ctx context.Context, filter map[string]interface{
 		Preload("RemoteClass.Schedules", func(db *gorm.DB) *gorm.DB {
 			return db.Order("display_order ASC")
 		}).
-		Order("id DESC").
-		Limit(limit).
-		Offset(offset).
-		Find(&cursos)
+		Order("id DESC")
+
+	// A non-positive limit means "no pagination" — return every matching row. This
+	// is used by availability sorting, which must order the full result set before
+	// slicing it into pages.
+	if limit > 0 {
+		query = query.Limit(limit).Offset(offset)
+	}
+
+	result := query.Find(&cursos)
 
 	if result.Error != nil {
 		return nil, 0, fmt.Errorf("erro ao listar cursos: %w", result.Error)

--- a/internal/repository/curso_repository_test.go
+++ b/internal/repository/curso_repository_test.go
@@ -539,6 +539,40 @@ func TestCursoRepository_List(t *testing.T) {
 		assert.Len(t, cursos, 2)
 	})
 
+	t.Run("list without pagination when limit <= 0 returns all rows", func(t *testing.T) {
+		// A non-positive limit is used by availability sorting to fetch the full
+		// result set (no SQL LIMIT/OFFSET) before ordering and slicing in memory.
+		db2, mock2, cleanup2 := SetupMockDB(t)
+		defer cleanup2()
+		repo2 := NewCursoRepository(db2)
+		mock2.MatchExpectationsInOrder(false)
+
+		mock2.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "cursos"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+
+		rows := sqlmock.NewRows([]string{"id", "titulo", "status"}).
+			AddRow(3, "Curso 3", "published").
+			AddRow(2, "Curso 2", "published").
+			AddRow(1, "Curso 1", "published")
+		mock2.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnRows(rows)
+
+		mock2.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos_categorias"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"curso_id", "categoria_id"}))
+		mock2.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos_acessibilidades"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"curso_id", "acessibilidade_id"}))
+		mock2.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+		mock2.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+		cursos, total, err := repo2.List(ctx, nil, -1, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, total)
+		assert.Len(t, cursos, 3)
+		assert.NoError(t, mock2.ExpectationsWereMet())
+	})
+
 	t.Run("list count error", func(t *testing.T) {
 		mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "cursos"`)).
 			WillReturnError(assert.AnError)


### PR DESCRIPTION
[PREF-416](https://iplanrio-pcrj.atlassian.net/browse/PREF-416)

## Contexto

O pref.rio passou a paginar a listagem de cursos via `GET /api/public/courses` (`page`/`limit`). Antes, o frontend ordenava a lista inteira no client — cursos em que ainda dá para se inscrever primeiro; os que não dá mais, no final (`sortCourses` em `superapp/src/lib/course-utils.ts`). Com paginação, ordenar no client não funciona mais: a ordem precisa vir da API.

O botão de inscrição no portal não depende só do campo `status`. Em `getCourseEnrollmentInfo`, ele fica desabilitado também por prazo de inscrição vencido e por falta de vagas — inclusive quando `status = accepting_enrollments` mas todas as turmas estão com `remaining_vacancies = 0` (ex. curso id 2804).

## O que muda

Novo query param **opcional** `sort=availability` no `GET /api/public/courses` (e no `/api/v1/courses`, que compartilha o handler):

| Sem o param | Com `sort=availability` |
|---|---|
| Comportamento atual (ordem `id desc`), **sem breaking change** | Cursos com inscrição disponível primeiro; os sem inscrição no final |

A ordenação é aplicada **antes da paginação** (globalmente sobre o resultado filtrado), então `page`/`limit`/`total`/`total_pages` ficam coerentes com a ordem.

`GET /api/public/courses?page=1&limit=12&status=...&sort=availability`


## Como a regra "pode se inscrever?" foi reproduzida

`Curso.IsEnrollmentAvailable(now)` espelha fielmente o `getCourseEnrollmentInfo(...).canEnroll` do frontend (sem `userEnrollment`): status derivado (`finished`/`closed`/`canceled`/`scheduled` → indisponível), janela de inscrição, fim das aulas e vagas por turma — com o mesmo gate por modalidade (`hibrido` e `LIVRE_FORMACAO_ONLINE` não são bloqueados por vaga).
Reusa o `DeriveStatus` e o cálculo de vagas restantes já existentes.

Quando `sort=availability`, o handler busca todo o conjunto filtrado (`repository.List` com `limit <= 0` = sem `LIMIT`/`OFFSET`), calcula vagas, faz um `sort.SliceStable` (disponíveis primeiro, preservando `id desc` dentro de cada grupo) e fatia a página em memória.

## Decisão de design: ordenação em memória vs. no SQL

A ordenação é feita **em memória** (busca todo o conjunto filtrado e ordena em Go), não via `ORDER BY` no banco. Foi uma escolha consciente de custo/risco:

- **A regra "disponível" não é uma coluna nem uma condição simples.** É uma cascata de ramos com precedência (status derivado → janela de inscrição → fim das aulas → vagas), com tratamento de datas opcionais (`NULL`) e gate por modalidade. Reproduzir isso em SQL bruto significaria uma **terceira** fonte de verdade (além do TS do frontend e do `DeriveStatus` em Go), mantida em sincronia manualmente, sem compilador nem teste forçando a consistência.
- **`remaining_vacancies` é um agregado filtrado, não uma coluna:** `vacancies` da turma menos a contagem de inscrições `approved`/`concluded`, em duas tabelas de turma (location e remote). No SQL isso vira subquery correlacionada com `COUNT` correlacionado dentro do `ORDER BY` — caro e com a definição de "vaga ocupada" duplicada em relação a `CountEnrollmentsByScheduleIDs`.
- **Fidelidade:** a abordagem em Go reusa o `DeriveStatus` já testado e o `IsEnrollmentAvailable` é testável unitariamente com `time` controlado. Já existe hoje no repo um exemplo de divergência entre a derivação real e a aproximação SQL (o ramo `accepting_enrollments` em `applyStatusINFilter` exige ambas as datas não-nulas, ao contrário do `DeriveStatus`) — replicar a regra inteira em SQL multiplicaria essas oportunidades de divergência.

**Trade-off / quando revisitar:** o caminho ordenado materializa todo o conjunto filtrado a cada cache-miss. Para o volume de uma prefeitura (centenas de cursos públicos) isso é tranquilo e é cacheado. Se o catálogo crescer para dezenas de milhares, vale portar a partição para o banco — provavelmente com uma coluna / materialized view de `remaining_vacancies` mantida por trigger, para não recalcular o agregado a cada query.

## Notas para revisão

- **Escopo dos caminhos:** o `sort` afeta apenas o handler de listagem (`List`, compartilhado por `/api/public/courses` e `/api/v1/courses`). `ListByUser` e `ListDrafts` **não** recebem o param — de propósito, pois não são a listagem pública que o frontend ordenava. O cálculo de vagas é **reusado** (`calculateRemainingVacanciesForCourses`), não duplicado.
- **"Disponível" ≠ validação de inscrição:** `IsEnrollmentAvailable` espelha o **botão do frontend**, que é uma noção distinta da validação real de inscrição no backend (`enforceWindow`/`ValidateForEnrollment`, que checa janela por turma). Isso é **por design** do ticket ("ordenar como o botão mostra").
- **Cache:** a chave passa a variar pela ordenação (marcador `_sort`), mantido fora do filtro enviado ao SQL para não ser tratado como coluna.
- O `swagger.json/yaml` foi atualizado.

## Testes

- `IsEnrollmentAvailable` — 12 casos, incluindo a regressão do curso 2804 (`accepting_enrollments` com vagas esgotadas → final).
- Handler — ordenação global + paginação coerente; e que o caminho sem `sort` continua usando `service.List`.
- Repository — `List` com `limit <= 0` retorna todas as linhas.
- `go build ./...`, `go vet ./internal/...` e os testes dos pacotes afetados (`models`, `handlers/v1`, `repository`, `cache`) passando localmente.