### PR TITLE
fix(rbac): permite cidadão listar a própria inscrição via search=CPF

### DIFF
--- a/internal/handlers/v1/inscricao_handler.go
+++ b/internal/handlers/v1/inscricao_handler.go
@@ -259,11 +259,15 @@ func (h *InscricaoHandler) List(c *gin.Context) {
 	// Enrich enrollments with personal info from citizen snapshots
 	h.service.EnrichMultipleWithPersonalInfo(c.Request.Context(), inscricoes)
 
-	// Get summary
-	summary, err := h.service.GetSummaryByCursoID(c.Request.Context(), cursoID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao obter resumo: " + err.Error()})
-		return
+	var summary interface{}
+	selfAccess := middlewares.IsEnrollmentListSelfAccess(c)
+
+	if !selfAccess {
+		summary, err = h.service.GetSummaryByCursoID(c.Request.Context(), cursoID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao obter resumo: " + err.Error()})
+			return
+		}
 	}
 
 	totalPages := (total + limit - 1) / limit

--- a/internal/handlers/v1/inscricao_handler_list_test.go
+++ b/internal/handlers/v1/inscricao_handler_list_test.go
@@ -2,6 +2,7 @@ package v1_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	v1 "github.com/prefeitura-rio/app-go-api/internal/handlers/v1"
+	"github.com/prefeitura-rio/app-go-api/internal/middlewares"
 	"github.com/prefeitura-rio/app-go-api/internal/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,6 +24,8 @@ type mockInscricaoServiceForList struct {
 	enrollments   []*models.Inscricao
 	total         int
 	summary       *models.EnrollmentSummary
+	lastFilter    map[string]interface{}
+	summaryCalls  int
 }
 
 func (m *mockInscricaoServiceForList) Create(ctx context.Context, inscricao *models.Inscricao) error {
@@ -41,6 +45,7 @@ func (m *mockInscricaoServiceForList) GetByID(ctx context.Context, id uuid.UUID)
 }
 
 func (m *mockInscricaoServiceForList) GetByCursoID(ctx context.Context, cursoID int, filter map[string]interface{}, page, limit int) ([]*models.Inscricao, int, error) {
+	m.lastFilter = filter
 	if m.getByCursoErr != nil {
 		return nil, 0, m.getByCursoErr
 	}
@@ -48,6 +53,7 @@ func (m *mockInscricaoServiceForList) GetByCursoID(ctx context.Context, cursoID 
 }
 
 func (m *mockInscricaoServiceForList) GetSummaryByCursoID(ctx context.Context, cursoID int) (*models.EnrollmentSummary, error) {
+	m.summaryCalls++
 	if m.summaryErr != nil {
 		return nil, m.summaryErr
 	}
@@ -326,4 +332,38 @@ func TestInscricaoHandler_ListByUser_ServiceError(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), "Erro ao listar inscrições do usuário")
+}
+
+func TestInscricaoHandler_List_SelfAccess_KeepsSearchAndSkipsSummary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const cpf = "00044242719"
+	mockSvc := &mockInscricaoServiceForList{
+		enrollments: []*models.Inscricao{{ID: uuid.New(), CursoID: 2852, CPF: cpf}},
+		total:       1,
+		summary:     &models.EnrollmentSummary{},
+	}
+	h := v1.NewInscricaoHandler(mockSvc, nil, nil)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(middlewares.UserCPFKey, cpf)
+		c.Set("enrollment_list_self_access", true)
+		c.Next()
+	})
+	r.GET("/api/v1/courses/:courseId/enrollments", h.List)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/courses/2852/enrollments?search="+cpf, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, cpf, mockSvc.lastFilter["search"])
+	_, hasCPF := mockSvc.lastFilter["cpf"]
+	assert.False(t, hasCPF)
+	assert.Equal(t, 0, mockSvc.summaryCalls)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	data := body["data"].(map[string]interface{})
+	assert.Nil(t, data["summary"])
 }

--- a/internal/middlewares/course_auth.go
+++ b/internal/middlewares/course_auth.go
@@ -162,3 +162,78 @@ func GetLoadedCursoOrgaoID(c *gin.Context) string {
 	}
 	return ""
 }
