### PR TITLE
fix(jobs): preserva status processing durante atualizações de progresso no import em massa.

### DIFF
--- a/internal/jobs/job_processor.go
+++ b/internal/jobs/job_processor.go
@@ -65,6 +65,7 @@ func (p *JobProcessor) ProcessJob(jobID uuid.UUID) error {
 		log.Printf("Erro ao atualizar status do job %s para processing: %v", jobID, err)
 		return err
 	}
+	job.Status = models.JobStatusProcessing
 
 	var processingErr error
 

--- a/internal/jobs/job_processor_test.go
+++ b/internal/jobs/job_processor_test.go
@@ -525,6 +525,49 @@ func TestEnrollmentRow_CustomFields(t *testing.T) {
 	assert.Equal(t, "Valor2", row.CustomFields["Campo2"])
 }
 
+// TestJobUpdate_AfterUpdateStatus_KeepsProcessing covers the enrollment-import race:
+// UpdateStatus(processing) then an intermediate Update() with a stale pending struct
+// must leave status as processing (not overwrite via Save of in-memory pending).
+func TestJobUpdate_AfterUpdateStatus_KeepsProcessing(t *testing.T) {
+	db := setupTestDB(t)
+	jobRepo := repository.NewJobRepository(db)
+	jobService := services.NewJobService(jobRepo)
+	ctx := context.Background()
+
+	job := &models.Job{
+		ID:     uuid.New(),
+		Type:   models.JobTypeEnrollmentImport,
+		Status: models.JobStatusPending,
+	}
+	err := jobService.Create(ctx, job)
+	assert.NoError(t, err)
+
+	// Simulate job_processor: load once, then UpdateStatus without refreshing the struct
+	staleJob, err := jobService.GetByID(ctx, job.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, models.JobStatusPending, staleJob.Status)
+
+	err = jobService.UpdateStatus(ctx, job.ID, models.JobStatusProcessing)
+	assert.NoError(t, err)
+
+	fromDB, err := jobService.GetByID(ctx, job.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, models.JobStatusProcessing, fromDB.Status)
+
+	// Intermediate progress update with stale in-memory status still "pending"
+	staleJob.TotalRecords = 100
+	staleJob.Progress = 25
+	err = jobService.Update(ctx, staleJob)
+	assert.NoError(t, err)
+
+	afterUpdate, err := jobService.GetByID(ctx, job.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, models.JobStatusProcessing, afterUpdate.Status,
+		"intermediate Update must not overwrite processing back to pending")
+	assert.Equal(t, 100, afterUpdate.TotalRecords)
+	assert.Equal(t, 25, afterUpdate.Progress)
+}
+
 func TestProcessJob_JobStateTransitions(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/services/job_service.go
+++ b/internal/services/job_service.go
@@ -50,6 +50,12 @@ func (s *JobService) Update(ctx context.Context, job *models.Job) error {
 		return fmt.Errorf("job não encontrado")
 	}
 
+	// Status (and CompletedAt) are managed exclusively via UpdateStatus.
+	// Preserve DB values so a stale in-memory Job (e.g. still "pending" after
+	// UpdateStatus("processing")) cannot overwrite the current status via Save.
+	job.Status = existingJob.Status
+	job.CompletedAt = existingJob.CompletedAt
+
 	return s.repo.Update(ctx, job)
 }
 

