### PR TITLE
fix(cursos): oculta cursos is_visible=false em GET /api/public/courses

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -26,7 +26,7 @@ const docTemplate = `{
     "paths": {
         "/api/public/courses": {
             "get": {
-                "description": "Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
+                "description": "Retorna lista paginada de cursos públicos. Exclui rascunhos e cursos marcados como não visíveis publicamente (is_visible=false); estes continuam acessíveis por link direto via GET /api/public/courses/{id}. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -24,7 +24,7 @@
     "paths": {
         "/api/public/courses": {
             "get": {
-                "description": "Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
+                "description": "Retorna lista paginada de cursos públicos. Exclui rascunhos e cursos marcados como não visíveis publicamente (is_visible=false); estes continuam acessíveis por link direto via GET /api/public/courses/{id}. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1667,9 +1667,11 @@ info:
 paths:
   /api/public/courses:
     get:
-      description: 'Retorna lista paginada de cursos. Sem status: exclui rascunhos.
-        Com status: filtra pelos status informados (CSV). Derived statuses (scheduled,
-        accepting_enrollments, in_progress, finished) são mapeados para published.'
+      description: 'Retorna lista paginada de cursos públicos. Exclui rascunhos e
+        cursos marcados como não visíveis publicamente (is_visible=false); estes continuam
+        acessíveis por link direto via GET /api/public/courses/{id}. Com status: filtra
+        pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments,
+        in_progress, finished) são mapeados para published.'
       parameters:
       - description: 'Número da página (default: 1)'
         in: query

--- a/internal/handlers/v1/course_handler.go
+++ b/internal/handlers/v1/course_handler.go
@@ -500,7 +500,7 @@ func parseStatusFilter(param string) []string {
 }
 
 // @Summary      Listar cursos criados
-// @Description  Retorna lista paginada de cursos. Sem status: exclui rascunhos. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.
+// @Description  Retorna lista paginada de cursos públicos. Exclui rascunhos e cursos marcados como não visíveis publicamente (is_visible=false); estes continuam acessíveis por link direto via GET /api/public/courses/{id}. Com status: filtra pelos status informados (CSV). Derived statuses (scheduled, accepting_enrollments, in_progress, finished) são mapeados para published.
 // @Tags         courses
 // @Produce      json
 // @Param        page              query     int     false  "Número da página (default: 1)"
@@ -517,7 +517,7 @@ func parseStatusFilter(param string) []string {
 // @Failure      500               {object}  models.ErrorResponse
 // @Router       /api/public/courses [get]
 func (h *CourseHandler) ListPublic(c *gin.Context) {
-	h.List(c)
+	h.list(c, true)
 }
 
 // @Summary      Listar cursos criados
@@ -538,6 +538,14 @@ func (h *CourseHandler) ListPublic(c *gin.Context) {
 // @Failure      500               {object}  models.ErrorResponse
 // @Router       /api/v1/courses [get]
 func (h *CourseHandler) List(c *gin.Context) {
+	h.list(c, false)
+}
+
+// list backs both the admin (/api/v1/courses) and public (/api/public/courses)
+// listings. When publicOnly is true, courses flagged as not publicly visible
+// (is_visible=false) are excluded so they are reachable only by direct link; the
+// admin listing always includes them.
+func (h *CourseHandler) list(c *gin.Context, publicOnly bool) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
 
@@ -579,6 +587,12 @@ func (h *CourseHandler) List(c *gin.Context) {
 		}
 	} else {
 		filter["status NOT"] = models.StatusCursoDraft
+	}
+
+	// Public listing hides courses marked as not publicly visible. They remain
+	// reachable by direct link (GetByIDPublic) and in the admin listing.
+	if publicOnly {
+		filter["is_visible NOT_FALSE"] = true
 	}
 
 	if modalidade := c.Query("modalidade"); modalidade != "" {

--- a/internal/handlers/v1/course_handler_sort_test.go
+++ b/internal/handlers/v1/course_handler_sort_test.go
@@ -100,6 +100,66 @@ func TestCourseHandler_List_SortByAvailability(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
+// The public listing must hide courses flagged is_visible=false; it does so by
+// passing the "is_visible NOT_FALSE" marker to the service filter. The admin
+// listing must not, so invisible courses remain manageable.
+func TestCourseHandler_ListPublic_FiltersInvisible(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	filterHasVisibility := func(filter map[string]interface{}) bool {
+		_, ok := filter["is_visible NOT_FALSE"]
+		return ok
+	}
+
+	t.Run("public list adds the visibility filter", func(t *testing.T) {
+		mockService := new(MockCursoService)
+		mockInscricaoService := new(MockInscricaoServiceForCourse)
+		mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+		handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+		r := gin.New()
+		r.GET("/api/public/courses", handler.ListPublic)
+
+		cursos := []*models.Curso{{ID: 1, Titulo: "Course 1"}}
+		mockService.On("List", mock.Anything,
+			mock.MatchedBy(filterHasVisibility), 1, 10).Return(cursos, 1, nil)
+		mockRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).
+			Return(make(map[uuid.UUID]int64), nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/public/courses", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		mockService.AssertExpectations(t)
+	})
+
+	t.Run("admin list does not add the visibility filter", func(t *testing.T) {
+		mockService := new(MockCursoService)
+		mockInscricaoService := new(MockInscricaoServiceForCourse)
+		mockRepo := new(MockCursoRepositoryForCourseHandler)
+
+		handler := v1.NewCourseHandler(mockService, mockInscricaoService, mockRepo)
+		r := gin.New()
+		r.GET("/api/v1/courses", handler.List)
+
+		cursos := []*models.Curso{{ID: 1, Titulo: "Course 1"}}
+		mockService.On("List", mock.Anything,
+			mock.MatchedBy(func(filter map[string]interface{}) bool {
+				return !filterHasVisibility(filter)
+			}), 1, 10).Return(cursos, 1, nil)
+		mockRepo.On("CountEnrollmentsByScheduleIDs", mock.Anything, mock.Anything).
+			Return(make(map[uuid.UUID]int64), nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/courses", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		mockService.AssertExpectations(t)
+	})
+}
+
 // Without the sort param, the handler keeps the existing behavior: it delegates to
 // the paginated service.List and does not fetch the full result set.
 func TestCourseHandler_List_NoSort_UsesService(t *testing.T) {

--- a/internal/repository/curso_repository.go
+++ b/internal/repository/curso_repository.go
@@ -169,6 +169,10 @@ func (r *CursoRepository) applyFilters(db *gorm.DB, filter map[string]interface{
 		switch key {
 		case "status NOT":
 			db = db.Where("status != ?", value)
+		case "is_visible NOT_FALSE":
+			// Include courses that are visible (true) or unset (null), excluding
+			// only those explicitly flagged is_visible=false.
+			db = db.Where("is_visible IS DISTINCT FROM false")
 		case "status IN":
 			if statuses, ok := value.([]string); ok && len(statuses) > 0 {
 				db = applyStatusINFilter(db, statuses)

--- a/internal/repository/curso_repository_test.go
+++ b/internal/repository/curso_repository_test.go
@@ -47,6 +47,14 @@ func TestCursoRepository_applyFilters(t *testing.T) {
 			description:        "title ILIKE filter should generate ILIKE condition",
 		},
 		{
+			name: "is_visible NOT_FALSE filter",
+			filter: map[string]interface{}{
+				"is_visible NOT_FALSE": true,
+			},
+			expectedConditions: []string{"is_visible IS DISTINCT FROM false"},
+			description:        "is_visible NOT_FALSE filter should exclude only explicit false",
+		},
+		{
 			name: "categoria_id filter",
 			filter: map[string]interface{}{
 				"categoria_id": 5,
@@ -126,11 +134,12 @@ func TestCursoRepository_applyFilters_AllFilterTypes(t *testing.T) {
 
 	// Test that all special filter keys are handled correctly
 	specialFilters := map[string]string{
-		"status NOT":        "status !=",
-		"title ILIKE":       "titulo ILIKE",
-		"categoria_id":      "curso_id FROM cursos_categorias WHERE categoria_id",
-		"acessibilidade_id": "curso_id FROM cursos_acessibilidades WHERE acessibilidade_id",
-		"neighborhood_zone": "curso_id FROM location_classes WHERE neighborhood_zone",
+		"status NOT":           "status !=",
+		"is_visible NOT_FALSE": "is_visible IS DISTINCT FROM false",
+		"title ILIKE":          "titulo ILIKE",
+		"categoria_id":         "curso_id FROM cursos_categorias WHERE categoria_id",
+		"acessibilidade_id":    "curso_id FROM cursos_acessibilidades WHERE acessibilidade_id",
+		"neighborhood_zone":    "curso_id FROM location_classes WHERE neighborhood_zone",
 	}
 
 	for filterKey, expectedSQLFragment := range specialFilters {

--- a/internal/router/routes_core.go
+++ b/internal/router/routes_core.go
@@ -105,7 +105,7 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 	}
 	apiV1.Group("/propostas-mei").GET("/por-empresa", app.PropostaMEIHandler.ListByMEIEmpresa)
 
-	apiPublic.GET("/courses", app.CourseHandler.List)
+	apiPublic.GET("/courses", app.CourseHandler.ListPublic)
 	apiPublic.GET("/courses/:courseId", app.CourseHandler.GetByID)
 	apiPublic.GET("/oportunidades-mei", app.OportunidadeMEIHandler.List)
 	apiPublic.GET("/oportunidades-mei/:id", app.OportunidadeMEIHandler.GetByID)

--- a/internal/router/routes_core_test.go
+++ b/internal/router/routes_core_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/prefeitura-rio/app-go-api/internal/config"
 	v1 "github.com/prefeitura-rio/app-go-api/internal/handlers/v1"
@@ -365,6 +366,35 @@ func TestRegisterCoreRoutes_PublicRoutes(t *testing.T) {
 		}
 		assert.True(t, found, "Should have public route %s %s", expected.method, expected.path)
 	}
+}
+
+// TestRegisterCoreRoutes_PublicCoursesUsesListPublic guards the wiring of the
+// public courses listing. It must resolve to CourseHandler.ListPublic (which
+// hides is_visible=false courses), not the admin List handler — a regression
+// that would silently expose non-visible courses in /api/public/courses.
+func TestRegisterCoreRoutes_PublicCoursesUsesListPublic(t *testing.T) {
+	router := gin.New()
+	apiV1 := router.Group("/api/v1")
+	apiPublic := router.Group("/api/public")
+
+	app := createMockApplicationContainer()
+	cfg := newTestCoreConfig()
+	registerCoreRoutes(apiV1, apiPublic, app, cfg)
+
+	var handler string
+	found := false
+	for _, route := range router.Routes() {
+		if route.Method == "GET" && route.Path == "/api/public/courses" {
+			handler = route.Handler
+			found = true
+			break
+		}
+	}
+
+	require.True(t, found, "GET /api/public/courses must be registered")
+	// The "CourseHandler)." prefix keeps this from matching the admin ".List-fm".
+	assert.Contains(t, handler, "CourseHandler).ListPublic",
+		"public courses listing must be wired to ListPublic, got %q", handler)
 }
 
 // TestRegisterCoreRoutes_RouteMethodCounts tests HTTP method distribution


### PR DESCRIPTION
[PREF-426](https://iplanrio-pcrj.atlassian.net/browse/PREF-426)

### Contexto
No portal-interno, o campo "Visibilidade do Curso" permite marcar "Curso não visível publicamente" (is_visible=false), esperando que o curso não apareça na home e só seja acessível por link. Na prática, continuavam retornando em GET /api/public/courses e na listagem /servicos/cursos do superapp.

### Causa raiz

1. A listagem pública não filtrava is_visible (só excluía rascunhos).
2. A rota pública nem passava pelo handler público: routes_core.go ligava GET /api/public/courses direto ao CourseHandler.List (admin). ListPublic/GetByIDPublic existiam mas nunca foram plugados — qualquer filtro no ListPublic ficaria inócuo. 

### Solução

- ListPublic delega para list(c, publicOnly); com publicOnly=true, adiciona is_visible NOT_FALSE.
- Repositório gera is_visible IS DISTINCT FROM false — exclui só o false explícito, mantendo true e null.
- Rota GET /api/public/courses religada para ListPublic; admin segue em List.
- Detalhe por link (GET /api/public/courses/{id}) inalterado.

### Evidência no front (superapp: /servicos/cursos)
Para isolar o efeito da API, o filtro client-side do superapp (shouldShowCourse) foi desativado temporariamente.

❌ SEM o fix (rota → List): o curso invisível aparece.

<img width="1568" height="747" alt="image" src="https://github.com/user-attachments/assets/7761b020-71b8-47a3-bd91-c3d2a4876e5b" />

✅ COM o fix (rota → ListPublic): o curso invisível some.

<img width="1568" height="747" alt="image" src="https://github.com/user-attachments/assets/228d7735-4164-47b1-825c-051db8fbad67" />