### PR TITLE
fix(cursos): batch delete de schedules/locations no update

### DIFF
--- a/internal/repository/curso_repository.go
+++ b/internal/repository/curso_repository.go
@@ -384,7 +384,9 @@ func (r *CursoRepository) updateRemoteClassWithTx(ctx context.Context, tx *gorm.
 		if err == nil {
 			// Update existing remote class
 			curso.RemoteClass.ID = existingRemote.ID
-			tx.WithContext(ctx).Model(&existingRemote).Updates(curso.RemoteClass)
+			if err := tx.WithContext(ctx).Model(&existingRemote).Updates(curso.RemoteClass).Error; err != nil {
+				return fmt.Errorf("erro ao atualizar remote class: %w", err)
+			}
 
 			// Build map of schedule IDs to keep
 			scheduleIDsToKeep := make(map[string]bool)
@@ -396,15 +398,27 @@ func (r *CursoRepository) updateRemoteClassWithTx(ctx context.Context, tx *gorm.
 
 			// Delete only schedules that are not in the update list
 			var existingSchedules []models.RemoteSchedule
-			tx.WithContext(ctx).Where("remote_class_id = ?", curso.RemoteClass.ID).Find(&existingSchedules)
+			if err := tx.WithContext(ctx).Where("remote_class_id = ?", curso.RemoteClass.ID).Find(&existingSchedules).Error; err != nil {
+				return fmt.Errorf("erro ao buscar remote schedules existentes: %w", err)
+			}
+			var scheduleIDsToDelete []uuid.UUID
 			for _, existing := range existingSchedules {
 				if !scheduleIDsToKeep[existing.ID.String()] {
-					tx.WithContext(ctx).Delete(&existing)
+					scheduleIDsToDelete = append(scheduleIDsToDelete, existing.ID)
 				}
 			}
+			if len(scheduleIDsToDelete) > 0 {
+				if err := tx.WithContext(ctx).Where("id IN ?", scheduleIDsToDelete).Delete(&models.RemoteSchedule{}).Error; err != nil {
+					return fmt.Errorf("erro ao deletar remote schedules obsoletos: %w", err)
+				}
+			}
+		} else if err != gorm.ErrRecordNotFound {
+			return fmt.Errorf("erro ao buscar remote class existente: %w", err)
 		} else {
 			// Create new remote class
-			tx.WithContext(ctx).Omit("Schedules").Create(curso.RemoteClass)
+			if err := tx.WithContext(ctx).Omit("Schedules").Create(curso.RemoteClass).Error; err != nil {
+				return fmt.Errorf("erro ao criar remote class: %w", err)
+			}
 		}
 
 		// Update or create schedules for this remote class
@@ -437,7 +451,9 @@ func (r *CursoRepository) updateRemoteClassWithTx(ctx context.Context, tx *gorm.
 		}
 	} else {
 		// If no remote class provided, delete existing one if any (CASCADE will delete schedules)
-		tx.WithContext(ctx).Where("curso_id = ?", curso.ID).Delete(&models.RemoteClass{})
+		if err := tx.WithContext(ctx).Where("curso_id = ?", curso.ID).Delete(&models.RemoteClass{}).Error; err != nil {
+			return fmt.Errorf("erro ao deletar remote class: %w", err)
+		}
 	}
 
 	return nil
@@ -447,7 +463,9 @@ func (r *CursoRepository) updateRemoteClassWithTx(ctx context.Context, tx *gorm.
 func (r *CursoRepository) updateLocationClassesWithTx(ctx context.Context, tx *gorm.DB, curso *models.Curso) error {
 	// Get existing location classes
 	var existingLocations []models.LocationClass
-	tx.WithContext(ctx).Where("curso_id = ?", curso.ID).Find(&existingLocations)
+	if err := tx.WithContext(ctx).Where("curso_id = ?", curso.ID).Find(&existingLocations).Error; err != nil {
+		return fmt.Errorf("erro ao buscar location classes existentes: %w", err)
+	}
 
 	// Build map of location IDs to keep
 	locationIDsToKeep := make(map[string]bool)
@@ -457,10 +475,16 @@ func (r *CursoRepository) updateLocationClassesWithTx(ctx context.Context, tx *g
 		}
 	}
 
-	// Delete locations that are not in the update list (CASCADE will delete schedules)
+	// Delete locations that are not in the update list in a single batch (CASCADE will delete schedules)
+	var locationIDsToDelete []uuid.UUID
 	for _, existing := range existingLocations {
 		if !locationIDsToKeep[existing.ID.String()] {
-			tx.WithContext(ctx).Delete(&existing)
+			locationIDsToDelete = append(locationIDsToDelete, existing.ID)
+		}
+	}
+	if len(locationIDsToDelete) > 0 {
+		if err := tx.WithContext(ctx).Where("id IN ?", locationIDsToDelete).Delete(&models.LocationClass{}).Error; err != nil {
+			return fmt.Errorf("erro ao deletar location classes obsoletas: %w", err)
 		}
 	}
 
@@ -471,9 +495,11 @@ func (r *CursoRepository) updateLocationClassesWithTx(ctx context.Context, tx *g
 
 		if locationID.String() != "00000000-0000-0000-0000-000000000000" {
 			// Update existing location
-			tx.WithContext(ctx).Model(&curso.LocationClasses[i]).
+			if err := tx.WithContext(ctx).Model(&curso.LocationClasses[i]).
 				Select("address", "neighborhood", "neighborhood_zone", "updated_at").
-				Updates(&curso.LocationClasses[i])
+				Updates(&curso.LocationClasses[i]).Error; err != nil {
+				return fmt.Errorf("erro ao atualizar location class: %w", err)
+			}
 
 			// Build map of schedule IDs to keep for this location
 			scheduleIDsToKeep := make(map[string]bool)
@@ -483,17 +509,27 @@ func (r *CursoRepository) updateLocationClassesWithTx(ctx context.Context, tx *g
 				}
 			}
 
-			// Delete only schedules that are not in the update list
+			// Delete only schedules that are not in the update list (single batch DELETE)
 			var existingSchedules []models.CourseSchedule
-			tx.WithContext(ctx).Where("location_id = ?", locationID).Find(&existingSchedules)
+			if err := tx.WithContext(ctx).Where("location_id = ?", locationID).Find(&existingSchedules).Error; err != nil {
+				return fmt.Errorf("erro ao buscar course schedules existentes: %w", err)
+			}
+			var scheduleIDsToDelete []uuid.UUID
 			for _, existing := range existingSchedules {
 				if !scheduleIDsToKeep[existing.ID.String()] {
-					tx.WithContext(ctx).Delete(&existing)
+					scheduleIDsToDelete = append(scheduleIDsToDelete, existing.ID)
+				}
+			}
+			if len(scheduleIDsToDelete) > 0 {
+				if err := tx.WithContext(ctx).Where("id IN ?", scheduleIDsToDelete).Delete(&models.CourseSchedule{}).Error; err != nil {
+					return fmt.Errorf("erro ao deletar course schedules obsoletos: %w", err)
 				}
 			}
 		} else {
 			// Create new location
-			tx.WithContext(ctx).Omit("Schedules").Create(&curso.LocationClasses[i])
+			if err := tx.WithContext(ctx).Omit("Schedules").Create(&curso.LocationClasses[i]).Error; err != nil {
+				return fmt.Errorf("erro ao criar location class: %w", err)
+			}
 		}
 
 		// Update or create schedules for this location

--- a/internal/repository/curso_repository_test.go
+++ b/internal/repository/curso_repository_test.go
@@ -1449,8 +1449,9 @@ func TestCursoRepository_Update_HelperIntegration(t *testing.T) {
 			WillReturnError(gorm.ErrRecordNotFound)
 		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
 			WillReturnResult(sqlmock.NewResult(0, 0))
-		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
-			WillReturnError(gorm.ErrRecordNotFound)
+		// RemoteClass nil => delete existing remote class if any
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// updateLocationClassesWithTx - create new
 		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
@@ -1502,8 +1503,9 @@ func TestCursoRepository_Update_HelperIntegration(t *testing.T) {
 			WillReturnError(gorm.ErrRecordNotFound)
 		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
 			WillReturnResult(sqlmock.NewResult(0, 0))
-		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
-			WillReturnError(gorm.ErrRecordNotFound)
+		// RemoteClass nil => delete existing remote class if any
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// updateLocationClassesWithTx - update existing
 		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
@@ -1560,9 +1562,9 @@ func TestCursoRepository_Update_HelperIntegration(t *testing.T) {
 		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
-		// Pass remoteClass
-		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
-			WillReturnError(gorm.ErrRecordNotFound)
+		// RemoteClass nil => delete existing remote class if any
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// updateLocationClassesWithTx - schedule update fails
 		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
@@ -1615,9 +1617,9 @@ func TestCursoRepository_Update_HelperIntegration(t *testing.T) {
 		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
-		// Pass remoteClass
-		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
-			WillReturnError(gorm.ErrRecordNotFound)
+		// RemoteClass nil => delete existing remote class if any
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
 
 		// updateLocationClassesWithTx - batch create fails
 		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
@@ -1634,5 +1636,130 @@ func TestCursoRepository_Update_HelperIntegration(t *testing.T) {
 		err := repo.Update(ctx, curso)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "erro ao atualizar location classes")
+	})
+
+	t.Run("update remoteClass batch deletes obsolete schedules", func(t *testing.T) {
+		db, mock, cleanup := SetupMockDB(t)
+		defer cleanup()
+		repo := NewCursoRepository(db)
+		ctx := context.Background()
+
+		existingRemoteID := uuid.New()
+		keepScheduleID := uuid.New()
+		obsoleteScheduleID1 := uuid.New()
+		obsoleteScheduleID2 := uuid.New()
+		curso := &models.Curso{
+			ID: 1,
+			RemoteClass: &models.RemoteClass{
+				ID:      existingRemoteID,
+				CursoID: 1,
+				Schedules: []models.RemoteSchedule{
+					{ID: keepScheduleID, Vacancies: 20},
+				},
+			},
+		}
+
+		mock.ExpectBegin()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "curso_id"}).AddRow(existingRemoteID, 1))
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_schedules"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).
+				AddRow(keepScheduleID).
+				AddRow(obsoleteScheduleID1).
+				AddRow(obsoleteScheduleID2))
+		// Single batch DELETE for obsolete schedules (not N individual deletes)
+		mock.ExpectExec(`DELETE FROM "remote_schedules" WHERE id IN \((\$\d+,)*\$\d+\)`).
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "remote_schedules"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "cursos"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		mock.ExpectCommit()
+
+		err := repo.Update(ctx, curso)
+		assert.NoError(t, err)
+	})
+
+	t.Run("update locationClasses batch deletes obsolete locations and schedules", func(t *testing.T) {
+		db, mock, cleanup := SetupMockDB(t)
+		defer cleanup()
+		repo := NewCursoRepository(db)
+		ctx := context.Background()
+
+		keepLocationID := uuid.New()
+		obsoleteLocationID1 := uuid.New()
+		obsoleteLocationID2 := uuid.New()
+		keepScheduleID := uuid.New()
+		obsoleteScheduleID1 := uuid.New()
+		obsoleteScheduleID2 := uuid.New()
+		curso := &models.Curso{
+			ID: 1,
+			LocationClasses: []models.LocationClass{
+				{
+					ID:      keepLocationID,
+					CursoID: 1,
+					Address: "Rua Keep",
+					Schedules: []models.CourseSchedule{
+						{ID: keepScheduleID, Vacancies: 25},
+					},
+				},
+			},
+		}
+
+		mock.ExpectBegin()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		// RemoteClass nil => delete existing remote class if any
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).
+				AddRow(keepLocationID).
+				AddRow(obsoleteLocationID1).
+				AddRow(obsoleteLocationID2))
+		// Single batch DELETE for obsolete locations
+		mock.ExpectExec(`DELETE FROM "location_classes" WHERE id IN \((\$\d+,)*\$\d+\)`).
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "location_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "course_schedules"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).
+				AddRow(keepScheduleID).
+				AddRow(obsoleteScheduleID1).
+				AddRow(obsoleteScheduleID2))
+		// Single batch DELETE for obsolete schedules
+		mock.ExpectExec(`DELETE FROM "course_schedules" WHERE id IN \((\$\d+,)*\$\d+\)`).
+			WillReturnResult(sqlmock.NewResult(0, 2))
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "course_schedules"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "cursos"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+
+		mock.ExpectCommit()
+
+		err := repo.Update(ctx, curso)
+		assert.NoError(t, err)
 	})
 }