--- a/internal/services/job_service_test.go
+++ b/internal/services/job_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/prefeitura-rio/app-go-api/internal/models"
@@ -25,6 +26,7 @@ type mockJobRepo struct {
 	updateCalls         int
 	updateStatusCalls   int
 	updateProgressCalls int
+	lastUpdatedJob      *models.Job
 }
 
 func (m *mockJobRepo) Create(ctx context.Context, j *models.Job) error {
@@ -47,6 +49,7 @@ func (m *mockJobRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Job, e
 
 func (m *mockJobRepo) Update(ctx context.Context, j *models.Job) error {
 	m.updateCalls++
+	m.lastUpdatedJob = j
 	return m.updateErr
 }
 
@@ -218,18 +221,21 @@ func TestJobService_Update(t *testing.T) {
 		updateErr   error
 		wantErr     bool
 		errContains string
+		wantStatus  models.JobStatus
 	}{
 		{
-			name: "success",
+			name: "success - preserves status from DB (does not overwrite via stale in-memory value)",
 			job: &models.Job{
-				ID:     existingID,
-				Type:   models.JobTypeEnrollmentImport,
-				Status: models.JobStatusCompleted,
+				ID:           existingID,
+				Type:         models.JobTypeEnrollmentImport,
+				Status:       models.JobStatusPending, // stale value from GetByID before UpdateStatus
+				TotalRecords: 100,
 			},
 			existingJob: &models.Job{
 				ID:     existingID,
 				Status: models.JobStatusProcessing,
 			},
+			wantStatus: models.JobStatusProcessing,
 		},
 		{
 			name: "job not found",
@@ -284,7 +290,54 @@ func TestJobService_Update(t *testing.T) {
 			if !tt.wantErr && repo.updateCalls != 1 {
 				t.Errorf("Update() expected 1 update call, got %d", repo.updateCalls)
 			}
+			if tt.wantStatus != "" && repo.lastUpdatedJob != nil {
+				if repo.lastUpdatedJob.Status != tt.wantStatus {
+					t.Errorf("Update() persisted status = %q, want %q (must not overwrite with stale in-memory status)",
+						repo.lastUpdatedJob.Status, tt.wantStatus)
+				}
+			}
 		})
+	}
+}
+
+// TestJobService_Update_AfterUpdateStatus_KeepsProcessing reproduces the enrollment-import
+// race: UpdateStatus(processing) then Update() with a stale pending struct must leave status as processing.
+func TestJobService_Update_AfterUpdateStatus_KeepsProcessing(t *testing.T) {
+	existingID := uuid.New()
+	completedAt := time.Now().Add(-time.Hour)
+
+	staleInMemory := &models.Job{
+		ID:           existingID,
+		Type:         models.JobTypeEnrollmentImport,
+		Status:       models.JobStatusPending, // never updated after UpdateStatus
+		TotalRecords: 50,
+		Progress:     10,
+		CompletedAt:  &completedAt, // stale pointer must not be written either
+	}
+
+	repo := &mockJobRepo{
+		entity: &models.Job{
+			ID:          existingID,
+			Status:      models.JobStatusProcessing,
+			CompletedAt: nil,
+		},
+	}
+	svc := services.NewJobServiceWithInterface(repo)
+	ctx := context.Background()
+
+	err := svc.Update(ctx, staleInMemory)
+	if err != nil {
+		t.Fatalf("Update() unexpected error: %v", err)
+	}
+	if repo.lastUpdatedJob.Status != models.JobStatusProcessing {
+		t.Errorf("status after intermediate Update = %q, want %q",
+			repo.lastUpdatedJob.Status, models.JobStatusProcessing)
+	}
+	if repo.lastUpdatedJob.CompletedAt != nil {
+		t.Errorf("CompletedAt should be preserved from DB (nil), got %v", repo.lastUpdatedJob.CompletedAt)
+	}
+	if repo.lastUpdatedJob.TotalRecords != 50 {
+		t.Errorf("TotalRecords = %d, want 50 (progress fields must still update)", repo.lastUpdatedJob.TotalRecords)
 	}
 }
 


### PR DESCRIPTION
## Fix: job fica como `pending` durante import em massa

### Problema

Durante o processamento de um import em massa via planilha, o status do job permanecia como `pending` para qualquer observador externo consultando a API, mesmo com o processamento já em andamento. O status só corrigia ao final, quando `UpdateStatus(completed)` era aplicado.

**Causa raiz:** condição de corrida entre `UpdateStatus()` e `Update()`:

1. `ProcessJob` carrega o job do banco (status=`pending`) e chama `UpdateStatus(processing)`, que atualiza apenas a coluna `status` no banco.
2. O struct em memória nunca era atualizado após esse `UpdateStatus()`.
3. `EnrollmentImportProcessor` chamava `jobService.Update(job)` para persistir progresso, passando o struct stale (status=`pending`).
4. `JobRepository.Update()` executava `tx.Save(job)`, sobrescrevendo o  `status=processing` do banco de volta para `pending`.

### Solução

Duas correções complementares:

- **`job_service.go` - `Update()`**: antes de salvar, recarrega `status` e `completed_at` do banco e os preserva no struct recebido. Garante que `Update()` nunca sobrescreva transições de status gerenciadas por `UpdateStatus()`.
- **`job_processor.go`**: sincroniza o struct em memória após chamar `UpdateStatus(processing)`, mantendo estado local consistente com o banco.

### Testes

- `TestJobUpdate_AfterUpdateStatus_KeepsProcessing`: cobre exatamente o cenário da race condition `UpdateStatus(processing)` seguido de `Update()` com struct stale não deve reverter o status para `pending`.
- Suite completa (`go test -race ./...`): todos os pacotes passando, sem regressões.