+
+const enrollmentListSelfAccessKey = "enrollment_list_self_access"
+
+func digitsOnly(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			b = append(b, s[i])
+		}
+	}
+	return string(b)
+}
+
+// IsEnrollmentListSelfAccess reports whether CourseEnrollmentListAccess allowed
+// the request because search CPF matches the JWT CPF (citizen self-read).
+func IsEnrollmentListSelfAccess(c *gin.Context) bool {
+	v, ok := c.Get(enrollmentListSelfAccessKey)
+	if !ok {
+		return false
+	}
+	flag, _ := v.(bool)
+	return flag
+}
+
+// CourseEnrollmentListAccess authorizes GET /courses/:courseId/enrollments.
+//
+// Allows:
+//   - admin / go:cursos:casa_civil / go:cursos:editor with org ownership (same as
+//     CourseAuthorization + CourseOwnershipCheck)
+//   - citizen self-read when ?search= matches the JWT CPF (digits-only compare)
+//
+// Self-read sets IsEnrollmentListSelfAccess so the handler can omit the
+// course-wide enrollment summary (search already scopes the list).
+func CourseEnrollmentListAccess(loader courseLoaderFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userCPF := GetUserCPF(c)
+		search := c.Query("search")
+		if userCPF != "" && search != "" && digitsOnly(search) == digitsOnly(userCPF) {
+			id, err := strconv.Atoi(c.Param("courseId"))
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "ID do curso inválido"})
+				c.Abort()
+				return
+			}
+			orgaoID, found, err := loader(c.Request.Context(), id)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Erro ao buscar curso: " + err.Error()})
+				c.Abort()
+				return
+			}
+			if !found {
+				c.JSON(http.StatusNotFound, gin.H{"error": "Curso não encontrado"})
+				c.Abort()
+				return
+			}
+			c.Set(courseLoadedCursoKey, orgaoID)
+			c.Set(enrollmentListSelfAccessKey, true)
+			c.Next()
+			return
+		}
+
+		if IsAdmin(c) || HasRole(c, "go:cursos:casa_civil") {
+			CourseOwnershipCheck(loader)(c)
+			return
+		}
+
+		if isCursosEditor(c) && hasCourseOrgaoScope(c) {
+			CourseOwnershipCheck(loader)(c)
+			return
+		}
+
+		c.JSON(http.StatusForbidden, gin.H{"error": "Sem permissão para acessar este recurso"})
+		c.Abort()
+	}
+}

--- a/internal/middlewares/course_auth.go
+++ b/internal/middlewares/course_auth.go
@@ -199,7 +199,8 @@ func CourseEnrollmentListAccess(loader courseLoaderFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userCPF := GetUserCPF(c)
 		search := c.Query("search")
-		if userCPF != "" && search != "" && digitsOnly(search) == digitsOnly(userCPF) {
+		cpfDigits := digitsOnly(userCPF)
+		if cpfDigits != "" && digitsOnly(search) == cpfDigits {
 			id, err := strconv.Atoi(c.Param("courseId"))
 			if err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "ID do curso inválido"})

--- a/internal/middlewares/course_auth_test.go
+++ b/internal/middlewares/course_auth_test.go
@@ -775,6 +775,22 @@ func TestCourseEnrollmentListAccess_SelfSearchOtherCPF_Forbidden(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "Sem permissão para acessar este recurso")
 }
 
