### PR TITLE
fix(cursos): normaliza datas em meia-noite UTC para o dia em BRT

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -12246,10 +12246,12 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "enrollment_end_date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2026-08-23T23:59:59-03:00"
                 },
                 "enrollment_start_date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2026-08-01T00:00:00-03:00"
                 },
                 "expected_results": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12244,10 +12244,12 @@
                     "type": "string"
                 },
                 "enrollment_end_date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2026-08-23T23:59:59-03:00"
                 },
                 "enrollment_start_date": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2026-08-01T00:00:00-03:00"
                 },
                 "expected_results": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -800,8 +800,10 @@ definitions:
       description:
         type: string
       enrollment_end_date:
+        example: "2026-08-23T23:59:59-03:00"
         type: string
       enrollment_start_date:
+        example: "2026-08-01T00:00:00-03:00"
         type: string
       expected_results:
         type: string

--- a/internal/db/migrations/20260727120000_normalize_course_dates_timezone.sql
+++ b/internal/db/migrations/20260727120000_normalize_course_dates_timezone.sql
@@ -1,0 +1,171 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Normaliza campos de data de cursos gravados em MEIA-NOITE UTC (00:00:00Z) para
+-- o dia correto no fuso de Brasília (America/Sao_Paulo).
+--
+-- Contexto: a app-go-api passou a serializar timestamptz com offset -03:00 (antes: "Z").
+-- O client (superapp) exibe essas datas truncando a string (split('T')[0]).
+--   - enrollment_end_date = 2026-08-23T00:00:00Z
+--       antes (UTC):    "2026-08-23" -> exibia 23/08  (batia com a intenção por acaso)
+--       depois (-03:00): "2026-08-22T21:00:00-03:00" -> "2026-08-22" -> exibe 22/08 (-1 dia)
+-- Causa-raiz: datas de dia inteiro foram gravadas em 00:00 UTC (= 21:00 BRT do dia anterior),
+-- e não na meia-noite de Brasília. Esta migration reancora o INSTANTE ao dia pretendido:
+--   - *_start_date  -> INÍCIO do dia em BRT  (00:00:00-03:00 == 03:00Z)
+--   - *_end_date    -> FIM do dia em BRT     (23:59:59-03:00 == 02:59:59Z do dia seguinte)
+--
+-- Guarda: só toca valores cujo horário em UTC é EXATAMENTE 00:00:00. Timestamps reais
+-- (created_at/updated_at, ou datas já com hora, como 22:00Z) têm fração/hora != 0 e são ignorados.
+-- A lógica funcional (abrir/encerrar inscrição) compara instantes e não muda; isto corrige só a EXIBIÇÃO.
+--
+-- Idempotente: após a correção os valores ficam em 03:00Z (start) ou 02:59:59Z (end),
+-- que não casam mais com a guarda `::time = '00:00:00'`; re-executar é no-op.
+--
+-- Ordem importa: normaliza as TURMAS primeiro e só então re-deriva o período
+-- denormalizado do curso (min/max das turmas), espelhando ApplyDerivedEnrollmentPeriod
+-- do runtime. Sem isso, um curso com turmas mistas (uma em 00:00Z, outra com hora real)
+-- ficaria com o curso-nível defasado em relação à turma reancorada.
+
+DO $$
+DECLARE
+    v_cursos_end   int;
+    v_cs_end       int;
+    v_cs_start     int;
+    v_rs_end       int;
+    v_rs_start     int;
+    v_cursos_start int;
+BEGIN
+    SELECT count(*) INTO v_cursos_start FROM cursos
+        WHERE enrollment_start_date IS NOT NULL AND (enrollment_start_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+    SELECT count(*) INTO v_cursos_end FROM cursos
+        WHERE enrollment_end_date   IS NOT NULL AND (enrollment_end_date   AT TIME ZONE 'UTC')::time = time '00:00:00';
+    SELECT count(*) INTO v_cs_start FROM course_schedules
+        WHERE (class_start_date      IS NOT NULL AND (class_start_date      AT TIME ZONE 'UTC')::time = time '00:00:00')
+           OR (enrollment_start_date IS NOT NULL AND (enrollment_start_date AT TIME ZONE 'UTC')::time = time '00:00:00');
+    SELECT count(*) INTO v_cs_end FROM course_schedules
+        WHERE (class_end_date        IS NOT NULL AND (class_end_date        AT TIME ZONE 'UTC')::time = time '00:00:00')
+           OR (enrollment_end_date   IS NOT NULL AND (enrollment_end_date   AT TIME ZONE 'UTC')::time = time '00:00:00');
+    SELECT count(*) INTO v_rs_start FROM remote_schedules
+        WHERE (class_start_date      IS NOT NULL AND (class_start_date      AT TIME ZONE 'UTC')::time = time '00:00:00')
+           OR (enrollment_start_date IS NOT NULL AND (enrollment_start_date AT TIME ZONE 'UTC')::time = time '00:00:00');
+    SELECT count(*) INTO v_rs_end FROM remote_schedules
+        WHERE (class_end_date        IS NOT NULL AND (class_end_date        AT TIME ZONE 'UTC')::time = time '00:00:00')
+           OR (enrollment_end_date   IS NOT NULL AND (enrollment_end_date   AT TIME ZONE 'UTC')::time = time '00:00:00');
+
+    RAISE NOTICE 'normalize_course_dates_timezone: cursos(start=%, end=%) course_schedules(start=%, end=%) remote_schedules(start=%, end=%)',
+        v_cursos_start, v_cursos_end, v_cs_start, v_cs_end, v_rs_start, v_rs_end;
+END $$;
+
+-- ---------- END dates -> fim do dia em BRT (23:59:59 America/Sao_Paulo) ----------
+
+UPDATE cursos
+SET enrollment_end_date =
+    ((enrollment_end_date AT TIME ZONE 'UTC')::date + time '23:59:59') AT TIME ZONE 'America/Sao_Paulo'
+WHERE enrollment_end_date IS NOT NULL
+  AND (enrollment_end_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE course_schedules
+SET class_end_date =
+    ((class_end_date AT TIME ZONE 'UTC')::date + time '23:59:59') AT TIME ZONE 'America/Sao_Paulo'
+WHERE class_end_date IS NOT NULL
+  AND (class_end_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE course_schedules
+SET enrollment_end_date =
+    ((enrollment_end_date AT TIME ZONE 'UTC')::date + time '23:59:59') AT TIME ZONE 'America/Sao_Paulo'
+WHERE enrollment_end_date IS NOT NULL
+  AND (enrollment_end_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE remote_schedules
+SET class_end_date =
+    ((class_end_date AT TIME ZONE 'UTC')::date + time '23:59:59') AT TIME ZONE 'America/Sao_Paulo'
+WHERE class_end_date IS NOT NULL
+  AND (class_end_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE remote_schedules
+SET enrollment_end_date =
+    ((enrollment_end_date AT TIME ZONE 'UTC')::date + time '23:59:59') AT TIME ZONE 'America/Sao_Paulo'
+WHERE enrollment_end_date IS NOT NULL
+  AND (enrollment_end_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+-- ---------- START dates -> início do dia em BRT (00:00:00 America/Sao_Paulo) ----------
+
+UPDATE cursos
+SET enrollment_start_date =
+    ((enrollment_start_date AT TIME ZONE 'UTC')::date)::timestamp AT TIME ZONE 'America/Sao_Paulo'
+WHERE enrollment_start_date IS NOT NULL
+  AND (enrollment_start_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE course_schedules
+SET class_start_date =
+    ((class_start_date AT TIME ZONE 'UTC')::date)::timestamp AT TIME ZONE 'America/Sao_Paulo'
+WHERE class_start_date IS NOT NULL
+  AND (class_start_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE course_schedules
+SET enrollment_start_date =
+    ((enrollment_start_date AT TIME ZONE 'UTC')::date)::timestamp AT TIME ZONE 'America/Sao_Paulo'
+WHERE enrollment_start_date IS NOT NULL
+  AND (enrollment_start_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE remote_schedules
+SET class_start_date =
+    ((class_start_date AT TIME ZONE 'UTC')::date)::timestamp AT TIME ZONE 'America/Sao_Paulo'
+WHERE class_start_date IS NOT NULL
+  AND (class_start_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+UPDATE remote_schedules
+SET enrollment_start_date =
+    ((enrollment_start_date AT TIME ZONE 'UTC')::date)::timestamp AT TIME ZONE 'America/Sao_Paulo'
+WHERE enrollment_start_date IS NOT NULL
+  AND (enrollment_start_date AT TIME ZONE 'UTC')::time = time '00:00:00';
+
+-- ---------- Re-deriva o período de inscrição denormalizado do curso ----------
+-- Espelha models.ApplyDerivedEnrollmentPeriod: curso.enrollment_{start,end} =
+-- (menor abertura, maior fechamento) entre as turmas. Roda DEPOIS das turmas já
+-- normalizadas para não deixar o curso-nível defasado no caso de turmas mistas.
+-- Não toca LIVRE_FORMACAO_ONLINE (sem turmas; mantém as próprias datas — igual ao runtime).
+-- `IS DISTINCT FROM` restringe a escrita apenas aos cursos que realmente divergem.
+WITH turma_enroll AS (
+    SELECT lc.curso_id AS curso_id,
+           cs.enrollment_start_date AS es,
+           cs.enrollment_end_date   AS ee
+      FROM course_schedules cs
+      JOIN location_classes lc ON lc.id = cs.location_id
+     WHERE cs.enrollment_start_date IS NOT NULL
+       AND cs.enrollment_end_date   IS NOT NULL
+    UNION ALL
+    SELECT rc.curso_id,
+           rs.enrollment_start_date,
+           rs.enrollment_end_date
+      FROM remote_schedules rs
+      JOIN remote_classes rc ON rc.id = rs.remote_class_id
+     WHERE rs.enrollment_start_date IS NOT NULL
+       AND rs.enrollment_end_date   IS NOT NULL
+),
+agg AS (
+    SELECT curso_id, MIN(es) AS min_start, MAX(ee) AS max_end
+      FROM turma_enroll
+     GROUP BY curso_id
+)
+UPDATE cursos c
+SET enrollment_start_date = agg.min_start,
+    enrollment_end_date   = agg.max_end
+FROM agg
+WHERE c.id = agg.curso_id
+  AND c.modalidade <> 'LIVRE_FORMACAO_ONLINE'
+  AND (c.enrollment_start_date IS DISTINCT FROM agg.min_start
+       OR c.enrollment_end_date IS DISTINCT FROM agg.max_end);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Migration de normalização de dados: não é reversível de forma segura, pois o valor
+-- original (00:00:00Z) é indistinguível de datas legitimamente gravadas como início/fim
+-- de dia em BRT após esta correção. Faça snapshot/backup das tabelas cursos,
+-- course_schedules e remote_schedules antes de aplicar, caso precise reverter.
+SELECT 1;
+
+-- +goose StatementEnd

--- a/internal/models/curso.go
+++ b/internal/models/curso.go
@@ -60,8 +60,8 @@ type Curso struct {
 	// Core fields (always required)
 	Titulo              string      `json:"title" gorm:"type:varchar(20000);not null"`
 	Descricao           string      `json:"description" gorm:"type:text"`
-	EnrollmentStartDate *time.Time  `json:"enrollment_start_date" gorm:"type:timestamp with time zone;column:enrollment_start_date"`
-	EnrollmentEndDate   *time.Time  `json:"enrollment_end_date" gorm:"type:timestamp with time zone;column:enrollment_end_date"`
+	EnrollmentStartDate *time.Time  `json:"enrollment_start_date" gorm:"type:timestamp with time zone;column:enrollment_start_date" example:"2026-08-01T00:00:00-03:00"`
+	EnrollmentEndDate   *time.Time  `json:"enrollment_end_date" gorm:"type:timestamp with time zone;column:enrollment_end_date" example:"2026-08-23T23:59:59-03:00"`
 	Organization        string      `json:"organization" gorm:"type:varchar(20000)"`
 	Modalidade          Modalidade  `json:"modalidade" gorm:"type:varchar(50)"`
 	Theme               string      `json:"theme" gorm:"type:varchar(20000)"`

--- a/internal/models/inscricao.go
+++ b/internal/models/inscricao.go
@@ -129,10 +129,10 @@ type CourseSchedule struct {
 	ID                   uuid.UUID  `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
 	LocationID           uuid.UUID  `json:"location_id" gorm:"type:uuid;column:location_id;not null"`
 	Vacancies            int        `json:"vacancies" gorm:"not null;check:vacancies >= 1 AND vacancies <= 1000"`
-	EnrollmentStartDate  *time.Time `json:"enrollment_start_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_start_date"`
-	EnrollmentEndDate    *time.Time `json:"enrollment_end_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_end_date"`
-	ClassStartDate       time.Time  `json:"class_start_date" gorm:"type:timestamp with time zone;column:class_start_date;not null"`
-	ClassEndDate         time.Time  `json:"class_end_date" gorm:"type:timestamp with time zone;column:class_end_date;not null"`
+	EnrollmentStartDate  *time.Time `json:"enrollment_start_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_start_date" example:"2026-08-01T00:00:00-03:00"`
+	EnrollmentEndDate    *time.Time `json:"enrollment_end_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_end_date" example:"2026-08-23T23:59:59-03:00"`
+	ClassStartDate       time.Time  `json:"class_start_date" gorm:"type:timestamp with time zone;column:class_start_date;not null" example:"2026-09-01T00:00:00-03:00"`
+	ClassEndDate         time.Time  `json:"class_end_date" gorm:"type:timestamp with time zone;column:class_end_date;not null" example:"2026-12-15T23:59:59-03:00"`
 	ClassTime            string     `json:"class_time" gorm:"type:varchar(20000);column:class_time;not null"`
 	ClassDays            string     `json:"class_days" gorm:"type:varchar(20000);column:class_days;not null"`
 	DisplayOrder         int        `json:"display_order" gorm:"column:display_order;not null;default:0"`
@@ -155,10 +155,10 @@ type RemoteSchedule struct {
 	ID                   uuid.UUID  `json:"id" gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
 	RemoteClassID        uuid.UUID  `json:"remote_class_id" gorm:"type:uuid;column:remote_class_id;not null"`
 	Vacancies            int        `json:"vacancies" gorm:"not null;check:vacancies >= 1 AND vacancies <= 1000"`
-	EnrollmentStartDate  *time.Time `json:"enrollment_start_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_start_date"`
-	EnrollmentEndDate    *time.Time `json:"enrollment_end_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_end_date"`
-	ClassStartDate       *time.Time `json:"class_start_date,omitempty" gorm:"type:timestamp with time zone;column:class_start_date"`
-	ClassEndDate         *time.Time `json:"class_end_date,omitempty" gorm:"type:timestamp with time zone;column:class_end_date"`
+	EnrollmentStartDate  *time.Time `json:"enrollment_start_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_start_date" example:"2026-08-01T00:00:00-03:00"`
+	EnrollmentEndDate    *time.Time `json:"enrollment_end_date,omitempty" gorm:"type:timestamp with time zone;column:enrollment_end_date" example:"2026-08-23T23:59:59-03:00"`
+	ClassStartDate       *time.Time `json:"class_start_date,omitempty" gorm:"type:timestamp with time zone;column:class_start_date" example:"2026-09-01T00:00:00-03:00"`
+	ClassEndDate         *time.Time `json:"class_end_date,omitempty" gorm:"type:timestamp with time zone;column:class_end_date" example:"2026-12-15T23:59:59-03:00"`
 	ClassTime            *string    `json:"class_time,omitempty" gorm:"type:varchar(20000);column:class_time"`
 	ClassDays            *string    `json:"class_days,omitempty" gorm:"type:varchar(20000);column:class_days"`
 	DisplayOrder         int        `json:"display_order" gorm:"column:display_order;not null;default:0"`

--- a/internal/services/curso_service.go
+++ b/internal/services/curso_service.go
@@ -289,6 +289,79 @@ func (s *CursoService) validatePublishedCurso(curso *models.Curso) error {
 	return nil
 }
 
+// brtLocation is America/Sao_Paulo, resolved once. The server already pins
+// time.Local to it via setupTimezone; this falls back to time.Local if the tzdata
+// lookup fails for any reason.
+var brtLocation = mustLoadBRT()
+
+func mustLoadBRT() *time.Location {
+	if loc, err := time.LoadLocation("America/Sao_Paulo"); err == nil {
+		return loc
+	}
+	return time.Local
+}
+
+// isMidnightUTC reports whether t falls exactly on 00:00:00.000000000 UTC — the
+// signature of a day-granular date encoded as midnight UTC (e.g. a date-picker
+// value serialized without an explicit -03:00 offset). Real timestamps and dates
+// carrying a time-of-day have a non-zero UTC time and are left untouched.
+func isMidnightUTC(t time.Time) bool {
+	u := t.UTC()
+	return u.Hour() == 0 && u.Minute() == 0 && u.Second() == 0 && u.Nanosecond() == 0
+}
+
+// normalizeDayStartBRT re-anchors a midnight-UTC instant to 00:00:00 America/Sao_Paulo
+// of the same calendar day (start-of-day). No-op for nil, zero or non-midnight-UTC values.
+func normalizeDayStartBRT(t *time.Time) {
+	if t == nil || t.IsZero() || !isMidnightUTC(*t) {
+		return
+	}
+	u := t.UTC()
+	*t = time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, brtLocation)
+}
+
+// normalizeDayEndBRT re-anchors a midnight-UTC instant to 23:59:59 America/Sao_Paulo
+// of the same calendar day (end-of-day), keeping the whole intended day inside the
+// window. No-op for nil, zero or non-midnight-UTC values.
+func normalizeDayEndBRT(t *time.Time) {
+	if t == nil || t.IsZero() || !isMidnightUTC(*t) {
+		return
+	}
+	u := t.UTC()
+	*t = time.Date(u.Year(), u.Month(), u.Day(), 23, 59, 59, 0, brtLocation)
+}
+
+// normalizeCourseDates re-anchors day-granular date fields that arrived at midnight
+// UTC to the intended day in BRT: openings/starts to start-of-day, closings/ends to
+// end-of-day. Without this, the API's -03:00 serialization plus the client's
+// date-string truncation would render such dates one day early. Turma dates are
+// normalized here so the course-level enrollment window derived afterwards stays
+// consistent with them.
+func normalizeCourseDates(curso *models.Curso) {
+	normalizeDayStartBRT(curso.EnrollmentStartDate)
+	normalizeDayEndBRT(curso.EnrollmentEndDate)
+
+	for i := range curso.LocationClasses {
+		for j := range curso.LocationClasses[i].Schedules {
+			sched := &curso.LocationClasses[i].Schedules[j]
+			normalizeDayStartBRT(&sched.ClassStartDate)
+			normalizeDayEndBRT(&sched.ClassEndDate)
+			normalizeDayStartBRT(sched.EnrollmentStartDate)
+			normalizeDayEndBRT(sched.EnrollmentEndDate)
+		}
+	}
+
+	if curso.RemoteClass != nil {
+		for j := range curso.RemoteClass.Schedules {
+			sched := &curso.RemoteClass.Schedules[j]
+			normalizeDayStartBRT(sched.ClassStartDate)
+			normalizeDayEndBRT(sched.ClassEndDate)
+			normalizeDayStartBRT(sched.EnrollmentStartDate)
+			normalizeDayEndBRT(sched.EnrollmentEndDate)
+		}
+	}
+}
+
 // normalizeCurso normalizes data for consistency
 func (s *CursoService) normalizeCurso(curso *models.Curso) {
 	curso.Status = curso.Status.Normalize()
@@ -362,6 +435,11 @@ func (s *CursoService) normalizeCurso(curso *models.Curso) {
 			}
 		}
 	}
+
+	// Re-anchor day-granular dates gravadas em meia-noite UTC ao dia pretendido em
+	// BRT antes de derivar o período do curso, para o instante e o dia exibido no
+	// client ficarem corretos sob a serialização -03:00.
+	normalizeCourseDates(curso)
 
 	// Enrollment period is managed per turma. Backfill any turma missing its
 	// window from the course-level dates (backward compatibility with payloads

--- a/internal/services/curso_service_timezone_test.go
+++ b/internal/services/curso_service_timezone_test.go
@@ -1,0 +1,142 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prefeitura-rio/app-go-api/internal/models"
+	"github.com/prefeitura-rio/app-go-api/internal/services"
+)
+
+// mustParse is a tiny helper for building expected/input instants in tests.
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+// TestNormalizeCurso_MidnightUTCDates verifies that day-granular date fields stored
+// at midnight UTC are re-anchored to the intended BRT day (start-of-day for openings,
+// end-of-day for closings) so they display correctly under -03:00 serialization,
+// while values carrying a real time-of-day are left untouched.
+func TestNormalizeCurso_MidnightUTCDates(t *testing.T) {
+	ctx := context.Background()
+
+	newSvc := func(capture **models.Curso) *services.CursoService {
+		repo := &MockCursoRepository{
+			CreateFunc: func(_ context.Context, curso *models.Curso) (int, error) {
+				*capture = curso
+				return 1, nil
+			},
+			CreateLocationClassesFunc: func(_ context.Context, _ []models.LocationClass) error {
+				return nil
+			},
+		}
+		return services.NewCursoServiceWithInterface(repo)
+	}
+
+	utc := func(tm time.Time) string { return tm.UTC().Format(time.RFC3339) }
+
+	t.Run("midnight-UTC dates re-anchored to BRT day", func(t *testing.T) {
+		var created *models.Curso
+		svc := newSvc(&created)
+
+		curso := &models.Curso{
+			Titulo:     "Curso TZ",
+			Status:     models.StatusCursoOpened,
+			Modalidade: models.ModalidadePresencial,
+			LocationClasses: []models.LocationClass{
+				{
+					Address:      "Rua de Teste, 123",
+					Neighborhood: "Centro",
+					Schedules: []models.CourseSchedule{
+						{
+							Vacancies:           30,
+							EnrollmentStartDate: ptr(mustParse(t, "2027-03-01T00:00:00Z")),
+							EnrollmentEndDate:   ptr(mustParse(t, "2027-03-08T00:00:00Z")),
+							ClassStartDate:      mustParse(t, "2027-03-10T00:00:00Z"),
+							ClassEndDate:        mustParse(t, "2027-03-20T00:00:00Z"),
+							ClassTime:           "09:00-12:00",
+							ClassDays:           "Segunda a Sexta",
+						},
+					},
+				},
+			},
+		}
+
+		if _, err := svc.Create(ctx, curso); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+
+		sched := created.LocationClasses[0].Schedules[0]
+		// start-of-day BRT == 03:00Z ; end-of-day BRT (23:59:59-03) == 02:59:59Z do dia seguinte
+		if got := utc(sched.ClassStartDate); got != "2027-03-10T03:00:00Z" {
+			t.Errorf("ClassStartDate: got %s, want 2027-03-10T03:00:00Z", got)
+		}
+		if got := utc(sched.ClassEndDate); got != "2027-03-21T02:59:59Z" {
+			t.Errorf("ClassEndDate: got %s, want 2027-03-21T02:59:59Z", got)
+		}
+		if got := utc(*sched.EnrollmentStartDate); got != "2027-03-01T03:00:00Z" {
+			t.Errorf("EnrollmentStartDate: got %s, want 2027-03-01T03:00:00Z", got)
+		}
+		if got := utc(*sched.EnrollmentEndDate); got != "2027-03-09T02:59:59Z" {
+			t.Errorf("EnrollmentEndDate: got %s, want 2027-03-09T02:59:59Z", got)
+		}
+
+		// Course-level enrollment window is derived from the (already normalized) turmas.
+		if got := utc(*created.EnrollmentStartDate); got != "2027-03-01T03:00:00Z" {
+			t.Errorf("course EnrollmentStartDate: got %s, want 2027-03-01T03:00:00Z", got)
+		}
+		if got := utc(*created.EnrollmentEndDate); got != "2027-03-09T02:59:59Z" {
+			t.Errorf("course EnrollmentEndDate: got %s, want 2027-03-09T02:59:59Z", got)
+		}
+	})
+
+	t.Run("dates with real time-of-day are left untouched", func(t *testing.T) {
+		var created *models.Curso
+		svc := newSvc(&created)
+
+		// 13:00Z = 10:00 BRT, 22:00Z = 19:00 BRT — same calendar day in BRT, no shift needed.
+		start := mustParse(t, "2027-03-10T13:00:00Z")
+		end := mustParse(t, "2027-03-20T22:00:00Z")
+
+		curso := &models.Curso{
+			Titulo:     "Curso Hora Real",
+			Status:     models.StatusCursoOpened,
+			Modalidade: models.ModalidadePresencial,
+			LocationClasses: []models.LocationClass{
+				{
+					Address:      "Rua de Teste, 123",
+					Neighborhood: "Centro",
+					Schedules: []models.CourseSchedule{
+						{
+							Vacancies:      30,
+							ClassStartDate: start,
+							ClassEndDate:   end,
+							ClassTime:      "10:00-13:00",
+							ClassDays:      "Segunda a Sexta",
+						},
+					},
+				},
+			},
+		}
+
+		if _, err := svc.Create(ctx, curso); err != nil {
+			t.Fatalf("Create failed: %v", err)
+		}
+
+		sched := created.LocationClasses[0].Schedules[0]
+		if !sched.ClassStartDate.Equal(start) {
+			t.Errorf("ClassStartDate mudou: got %s, want %s", utc(sched.ClassStartDate), utc(start))
+		}
+		if !sched.ClassEndDate.Equal(end) {
+			t.Errorf("ClassEndDate mudou: got %s, want %s", utc(sched.ClassEndDate), utc(end))
+		}
+	})
+}
+
+func ptr(t time.Time) *time.Time { return &t }


### PR DESCRIPTION
### Contexto

A `app-go-api` passou a serializar `timestamptz` com offset de Brasília (`-03:00`) em vez de `Z` (commits de fuso 0631cd9 / d340c4b). O client (superapp) exibe as datas de curso **truncando a string ISO** (`split('T')[0]`).

Datas de "dia inteiro" (início/fim de inscrição e de turma) estavam gravadas em **meia-noite UTC** (`00:00:00Z`), que como instante é **21:00 BRT do dia anterior**. Com o novo offset, o dia exibido cai **-1**:

| Valor no banco | Serializado | Dia exibido no client |
|---|---|---|
| `2027-03-20T00:00:00Z` | `2027-03-19T21:00:00-03:00` | **19/03** ❌ (era 20) |

Isso afeta ~761 valores em produção (`enrollment_end_date` + `class_end_date`).

### Antes / Depois (curso 17, `enrollment_end_date` = meia-noite UTC)

<!-- Arraste os 2 PNGs aqui; o GitHub gera os links. Sugestão de layout: -->
|  Antes (bug) |  Depois (fix) |
|---|---|
| <img width="567" height="373" alt="image" src="https://github.com/user-attachments/assets/191cbb29-1177-4099-b51d-4371d3a51751" /> | <img width="407" height="375" alt="image" src="https://github.com/user-attachments/assets/1a441071-a50f-4958-9971-ae100b89c2f7" /> |

No "antes", o cabeçalho mostra **"Inscrições até 19 MAR"** enquanto a Turma 1 mostra **"20/03/2027"** — inconsistência de -1 dia. No "depois", cabeçalho e turma batem em **20**.

### Causa-raiz

Datas de dia inteiro gravadas em `00:00 UTC` em vez de `00:00 BRT`. O truncamento sobre-UTC do client "cancelava" o erro por acaso; a serialização `-03:00` o expõe. A **lógica funcional** (abrir/encerrar inscrição) compara instantes e **não muda**, só a exibição.

### Solução (2 frentes, ambas na app-go-api)

1. **Escrita futura** — `normalizeCourseDates` em `curso_service.go`, chamado no `normalizeCurso` **antes** de derivar o período do curso. Reancora valores em meia-noite UTC ao dia pretendido em BRT: `*_start` → `00:00:00-03:00`, `*_end` → `23:59:59-03:00`. Valores com hora real são preservados. Impede que cursos novos reintroduzam o bug.

2. **Dados existentes** — migration `20260727120000_normalize_course_dates_timezone.sql` aplica a mesma normalização em `cursos`, `course_schedules` e `remote_schedules`, e **re-deriva** o período denormalizado do curso a partir das turmas (espelha `ApplyDerivedEnrollmentPeriod`).

3. **Docs** — exemplos `-03:00` adicionados aos campos de data nos models + `swag init`.

### Detalhes técnicos

- **Idempotente**: guarda `(<col> AT TIME ZONE 'UTC')::time = '00:00:00'`; após a correção os valores viram `03:00Z`/`02:59:59Z` e não casam mais. Testado: 2ª execução da migration = todos `UPDATE 0`.
- **DST-safe**: usa `AT TIME ZONE 'America/Sao_Paulo'` (não offset fixo).
- **Consistência curso↔turma**: a migration normaliza turmas **antes** de re-derivar o curso-nível, evitando drift no caso de turmas mistas (uma em `00:00Z`, outra com hora real). `IS DISTINCT FROM` restringe a escrita só aos cursos que divergem.
- **Guarda precisa**: só `00:00:00.000000Z` exato → `created_at`/`updated_at` e datas com hora (ex. `22:00Z`) ficam intocadas.

### Plano de deploy / riscos

- ⚠️ A migration **muta dados de produção**: fazer **snapshot** de `cursos`, `course_schedules`, `remote_schedules` antes (o `down` não reconstrói valores).
- Subir a migration **junto/antes** do deploy que ativa `APP_TIMEZONE`, para não abrir janela com datas -1 dia.
- Impacto restrito à **exibição**; nenhuma mudança na regra de abrir/encerrar inscrição.