### PR TITLE
fix(empregabilidade): mapeia erros de DB para 400/404/409 nos handlers

### DIFF
--- a/internal/handlers/v1/empregabilidade/empresa_handler.go
+++ b/internal/handlers/v1/empregabilidade/empresa_handler.go
@@ -33,6 +33,7 @@ func (h *EmpresaHandler) WithCNPJConsulta(cnpjConsultaService *services.CNPJCons
 // @Param        request  body      empregabilidade.Empresa  true  "Dados da empresa"
 // @Success      201      {object}  empregabilidade.Empresa
 // @Failure      400      {object}  map[string]string
+// @Failure      409      {object}  map[string]string
 // @Failure      500      {object}  map[string]string
 // @Router       /api/v1/empregabilidade/empresas [post]
 func (h *EmpresaHandler) Create(c *gin.Context) {
@@ -44,7 +45,7 @@ func (h *EmpresaHandler) Create(c *gin.Context) {
 
 	cnpj, err := h.service.Create(c.Request.Context(), &entity)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -81,7 +82,7 @@ func (h *EmpresaHandler) List(c *gin.Context) {
 
 	entities, total, err := h.service.List(c.Request.Context(), filter, page, pageSize)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -109,7 +110,7 @@ func (h *EmpresaHandler) GetByID(c *gin.Context) {
 
 	entity, err := h.service.GetByID(c.Request.Context(), cnpj)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -144,7 +145,7 @@ func (h *EmpresaHandler) Update(c *gin.Context) {
 	entity.CNPJ = cnpj
 
 	if err := h.service.Update(c.Request.Context(), &entity); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -163,7 +164,7 @@ func (h *EmpresaHandler) Delete(c *gin.Context) {
 	cnpj := c.Param("cnpj")
 
 	if err := h.service.Delete(c.Request.Context(), cnpj); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 

--- a/internal/handlers/v1/empregabilidade/empresa_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/empresa_handler_test.go
@@ -97,6 +97,32 @@ func TestEmpresaHandler_Create_Error(t *testing.T) {
 	}
 }
 
+func TestEmpresaHandler_Create_UniqueViolation_Returns409(t *testing.T) {
+	repo := &mockEmpresaRepoEmpH{err: uniqueViolationErr("empresas_cnpj_key")}
+	r := setupEmpresaHandlerRouter(repo)
+	body := bytes.NewBufferString(`{"cnpj":"12345678000100","razao_social":"Empresa Teste"}`)
+	req := httptest.NewRequest(http.MethodPost, "/empresas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestEmpresaHandler_Create_NotNullViolation_Returns400(t *testing.T) {
+	repo := &mockEmpresaRepoEmpH{err: notNullViolationErr("razao_social")}
+	r := setupEmpresaHandlerRouter(repo)
+	body := bytes.NewBufferString(`{"cnpj":"12345678000100"}`)
+	req := httptest.NewRequest(http.MethodPost, "/empresas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestEmpresaHandler_List_Success(t *testing.T) {
 	repo := &mockEmpresaRepoEmpH{
 		listItems: []*empmodels.Empresa{{CNPJ: "12345678000100", RazaoSocial: "Empresa Teste"}},

--- a/internal/handlers/v1/empregabilidade/etapa_handler.go
+++ b/internal/handlers/v1/empregabilidade/etapa_handler.go
@@ -26,6 +26,7 @@ func NewEtapaHandler(service *services.EtapaService) *EtapaHandler {
 // @Param        request  body      empregabilidade.Etapa  true  "Dados da etapa"
 // @Success      201      {object}  empregabilidade.Etapa
 // @Failure      400      {object}  map[string]string
+// @Failure      409      {object}  map[string]string
 // @Failure      500      {object}  map[string]string
 // @Router       /api/v1/empregabilidade/vagas/{id}/etapas [post]
 func (h *EtapaHandler) Create(c *gin.Context) {
@@ -45,7 +46,7 @@ func (h *EtapaHandler) Create(c *gin.Context) {
 
 	id, err := h.service.Create(c.Request.Context(), &entity)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -71,7 +72,7 @@ func (h *EtapaHandler) ListByVaga(c *gin.Context) {
 
 	entities, err := h.service.ListByVaga(c.Request.Context(), vagaID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -98,7 +99,7 @@ func (h *EtapaHandler) GetByID(c *gin.Context) {
 
 	entity, err := h.service.GetByID(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -145,7 +146,7 @@ func (h *EtapaHandler) Update(c *gin.Context) {
 	entity.IDVaga = vagaID
 
 	if err := h.service.Update(c.Request.Context(), &entity); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -170,7 +171,7 @@ func (h *EtapaHandler) Delete(c *gin.Context) {
 	}
 
 	if err := h.service.Delete(c.Request.Context(), etapaID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 

--- a/internal/handlers/v1/empregabilidade/etapa_handler_test.go
+++ b/internal/handlers/v1/empregabilidade/etapa_handler_test.go
@@ -116,6 +116,32 @@ func TestEtapaHandler_Create_ServiceError(t *testing.T) {
 	}
 }
 
+func TestEtapaHandler_Create_UniqueViolation_Returns409(t *testing.T) {
+	repo := &mockEtapaRepoH{err: uniqueViolationErr("etapas_id_vaga_ordem_key")}
+	r := setupEtapaRouter(repo)
+	body := bodyOf(`{"nome":"Entrevista"}`)
+	req := httptest.NewRequest(http.MethodPost, "/vagas/"+validUUID+"/etapas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestEtapaHandler_Create_NotNullViolation_Returns400(t *testing.T) {
+	repo := &mockEtapaRepoH{err: notNullViolationErr("titulo")}
+	r := setupEtapaRouter(repo)
+	body := bodyOf(`{"nome":"Entrevista"}`)
+	req := httptest.NewRequest(http.MethodPost, "/vagas/"+validUUID+"/etapas", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestEtapaHandler_ListByVaga_Success(t *testing.T) {
 	repo := &mockEtapaRepoH{
 		listItems: []*empmodels.Etapa{{Titulo: "Triagem"}},

--- a/internal/handlers/v1/empregabilidade/lookup_handlers_test.go
+++ b/internal/handlers/v1/empregabilidade/lookup_handlers_test.go
@@ -82,8 +82,34 @@ func TestRegimeContratacaoHandler_Create_Error(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
-	if w.Code == http.StatusCreated {
-		t.Error("expected error status, got 201")
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestRegimeContratacaoHandler_Create_UniqueViolation_Returns409(t *testing.T) {
+	repo := &mockRegimeContratacaoRepoH{err: uniqueViolationErr("regimes_contratacao_descricao_key")}
+	r := setupRegimeContratacaoRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"CLT"}`)
+	req := httptest.NewRequest(http.MethodPost, "/regimes", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegimeContratacaoHandler_Create_NotNullViolation_Returns400(t *testing.T) {
+	repo := &mockRegimeContratacaoRepoH{err: notNullViolationErr("descricao")}
+	r := setupRegimeContratacaoRouter(repo)
+	body := bytes.NewBufferString(`{"descricao":"CLT"}`)
+	req := httptest.NewRequest(http.MethodPost, "/regimes", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/handlers/v1/empregabilidade/regime_contratacao_handler.go
+++ b/internal/handlers/v1/empregabilidade/regime_contratacao_handler.go
@@ -26,6 +26,7 @@ func NewRegimeContratacaoHandler(service *services.RegimeContratacaoService) *Re
 // @Param        request  body      empregabilidade.RegimeContratacao  true  "Dados do regime"
 // @Success      201      {object}  empregabilidade.RegimeContratacao
 // @Failure      400      {object}  map[string]string
+// @Failure      409      {object}  map[string]string
 // @Failure      500      {object}  map[string]string
 // @Router       /api/v1/empregabilidade/regimes-contratacao [post]
 func (h *RegimeContratacaoHandler) Create(c *gin.Context) {
@@ -37,7 +38,7 @@ func (h *RegimeContratacaoHandler) Create(c *gin.Context) {
 
 	id, err := h.service.Create(c.Request.Context(), &entity)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -67,7 +68,7 @@ func (h *RegimeContratacaoHandler) List(c *gin.Context) {
 
 	entities, total, err := h.service.List(c.Request.Context(), nil, page, pageSize)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -100,7 +101,7 @@ func (h *RegimeContratacaoHandler) GetByID(c *gin.Context) {
 
 	entity, err := h.service.GetByID(c.Request.Context(), id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -140,7 +141,7 @@ func (h *RegimeContratacaoHandler) Update(c *gin.Context) {
 	entity.ID = id
 
 	if err := h.service.Update(c.Request.Context(), &entity); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 
@@ -164,7 +165,7 @@ func (h *RegimeContratacaoHandler) Delete(c *gin.Context) {
 	}
 
 	if err := h.service.Delete(c.Request.Context(), id); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		handleLookupError(c, err)
 		return
 	}
 

--- a/internal/handlers/v1/empregabilidade/test_helpers_test.go
+++ b/internal/handlers/v1/empregabilidade/test_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+
+	"github.com/lib/pq"
 )
 
 var (
@@ -18,4 +20,12 @@ func bodyOf(s string) *bytes.Buffer {
 // bodyReader returns a reader that reports garbage JSON
 func garbageBody() *strings.Reader {
 	return strings.NewReader("not valid json")
+}
+
+func uniqueViolationErr(constraint string) error {
+	return &pq.Error{Code: pq.ErrorCode("23505"), Constraint: constraint}
+}
+
+func notNullViolationErr(column string) error {
+	return &pq.Error{Code: pq.ErrorCode("23502"), Column: column}
 }

--- a/internal/utils/error_handler.go
+++ b/internal/utils/error_handler.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
 )
 
@@ -25,15 +26,43 @@ const (
 	UnknownError
 )
 
+// pgErrorFields normaliza erros do lib/pq e do pgx (usado pelo GORM postgres driver).
+type pgErrorFields struct {
+	Code       string
+	Constraint string
+	Column     string
+}
+
+func extractPGErrorFields(err error) (pgErrorFields, bool) {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pgErrorFields{
+			Code:       string(pqErr.Code),
+			Constraint: pqErr.Constraint,
+			Column:     pqErr.Column,
+		}, true
+	}
+
+	var pgxErr *pgconn.PgError
+	if errors.As(err, &pgxErr) {
+		return pgErrorFields{
+			Code:       pgxErr.Code,
+			Constraint: pgxErr.ConstraintName,
+			Column:     pgxErr.ColumnName,
+		}, true
+	}
+
+	return pgErrorFields{}, false
+}
+
 // ParseDatabaseError analisa erros do PostgreSQL e retorna mensagens amigáveis
 func ParseDatabaseError(err error) *DatabaseError {
 	if err == nil {
 		return nil
 	}
 
-	// Verifica se é um erro do PostgreSQL
-	var pqErr *pq.Error
-	if !errors.As(err, &pqErr) {
+	fields, ok := extractPGErrorFields(err)
+	if !ok {
 		// In production, hide detailed error messages
 		return &DatabaseError{
 			Type:    UnknownError,
@@ -41,15 +70,15 @@ func ParseDatabaseError(err error) *DatabaseError {
 		}
 	}
 
-	switch pqErr.Code {
+	switch fields.Code {
 	case "23503": // foreign_key_violation
-		return parseForeignKeyError(pqErr)
+		return parseForeignKeyError(fields.Constraint)
 	case "23505": // unique_violation
-		return parseUniqueViolationError(pqErr)
+		return parseUniqueViolationError(fields.Constraint)
 	case "23502": // not_null_violation
-		return parseNotNullError(pqErr)
+		return parseNotNullError(fields.Column)
 	case "23514": // check_violation
-		return parseCheckViolationError(pqErr)
+		return parseCheckViolationError(fields.Constraint)
 	default:
 		return &DatabaseError{
 			Type:    UnknownError,
@@ -58,9 +87,7 @@ func ParseDatabaseError(err error) *DatabaseError {
 	}
 }
 
-func parseForeignKeyError(pqErr *pq.Error) *DatabaseError {
-	constraint := pqErr.Constraint
-
+func parseForeignKeyError(constraint string) *DatabaseError {
 	// Mapear constraints para mensagens amigáveis
 	switch {
 	case strings.Contains(constraint, "instituicao_id"):
@@ -101,9 +128,7 @@ func parseForeignKeyError(pqErr *pq.Error) *DatabaseError {
 	}
 }
 
-func parseUniqueViolationError(pqErr *pq.Error) *DatabaseError {
-	constraint := pqErr.Constraint
-
+func parseUniqueViolationError(constraint string) *DatabaseError {
 	switch {
 	case strings.Contains(constraint, "email"):
 		return &DatabaseError{
@@ -131,9 +156,7 @@ func parseUniqueViolationError(pqErr *pq.Error) *DatabaseError {
 	}
 }
 
-func parseNotNullError(pqErr *pq.Error) *DatabaseError {
-	column := pqErr.Column
-
+func parseNotNullError(column string) *DatabaseError {
 	// Mapear colunas para nomes amigáveis
 	fieldNames := map[string]string{
 		"titulo":       "título",
@@ -158,9 +181,7 @@ func parseNotNullError(pqErr *pq.Error) *DatabaseError {
 	}
 }
 
-func parseCheckViolationError(pqErr *pq.Error) *DatabaseError {
-	constraint := pqErr.Constraint
-
+func parseCheckViolationError(constraint string) *DatabaseError {
 	switch {
 	case strings.Contains(constraint, "modalidade"):
 		return &DatabaseError{

--- a/internal/utils/error_handler_test.go
+++ b/internal/utils/error_handler_test.go
@@ -2,9 +2,11 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
 )
 
@@ -236,5 +238,62 @@ func TestParseDatabaseError_UnknownCode(t *testing.T) {
 	}
 	if out.Message != "Erro interno do servidor" {
 		t.Errorf("unexpected Message: %s", out.Message)
+	}
+}
+
+func TestParseDatabaseError_PgxUniqueViolation(t *testing.T) {
+	err := &pgconn.PgError{Code: "23505", ConstraintName: "empresas_pkey"}
+	out := ParseDatabaseError(err)
+	if out == nil {
+		t.Fatal("expected non-nil")
+	}
+	if out.Type != UniqueViolation {
+		t.Errorf("expected UniqueViolation, got %d", out.Type)
+	}
+	if out.GetHTTPStatusCode() != 409 {
+		t.Errorf("expected HTTP 409, got %d", out.GetHTTPStatusCode())
+	}
+}
+
+func TestParseDatabaseError_PgxNotNullViolation(t *testing.T) {
+	err := &pgconn.PgError{Code: "23502", ColumnName: "descricao"}
+	out := ParseDatabaseError(err)
+	if out == nil {
+		t.Fatal("expected non-nil")
+	}
+	if out.Type != NotNullViolation {
+		t.Errorf("expected NotNullViolation, got %d", out.Type)
+	}
+	if out.GetHTTPStatusCode() != 400 {
+		t.Errorf("expected HTTP 400, got %d", out.GetHTTPStatusCode())
+	}
+}
+
+func TestParseDatabaseError_PgxWrappedUniqueViolation(t *testing.T) {
+	inner := &pgconn.PgError{Code: "23505", ConstraintName: "emp_regimes_contratacao_descricao_key"}
+	err := fmt.Errorf("erro ao criar regime: %w", inner)
+	out := ParseDatabaseError(err)
+	if out == nil {
+		t.Fatal("expected non-nil")
+	}
+	if out.Type != UniqueViolation {
+		t.Errorf("expected UniqueViolation, got %d", out.Type)
+	}
+	if out.GetHTTPStatusCode() != 409 {
+		t.Errorf("expected HTTP 409, got %d", out.GetHTTPStatusCode())
+	}
+}
+
+func TestParseDatabaseError_PgxForeignKeyViolation(t *testing.T) {
+	err := &pgconn.PgError{Code: "23503", ConstraintName: "emp_etapas_id_vaga_fkey"}
+	out := ParseDatabaseError(err)
+	if out == nil {
+		t.Fatal("expected non-nil")
+	}
+	if out.Type != ForeignKeyViolation {
+		t.Errorf("expected ForeignKeyViolation, got %d", out.Type)
+	}
+	if out.GetHTTPStatusCode() != 400 {
+		t.Errorf("expected HTTP 400, got %d", out.GetHTTPStatusCode())
 	}
 }


### PR DESCRIPTION
## Fix: erros de empregabilidade retornavam HTTP 500 indevidamente

### Problema

Os handlers `RegimeContratacaoHandler`, `EtapaHandler` e `EmpresaHandler` capturavam qualquer erro do service/repository e respondiam sempre com HTTP 500. Consumidores (superapp, portal-interno) não conseguiam distinguir erro de cliente de falha real de servidor.

Exemplo concreto: criar `Empresa` com CNPJ já cadastrado retornava **500** em vez de **409 Conflict**.

**Causa raiz (duas camadas):**

1. **Handlers** usavam `c.JSON(http.StatusInternalServerError, …)` em todos os erros de Create/List/GetByID/Update/Delete, em vez do padrão já estabelecido (`handleLookupError` / `ParseDatabaseError`) em `candidatura_handler`, `vaga_handler`, lookup handlers, etc.
2. **`ParseDatabaseError`** só reconhecia `*pq.Error` (`lib/pq`). Em runtime o GORM usa **pgx**, que devolve `*pgconn.PgError`. Com isso, mesmo após plugar o helper nos handlers, unique/FK/not-null continuavam caindo no fallback `"Erro interno do servidor"` → **500**.

### Solução

- **Handlers** (`regime_contratacao_handler`, `etapa_handler`, `empresa_handler`): trocam o 500 genérico por `handleLookupError`, que mapeia via `ParseDatabaseError`:
  - unique → **409**
  - FK / not-null / check → **400**
  - demais → **500**
  - GetByID com entidade `nil` permanece **404**
  - JSON inválido permanece **400** no `ShouldBindJSON`
- **`error_handler.go`**: `extractPGErrorFields` normaliza `*pq.Error` e `*pgconn.PgError` (incluindo erros wrapped com `%w`), para o mapeamento funcionar de verdade no ambiente com GORM/pgx.

### Testes

- Unit: `UniqueViolation_Returns409` e `NotNullViolation_Returns400` para Empresa, Etapa e Regime; testes novos de pgx em `error_handler_test.go` (incluindo erro wrapped).
- API local: Regime e Empresa — 409 (duplicata), 404 (ID inexistente), 400 (payload inválido); Etapa — 404 e 400.

### Nota

`emp_etapas` não tem unique constraint de negócio (só PK), então 409 por duplicata não é reproduzível via API nesse recurso.