+func TestCourseEnrollmentListAccess_NonNumericUsernameAndSearch_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserCPFKey, "joao@gmail.com")
+			c.Next()
+		},
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("orgao-a", true, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments?search=silva", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Sem permissão para acessar este recurso")
+}
+
 func TestCourseEnrollmentListAccess_NoSearch_NoRole_Forbidden(t *testing.T) {
 	r := setupCourseTestRouter(
 		func(c *gin.Context) {

--- a/internal/middlewares/course_auth_test.go
+++ b/internal/middlewares/course_auth_test.go
@@ -717,3 +717,105 @@ func TestGetLoadedCursoOrgaoID_KeyExistsWithWrongType_ReturnsEmpty(t *testing.T)
 	assert.NoError(t, err)
 	assert.Equal(t, "", response["orgao_id"])
 }
+
+// ============ CourseEnrollmentListAccess Tests ============
+
+func enrollmentListLoader(orgaoID string, found bool, err error) func(context.Context, int) (string, bool, error) {
+	return func(context.Context, int) (string, bool, error) {
+		return orgaoID, found, err
+	}
+}
+
+func TestCourseEnrollmentListAccess_SelfSearchMatchingCPF_Passes(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserCPFKey, "00044242719")
+			c.Next()
+		},
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("orgao-a", true, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) {
+		assert.True(t, middlewares.IsEnrollmentListSelfAccess(c))
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments?search=00044242719", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseEnrollmentListAccess_SelfSearchMatchingCPF_IgnoresFormatting(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserCPFKey, "00044242719")
+			c.Next()
+		},
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("orgao-a", true, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments?search=000.442.427-19", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseEnrollmentListAccess_SelfSearchOtherCPF_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserCPFKey, "00044242719")
+			c.Next()
+		},
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("orgao-a", true, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments?search=11122233344", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "Sem permissão para acessar este recurso")
+}
+
+func TestCourseEnrollmentListAccess_NoSearch_NoRole_Forbidden(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserCPFKey, "00044242719")
+			c.Next()
+		},
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("orgao-a", true, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments", nil))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCourseEnrollmentListAccess_EditorWithScope_PassesWithoutSearch(t *testing.T) {
+	r := setupCourseTestRouter(
+		injectCourseRoles("go:cursos:editor", "orgao-a", nil),
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("orgao-a", true, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) {
+		assert.False(t, middlewares.IsEnrollmentListSelfAccess(c))
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments", nil))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCourseEnrollmentListAccess_SelfSearch_CourseNotFound(t *testing.T) {
+	r := setupCourseTestRouter(
+		func(c *gin.Context) {
+			c.Set(middlewares.UserCPFKey, "00044242719")
+			c.Next()
+		},
+		middlewares.CourseEnrollmentListAccess(enrollmentListLoader("", false, nil)),
+	)
+	r.GET("/courses/:courseId/enrollments", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/courses/2852/enrollments?search=00044242719", nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/router/routes_core.go
+++ b/internal/router/routes_core.go
@@ -40,6 +40,7 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 	var courseAuth gin.HandlerFunc
 	var courseOrgaoInjector gin.HandlerFunc
 	var courseListFilter gin.HandlerFunc
+	var enrollmentListAccess gin.HandlerFunc
 
 	// "development" cobre local + staging (ver comentário de noOpHandler em router.go).
 	if cfg.App.Environment == "development" || cfg.App.Environment == "test" {
@@ -47,11 +48,13 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 		courseAuth = middlewares.CourseAuthorization()
 		courseOrgaoInjector = middlewares.CourseOrgaoInjector()
 		courseListFilter = middlewares.CourseListFilter()
+		enrollmentListAccess = middlewares.CourseEnrollmentListAccess(cursoLoader)
 	} else {
 		ownershipCheck = noOpHandler
 		courseAuth = noOpHandler
 		courseOrgaoInjector = noOpHandler
 		courseListFilter = noOpHandler
+		enrollmentListAccess = noOpHandler
 	}
 
 	courses := apiV1.Group("/courses")
@@ -70,7 +73,7 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 		courses.POST("/:courseId/enrollments", app.InscricaoHandler.Create)
 		courses.POST("/:courseId/enrollments/manual", courseAuth, ownershipCheck, app.InscricaoHandler.CreateManual)
 		courses.POST("/:courseId/enrollments/import", courseAuth, ownershipCheck, app.InscricaoHandler.Import)
-		courses.GET("/:courseId/enrollments", courseAuth, ownershipCheck, app.InscricaoHandler.List)
+		courses.GET("/:courseId/enrollments", enrollmentListAccess, app.InscricaoHandler.List)
 		courses.PUT("/:courseId/enrollments/status", courseAuth, ownershipCheck, app.InscricaoHandler.UpdateStatus)
 		courses.PUT("/:courseId/enrollments/:enrollmentId", app.InscricaoHandler.Update)
 		courses.PUT("/:courseId/enrollments/:enrollmentId/status", courseAuth, ownershipCheck, app.InscricaoHandler.UpdateIndividualStatus)


### PR DESCRIPTION
## Summary
- Ajusta `GET /api/v1/courses/{courseId}/enrollments` para permitir leitura quando `?search=` for o CPF do JWT (mesmo fluxo do front, sem endpoint novo).
- Mantém o RBAC atual para admin / `go:cursos:casa_civil` / editor com escopo.
- Em self-access, omite o `summary` do curso para não vazar agregados; o filtro continua sendo só o `search` existente.