### PR TITLE
feat(rbac): controla autorização de cursos/vagas via RBAC_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ DEBUG=true
 API_PREFIX=/api/v1
 LOG_LEVEL=debug
 
+# RBAC de cursos e vagas (CourseAuthorization, VagaAuthorization, ownership, etc.).
+# Default: true. Em produção, defina RBAC_ENABLED=false enquanto o RBAC não estiver homologado.
+RBAC_ENABLED=true
+
 # Configurações do Banco de Dados
 DB_HOST=localhost
 DB_PORT=5432

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,6 +491,7 @@ Key variables (see `.env.example` for the full list):
 | Variable | Default | Description |
 |---|---|---|
 | `APP_ENV` | `development` | Raw environment string, compared as-is by `cfg.App.Environment` / `IsDevelopment()` / `IsProduction()` / `IsTest()` — see note below, the deployed values are **not** `staging`/`production` |
+| `RBAC_ENABLED` | `true` | Enables course/vaga RBAC middlewares (`CourseAuthorization`, `VagaAuthorization`, ownership checks, `ExtractSecretariaOrgaoIDs`). Independent of `APP_ENV`. Set `false` in production until RBAC is ready there. |
 | `DB_HOST` | `localhost` | PostgreSQL host |
 | `DB_PORT` | `5432` | PostgreSQL port |
 | `DB_USER` | `postgres` | PostgreSQL user |
@@ -515,10 +516,10 @@ Key variables (see `.env.example` for the full list):
 > **Real `APP_ENV` values per deployed environment** (confirmed via `kubectl logs -n go <pod>`, which prints `Ambiente: <value>` on startup when `APP_DEBUG=true`; the value is not set in the committed `k8s/*/resources.yaml` — it comes from the Infisical-managed `go-secrets` SecretRef):
 >
 > - **Local dev**: `development` (the `.env.example` default)
-> - **Staging**: `development` — **not** `staging`. The `go-secrets` for staging sets `APP_ENV=development`, so any code that branches on `cfg.App.Environment == "development"` (or `IsDevelopment()`) is also active in staging. Today this is relied upon intentionally (e.g. environment-gated feature flags stay active in staging for homologation and only go no-op in production), but it means `IsDevelopment()`/`"development"` does **not** mean "only a developer's laptop".
-> - **Production**: `prod` — **not** `production`. `AppSettings.IsProduction()` compares against the literal string `"production"` and therefore never returns `true` for the real deployed value.
+> - **Staging**: `development` — **not** `staging`. The `go-secrets` for staging sets `APP_ENV=development`, so any code that branches on `cfg.App.Environment == "development"` (or `IsDevelopment()`) is also active in staging. Prefer dedicated env vars (e.g. `RBAC_ENABLED`) for feature flags instead of gating on `APP_ENV`.
+> - **Production**: `prod` — **not** `production`. `AppSettings.IsProduction()` compares against both `"prod"` and `"production"`.
 >
-> Before writing a new environment-gated feature flag, check the real deployed value first (`kubectl logs -n go <pod> | grep Ambiente` in both the staging and production contexts) instead of assuming `staging`/`production` are used literally.
+> Before writing a new environment-gated feature flag, prefer an explicit env var (like `RBAC_ENABLED`) over branching on `APP_ENV`. If you must branch on environment, check the real deployed value first (`kubectl logs -n go <pod> | grep Ambiente` in both the staging and production contexts) instead of assuming `staging`/`production` are used literally.
 
 ### Running Tests
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,11 @@ type AppSettings struct {
 	LogLevel    string
 	APIPrefix   string
 	APIToken    string
+	// RBACEnabled controla os middlewares de autorização de cursos e vagas
+	// (CourseAuthorization, VagaAuthorization, ownership checks, etc.).
+	// Independente de APP_ENV — use RBAC_ENABLED=false em produção enquanto
+	// o RBAC não estiver homologado lá.
+	RBACEnabled bool
 }
 
 // DatabaseSettings define configurações do banco de dados