--- a/internal/repository/curso_repository_test.go
+++ b/internal/repository/curso_repository_test.go
@@ -1762,4 +1762,156 @@ func TestCursoRepository_Update_HelperIntegration(t *testing.T) {
 		err := repo.Update(ctx, curso)
 		assert.NoError(t, err)
 	})
+
+	t.Run("update remoteClass batch delete schedules error aborts transaction", func(t *testing.T) {
+		db, mock, cleanup := SetupMockDB(t)
+		defer cleanup()
+		repo := NewCursoRepository(db)
+		ctx := context.Background()
+
+		existingRemoteID := uuid.New()
+		keepScheduleID := uuid.New()
+		obsoleteScheduleID := uuid.New()
+		curso := &models.Curso{
+			ID: 1,
+			RemoteClass: &models.RemoteClass{
+				ID:      existingRemoteID,
+				CursoID: 1,
+				Schedules: []models.RemoteSchedule{
+					{ID: keepScheduleID, Vacancies: 20},
+				},
+			},
+		}
+
+		mock.ExpectBegin()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id", "curso_id"}).AddRow(existingRemoteID, 1))
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "remote_schedules"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).
+				AddRow(keepScheduleID).
+				AddRow(obsoleteScheduleID))
+		mock.ExpectExec(`DELETE FROM "remote_schedules" WHERE id IN \((\$\d+,)*\$\d+\)`).
+			WillReturnError(assert.AnError)
+
+		mock.ExpectRollback()
+
+		err := repo.Update(ctx, curso)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "erro ao atualizar remote class")
+		assert.Contains(t, err.Error(), "erro ao deletar remote schedules obsoletos")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("update locationClasses batch delete locations error aborts transaction", func(t *testing.T) {
+		db, mock, cleanup := SetupMockDB(t)
+		defer cleanup()
+		repo := NewCursoRepository(db)
+		ctx := context.Background()
+
+		keepLocationID := uuid.New()
+		obsoleteLocationID := uuid.New()
+		curso := &models.Curso{
+			ID: 1,
+			LocationClasses: []models.LocationClass{
+				{
+					ID:      keepLocationID,
+					CursoID: 1,
+					Address: "Rua Keep",
+					Schedules: []models.CourseSchedule{
+						{ID: uuid.New(), Vacancies: 25},
+					},
+				},
+			},
+		}
+
+		mock.ExpectBegin()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).
+				AddRow(keepLocationID).
+				AddRow(obsoleteLocationID))
+		mock.ExpectExec(`DELETE FROM "location_classes" WHERE id IN \((\$\d+,)*\$\d+\)`).
+			WillReturnError(assert.AnError)
+
+		mock.ExpectRollback()
+
+		err := repo.Update(ctx, curso)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "erro ao atualizar location classes")
+		assert.Contains(t, err.Error(), "erro ao deletar location classes obsoletas")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("update locationClasses batch delete course schedules error aborts transaction", func(t *testing.T) {
+		db, mock, cleanup := SetupMockDB(t)
+		defer cleanup()
+		repo := NewCursoRepository(db)
+		ctx := context.Background()
+
+		locationID := uuid.New()
+		keepScheduleID := uuid.New()
+		obsoleteScheduleID := uuid.New()
+		curso := &models.Curso{
+			ID: 1,
+			LocationClasses: []models.LocationClass{
+				{
+					ID:      locationID,
+					CursoID: 1,
+					Address: "Rua Keep",
+					Schedules: []models.CourseSchedule{
+						{ID: keepScheduleID, Vacancies: 25},
+					},
+				},
+			},
+		}
+
+		mock.ExpectBegin()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "cursos"`)).
+			WillReturnError(gorm.ErrRecordNotFound)
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "custom_fields"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "remote_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 0))
+
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "location_classes"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(locationID))
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE "location_classes"`)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "course_schedules"`)).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).
+				AddRow(keepScheduleID).
+				AddRow(obsoleteScheduleID))
+		mock.ExpectExec(`DELETE FROM "course_schedules" WHERE id IN \((\$\d+,)*\$\d+\)`).
+			WillReturnError(assert.AnError)
+
+		mock.ExpectRollback()
+
+		err := repo.Update(ctx, curso)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "erro ao atualizar location classes")
+		assert.Contains(t, err.Error(), "erro ao deletar course schedules obsoletos")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
 }


### PR DESCRIPTION
## Summary
- No update de curso, remoção de horários/locais obsoletos passa a usar um único `DELETE ... WHERE id IN (?)` por tipo de entidade (`RemoteSchedule`, `LocationClass`, `CourseSchedule`), em vez de um DELETE por registro no loop.
- Chamadas GORM nessa sincronização agora checam `.Error` e fazem rollback da transação em caso de falha (antes falhavam em silêncio).

## Disclaimer
- Comportamento funcional permanece o mesmo (mesmos registros removidos); a mudança é de performance e de confiabilidade da transação.
- Não altera contrato da API nem o formato do payload de `PUT /api/v1/courses/{id}`.
- Validado localmente com create draft (múltiplos locations/schedules) → update mantendo um de cada → GET confirmando remoções; unitários de `curso_repository` e helpers de update passando.