@@ -358,6 +363,7 @@ func Load() (*AppConfig, error) {
 			LogLevel:    getEnv(v, "LOG_LEVEL", "info"),
 			APIPrefix:   getEnv(v, "API_PREFIX", "/api"),
 			APIToken:    getEnv(v, "API_TOKEN", ""),
+			RBACEnabled: getBool(v, "RBAC_ENABLED", true),
 		},
 		Database: DatabaseSettings{
 			Host:            getEnv(v, "DB_HOST", "localhost"),
@@ -624,6 +630,7 @@ func logConfig(config *AppConfig) {
 	log.Printf("Debug: %v", config.App.Debug)
 	log.Printf("Log Level: %s", config.App.LogLevel)
 	log.Printf("API Prefix: %s", config.App.APIPrefix)
+	log.Printf("RBAC Enabled: %v", config.App.RBACEnabled)
 	log.Printf("DB: %s@%s:%d/%s", config.Database.User, config.Database.Host, config.Database.Port, config.Database.Name)
 	log.Printf("Server: %s:%d", config.Server.Host, config.Server.Port)
 	log.Printf("Migrations: %v", config.Migrations.Run)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -422,7 +422,7 @@ func TestLoad_WithEnvironmentVariables(t *testing.T) {
 func TestLoad_DefaultValues(t *testing.T) {
 	// Clear environment variables
 	envVars := []string{
-		"APP_ENV", "APP_DEBUG", "LOG_LEVEL", "API_PREFIX",
+		"APP_ENV", "APP_DEBUG", "LOG_LEVEL", "API_PREFIX", "RBAC_ENABLED",
 		"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
 		"SERVER_HOST", "SERVER_PORT",
 	}
@@ -454,6 +454,7 @@ func TestLoad_DefaultValues(t *testing.T) {
 	assert.True(t, config.App.Debug)
 	assert.Equal(t, "info", config.App.LogLevel)
 	assert.Equal(t, "/api", config.App.APIPrefix)
+	assert.True(t, config.App.RBACEnabled)
 
 	// Verify default Database settings
 	assert.Equal(t, "localhost", config.Database.Host)
@@ -887,6 +888,7 @@ func TestLoad_BooleanSettings(t *testing.T) {
 		"RUN_MIGRATIONS",
 		"TRACING_ENABLED",
 		"CERBOS_ENABLED",
+		"RBAC_ENABLED",
 		"DB_HOST", "DB_PORT",
 		"SERVER_HOST", "SERVER_PORT",
 	}
@@ -917,6 +919,7 @@ func TestLoad_BooleanSettings(t *testing.T) {
 	os.Setenv("RUN_MIGRATIONS", "true")
 	os.Setenv("TRACING_ENABLED", "true")
 	os.Setenv("CERBOS_ENABLED", "true")
+	os.Setenv("RBAC_ENABLED", "false")
 
 	config, err := Load()
 	require.NoError(t, err)
@@ -926,6 +929,55 @@ func TestLoad_BooleanSettings(t *testing.T) {
 	assert.True(t, config.Migrations.Run)
 	assert.True(t, config.Tracing.Enabled)
 	assert.True(t, config.Cerbos.Enabled)
+	assert.False(t, config.App.RBACEnabled)
+}
+
+func TestLoad_RBACEnabled_DefaultTrue(t *testing.T) {
+	original := os.Getenv("RBAC_ENABLED")
+	os.Unsetenv("RBAC_ENABLED")
+	defer func() {
+		if original == "" {
+			os.Unsetenv("RBAC_ENABLED")
+		} else {
+			os.Setenv("RBAC_ENABLED", original)
+		}
+		instance = nil
+		once = sync.Once{}
+		v = nil
+	}()
+
+	os.Setenv("DB_HOST", "localhost")
+	os.Setenv("DB_PORT", "5432")
+	os.Setenv("SERVER_HOST", "0.0.0.0")
+	os.Setenv("SERVER_PORT", "8080")
+
+	config, err := Load()
+	require.NoError(t, err)
+	assert.True(t, config.App.RBACEnabled, "RBAC_ENABLED should default to true")
+}
+
+func TestLoad_RBACEnabled_ExplicitTrue(t *testing.T) {
+	original := os.Getenv("RBAC_ENABLED")
+	defer func() {
+		if original == "" {
+			os.Unsetenv("RBAC_ENABLED")
+		} else {
+			os.Setenv("RBAC_ENABLED", original)
+		}
+		instance = nil
+		once = sync.Once{}
+		v = nil
+	}()
+
+	os.Setenv("DB_HOST", "localhost")
+	os.Setenv("DB_PORT", "5432")
+	os.Setenv("SERVER_HOST", "0.0.0.0")
+	os.Setenv("SERVER_PORT", "8080")
+	os.Setenv("RBAC_ENABLED", "true")
+
+	config, err := Load()
+	require.NoError(t, err)
+	assert.True(t, config.App.RBACEnabled)
 }
 
 func TestLoad_SliceSettings(t *testing.T) {

--- a/internal/middlewares/vaga_auth.go
+++ b/internal/middlewares/vaga_auth.go
@@ -156,8 +156,8 @@ type VagaLoaderFunc func(ctx context.Context, id uuid.UUID) (*VagaOwnershipInfo,
 // A regra de "quem pode editar vaga já publicada" NÃO fica aqui: ela depende do
 // status da vaga (que o gateway Heimdall não conhece) e por isso é aplicada no
 // handler (VagaHandler.Update), ativa em qualquer ambiente. Este middleware,
-// como os demais de autorização, roda só em development/test (no-op em prod —
-// ver routes_emp.go / noOpHandler).
+// como os demais de autorização de vaga/curso, só roda quando RBAC_ENABLED=true
+// (ver routes_emp.go / rbacMiddleware).
 func VagaOwnershipCheck(loader VagaLoaderFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if IsAdmin(c) || HasRole(c, "go:empregabilidade:admin") {

--- a/internal/router/rbac_middleware_test.go
+++ b/internal/router/rbac_middleware_test.go
@@ -1,0 +1,69 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRBACMiddleware_Enabled_UsesReal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	real := func(c *gin.Context) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "denied"})
+		c.Abort()
+	}
+
+	r := gin.New()
+	r.GET("/protected", rbacMiddleware(true, real), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/protected", nil))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRBACMiddleware_Disabled_UsesNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	real := func(c *gin.Context) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "denied"})
+		c.Abort()
+	}
+
+	r := gin.New()
+	r.GET("/protected", rbacMiddleware(false, real), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/protected", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRBACMiddleware_IndependentOfAppEnv(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	real := func(c *gin.Context) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "denied"})
+		c.Abort()
+	}
+
+	// Even with APP_ENV=prod semantics historically disabling RBAC, the env var
+	// alone controls whether the real middleware runs.
+	r := gin.New()
+	r.GET("/protected", rbacMiddleware(true, real), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/protected", nil))
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -18,16 +18,18 @@ import (
 	_ "github.com/prefeitura-rio/app-go-api/docs"
 )
 
-// noOpHandler substitui os middlewares de autorização fora de dev/test/staging.
-//
-// NOTA: o secret de staging define APP_ENV=development (não "staging"), então
-// cfg.App.Environment == "development" também é verdadeiro em staging — isso é
-// intencional, pois é o que permite homologar RBAC em staging antes de um
-// release. Produção usa APP_ENV=prod e cai neste no-op. Ver AGENTS.md
-// ("Environment Variables Reference") para os valores reais confirmados via
-// kubectl logs.
+// noOpHandler substitui os middlewares de autorização quando RBAC_ENABLED=false.
 func noOpHandler(c *gin.Context) {
 	c.Next()
+}
+
+// rbacMiddleware retorna o middleware real quando RBAC está habilitado via
+// RBAC_ENABLED; caso contrário retorna noOpHandler. Independente de APP_ENV.
+func rbacMiddleware(enabled bool, real gin.HandlerFunc) gin.HandlerFunc {
+	if enabled {
+		return real
+	}
+	return noOpHandler
 }
 
 // SetupRouter initializes the Gin engine with all routes using Wire-managed dependencies.
@@ -98,8 +100,7 @@ func SetupRouter(ctx context.Context, cfg *config.AppConfig) (*gin.Engine, error
 			return app.OrgaoSnapshotRepo.GetOrgaoIDsByCdUAs(ctx, cdUAs)
 		}
 
-		// "development" cobre local + staging (ver comentário de noOpHandler acima).
-		if cfg.App.Environment == "development" || cfg.App.Environment == "test" {
+		if cfg.App.RBACEnabled {
 			apiV1.Use(middlewares.ExtractSecretariaOrgaoIDs(resolver))
 		}
 	}

--- a/internal/router/routes_core.go
+++ b/internal/router/routes_core.go
@@ -36,26 +36,11 @@ func registerCoreRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.Application
 		return curso.OrgaoID, true, nil
 	}
 
-	var ownershipCheck gin.HandlerFunc
-	var courseAuth gin.HandlerFunc
-	var courseOrgaoInjector gin.HandlerFunc
-	var courseListFilter gin.HandlerFunc
-	var enrollmentListAccess gin.HandlerFunc
-
-	// "development" cobre local + staging (ver comentário de noOpHandler em router.go).
-	if cfg.App.Environment == "development" || cfg.App.Environment == "test" {
-		ownershipCheck = middlewares.CourseOwnershipCheck(cursoLoader)
-		courseAuth = middlewares.CourseAuthorization()
-		courseOrgaoInjector = middlewares.CourseOrgaoInjector()
-		courseListFilter = middlewares.CourseListFilter()
-		enrollmentListAccess = middlewares.CourseEnrollmentListAccess(cursoLoader)
-	} else {
-		ownershipCheck = noOpHandler
-		courseAuth = noOpHandler
-		courseOrgaoInjector = noOpHandler
-		courseListFilter = noOpHandler
-		enrollmentListAccess = noOpHandler
-	}
+	ownershipCheck := rbacMiddleware(cfg.App.RBACEnabled, middlewares.CourseOwnershipCheck(cursoLoader))
+	courseAuth := rbacMiddleware(cfg.App.RBACEnabled, middlewares.CourseAuthorization())
+	courseOrgaoInjector := rbacMiddleware(cfg.App.RBACEnabled, middlewares.CourseOrgaoInjector())
+	courseListFilter := rbacMiddleware(cfg.App.RBACEnabled, middlewares.CourseListFilter())
+	enrollmentListAccess := rbacMiddleware(cfg.App.RBACEnabled, middlewares.CourseEnrollmentListAccess(cursoLoader))
 
 	courses := apiV1.Group("/courses")
 	{

--- a/internal/router/routes_core_test.go
+++ b/internal/router/routes_core_test.go
@@ -16,12 +16,11 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-// newTestCoreConfig returns a minimal AppConfig with environment set to "test"
-// so that the real authorization middlewares (CourseOwnershipCheck, CourseAuthorization,
-// CourseOrgaoInjector, CourseListFilter) are wired into the routes, matching
-// production intent while remaining exercisable in unit tests.
+// newTestCoreConfig returns a minimal AppConfig with RBAC enabled so that the
+// real authorization middlewares (CourseOwnershipCheck, CourseAuthorization,
+// CourseOrgaoInjector, CourseListFilter) are wired into the routes.
 func newTestCoreConfig() *config.AppConfig {
-	return &config.AppConfig{App: config.AppSettings{Environment: "test"}}
+	return &config.AppConfig{App: config.AppSettings{RBACEnabled: true}}
 }
 
 // TestRegisterCoreRoutes tests the complete core routes registration

--- a/internal/router/routes_emp.go
+++ b/internal/router/routes_emp.go
@@ -50,24 +50,11 @@ func registerEmpregabilidadeRoutes(apiV1, apiPublic *gin.RouterGroup, app *wire.
 		}, nil
 	}
 
-	var vagaAuth gin.HandlerFunc
-	var vagaOrgaoInjector gin.HandlerFunc
-	var vagaListFilter gin.HandlerFunc
-	var vagaOwnership gin.HandlerFunc // ownership por órgão (mutações)
-
-	// "development" cobre local + staging (ver comentário de noOpHandler em router.go).
 	// vagaAuth também protege o grupo /candidaturas mais abaixo nesta função.
-	if cfg.App.Environment == "development" || cfg.App.Environment == "test" {
-		vagaAuth = middlewares.VagaAuthorization()
-		vagaOrgaoInjector = middlewares.VagaOrgaoInjector()
-		vagaListFilter = middlewares.VagaListFilter()
-		vagaOwnership = middlewares.VagaOwnershipCheck(vagaLoader)
-	} else {
-		vagaAuth = noOpHandler
-		vagaOrgaoInjector = noOpHandler
-		vagaListFilter = noOpHandler
-		vagaOwnership = noOpHandler
-	}
+	vagaAuth := rbacMiddleware(cfg.App.RBACEnabled, middlewares.VagaAuthorization())
+	vagaOrgaoInjector := rbacMiddleware(cfg.App.RBACEnabled, middlewares.VagaOrgaoInjector())
+	vagaListFilter := rbacMiddleware(cfg.App.RBACEnabled, middlewares.VagaListFilter())
+	vagaOwnership := rbacMiddleware(cfg.App.RBACEnabled, middlewares.VagaOwnershipCheck(vagaLoader))
 
 	// Vagas
 	empVagas := emp.Group("/vagas")

--- a/internal/router/routes_emp_test.go
+++ b/internal/router/routes_emp_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/prefeitura-rio/app-go-api/internal/wire"
 )
 
-// newTestEmpConfig returns a minimal AppConfig with environment set to "test"
-// so that the real authorization middlewares (VagaAuthorization, VagaOrgaoInjector,
-// VagaListFilter) are wired into the routes, matching production intent while
-// remaining exercisable in unit tests.
+// newTestEmpConfig returns a minimal AppConfig with RBAC enabled so that the
+// real authorization middlewares (VagaAuthorization, VagaOrgaoInjector,
+// VagaListFilter, VagaOwnershipCheck) are wired into the routes.
 func newTestEmpConfig() *config.AppConfig {
-	return &config.AppConfig{App: config.AppSettings{Environment: "test"}}
+	return &config.AppConfig{App: config.AppSettings{RBACEnabled: true}}
 }
 
 // createMockAppContainer creates a minimal ApplicationContainer with mock handlers.


### PR DESCRIPTION
## Resumo
- Introduz a variável de ambiente `RBAC_ENABLED` (default `true`) para controlar os middlewares de RBAC de cursos e vagas.
- Remove o gate implícito por `APP_ENV == development|test`, que desativava o RBAC em produção de forma acoplada ao ambiente.
- Atualiza wiring em `routes_core`, `routes_emp` e `ExtractSecretariaOrgaoIDs`, além de docs (`.env.example`, `AGENTS.md`).