### PR TITLE
fix: graceful shutdown do servidor HTTP

### DIFF
--- a/cmd/server/graceful_serve_test.go
+++ b/cmd/server/graceful_serve_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// noKeepAliveClient avoids lingering connections that race with other tests
+// mutating process-global state (e.g. time.Local).
+var noKeepAliveClient = &http.Client{
+	Transport: &http.Transport{DisableKeepAlives: true},
+	Timeout:   2 * time.Second,
+}
+
+func newListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln
+}
+
+func waitReady(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		resp, err := noKeepAliveClient.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not become ready: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestGracefulServe_CompletesInFlightRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "pong")
+	})
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		_, _ = io.WriteString(w, "done")
+	})
+
+	ln := newListener(t)
+	addr := ln.Addr().String()
+	srv := &http.Server{Handler: mux}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- gracefulServe(ctx, srv, ln, 2*time.Second)
+	}()
+	t.Cleanup(cancel)
+
+	waitReady(t, "http://"+addr+"/ping")
+
+	reqDone := make(chan string, 1)
+	go func() {
+		resp, err := noKeepAliveClient.Get("http://" + addr + "/slow")
+		if err != nil {
+			reqDone <- fmt.Sprintf("err: %v", err)
+			return
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		reqDone <- string(body)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request never started")
+	}
+
+	cancel() // trigger graceful shutdown while request is in flight
+
+	// ctx.Done() is closed synchronously with cancel(); release the handler
+	// only after that, so the slow handler finishes inside the drain window.
+	<-ctx.Done()
+	close(release)
+
+	select {
+	case body := <-reqDone:
+		if body != "done" {
+			t.Fatalf("in-flight request result = %q, want done", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight request did not complete during shutdown")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("gracefulServe returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("gracefulServe did not return")
+	}
+}
+
+func TestGracefulServe_RejectsNewConnectionsAfterShutdown(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+
+	ln := newListener(t)
+	addr := ln.Addr().String()
+	srv := &http.Server{Handler: mux}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- gracefulServe(ctx, srv, ln, time.Second)
+	}()
+
+	waitReady(t, "http://"+addr+"/")
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("gracefulServe returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("gracefulServe did not return")
+	}
+
+	_, err := noKeepAliveClient.Get("http://" + addr + "/")
+	if err == nil {
+		t.Fatal("expected connection error after shutdown, got nil")
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net"
+	"net/http"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 	// Embute a base de fusos (zoneinfo) no binário, para que
@@ -63,7 +67,6 @@ func main() {
 	if err := observability.InitTracer(cfg); err != nil {
 		log.Fatalf("Erro ao inicializar tracer: %v", err)
 	}
-	defer observability.ShutdownTracer()
 
 	// Run database migrations if enabled.
 	// Wire owns the primary DB connection; we open a short-lived connection
@@ -92,6 +95,11 @@ func main() {
 			Password: cfg.Redis.Password,
 			DB:       cfg.Redis.DB,
 		})
+		defer func() {
+			if err := workerRedis.Close(); err != nil {
+				log.Printf("Erro ao fechar conexão Redis do worker: %v", err)
+			}
+		}()
 
 		// Open a dedicated DB connection for the worker
 		workerDB, err := openDB(cfg)
@@ -128,17 +136,83 @@ func main() {
 	}
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
-	log.Printf("Servidor iniciado em %s", addr)
 
-	go func() {
-		if err := r.Run(addr); err != nil {
-			log.Fatalf("Erro ao iniciar o servidor: %v", err)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatalf("Erro ao abrir porta %s: %v", addr, err)
+	}
+	log.Printf("Servidor iniciado em %s", ln.Addr())
+
+	// Align shutdown drain window with the per-request timeout so in-flight
+	// handlers have a chance to finish before the process exits.
+	shutdownTimeout := time.Duration(cfg.Server.RequestTimeout) * time.Second
+	if shutdownTimeout <= 0 {
+		shutdownTimeout = 30 * time.Second
+	}
+
+	srv := &http.Server{Handler: r}
+	if err := gracefulServe(ctx, srv, ln, shutdownTimeout); err != nil {
+		log.Fatalf("Erro no servidor HTTP: %v", err)
+	}
+
+	// Flush any pending spans only after all in-flight HTTP requests have
+	// finished. Running this as a defer would race with the drain window.
+	observability.ShutdownTracer()
+}
+
+// gracefulServe serves on the pre-bound ln and blocks until ctx is cancelled,
+// then drains in-flight requests via Shutdown bounded by shutdownTimeout.
+// New connections are rejected as soon as Shutdown begins.
+// Returns only after all connection goroutines have fully exited.
+func gracefulServe(ctx context.Context, srv *http.Server, ln net.Listener, shutdownTimeout time.Duration) error {
+	var wg sync.WaitGroup
+	prev := srv.ConnState
+	srv.ConnState = func(conn net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateNew:
+			wg.Add(1)
+		case http.StateClosed, http.StateHijacked:
+			wg.Done()
 		}
+		if prev != nil {
+			prev(conn, state)
+		}
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		err := srv.Serve(ln)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
 	}()
 
-	<-ctx.Done()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("http server failed: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+	}
+
 	log.Println("Shutting down server...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("graceful shutdown failed: %w", err)
+	}
+
+	if err := <-errCh; err != nil {
+		return err
+	}
+
+	wg.Wait()
 	log.Println("Server shutdown complete")
+	return nil
 }
 
 // openDB opens a GORM database connection using the application configuration.

--- a/cmd/server/timezone_test.go
+++ b/cmd/server/timezone_test.go
@@ -21,6 +21,8 @@ func TestSetupTimezone_ApiSerializesWithBrasiliaOffset(t *testing.T) {
 	stored := time.Date(2026, 6, 27, 2, 59, 0, 0, time.UTC)
 
 	t.Run("sem fuso configurado (UTC) a API devolve Z (bug)", func(t *testing.T) {
+		orig := time.Local
+		t.Cleanup(func() { time.Local = orig })
 		time.Local = time.UTC
 		b, _ := json.Marshal(pgxLikeDecode(stored))
 		if got := string(b); got != `"2026-06-27T02:59:00Z"` {
@@ -29,6 +31,8 @@ func TestSetupTimezone_ApiSerializesWithBrasiliaOffset(t *testing.T) {
 	})
 
 	t.Run("com America/Sao_Paulo a API devolve -03:00", func(t *testing.T) {
+		orig := time.Local
+		t.Cleanup(func() { time.Local = orig })
 		setupTimezone("America/Sao_Paulo")
 		b, _ := json.Marshal(pgxLikeDecode(stored))
 		want := `"2026-06-26T23:59:00-03:00"`


### PR DESCRIPTION
## Problema

O servidor HTTP era iniciado com `r.Run(addr)` (Gin) dentro de uma goroutine. Ao receber `SIGTERM` — disparado a cada rollout do Argo Rollouts (blue-green em staging, canary em produção) — o processo apenas logava uma mensagem e encerrava imediatamente, derrubando todas as requisições em andamento com connection reset.

## Causa raiz

`r.Run()` não expõe um `http.Server` controlável. Sem uma referência ao servidor, não há como chamar `Shutdown(ctx)` para drenar as conexões ativas antes de o processo morrer. O código anterior simplesmente aguardava `ctx.Done()` e encerrava.

## Solução

Substituído `r.Run(addr)` por um `http.Server` explícito gerenciado pela nova função `gracefulServe()`:

- **`net.Listen` pré-bound**: o listener TCP é aberto antes de `gracefulServe` ser chamado, fazendo com que falhas de porta sejam detectadas na inicialização.
- **Drain com `Shutdown(ctx)`**: ao receber `SIGTERM`/`SIGINT`, o servidor para de aceitar novas conexões e aguarda que as requisições em andamento terminem dentro do `shutdownTimeout` (derivado de `SERVER_REQUEST_TIMEOUT`, padrão 30s).
- **`sync.WaitGroup` via `Server.ConnState`**: rastreia o ciclo de vida de cada conexão TCP até `StateClosed`/`StateHijacked`, garantindo que todas as goroutines internas do `net/http` tenham terminado antes de `gracefulServe` retornar — necessário para eliminar data race com `time.Local`.
- **`ShutdownTracer` pós-drain**: o flush de spans do OpenTelemetry é chamado explicitamente após `gracefulServe` retornar, garantindo que nenhum span de requisição em andamento seja perdido.
- **`workerRedis.Close()`**: o cliente Redis dedicado ao `OrgaoSyncWorker` agora é fechado corretamente via `defer`, evitando conexões órfãs a cada restart.

## Testes

**Testes unitários** (`cmd/server/graceful_serve_test.go`):
- `TestGracefulServe_CompletesInFlightRequest`: dispara uma requisição lenta, envia o sinal de shutdown via cancelamento de contexto e verifica que a resposta é entregue normalmente (`"done"`).
- `TestGracefulServe_RejectsNewConnectionsAfterShutdown`: verifica que novas conexões são recusadas após o shutdown.
- Ambos usam `net.Listener` pré-bound (elimina TOCTOU do padrão listen→close→rebind) e sincronização por canal (elimina `time.Sleep` não-determinístico).

**Teste ao vivo** (processo real local):
- Health check antes do `SIGTERM`: HTTP 200 ✅
- Requisição em voo completa normalmente após `SIGTERM`: HTTP 200 ✅
- Novas conexões rejeitadas após o sinal: `connection refused` ✅
- Processo encerrado de forma limpa: saída imediata sem erro ✅

**`just ci`**: lint + testes com `-race` passando ✅

## Nota

A data race detectada pelo `-race` em `timezone_test.go` foi corrigida como parte deste PR: goroutines internas do `net/http` liam `time.Local` (via `time.Now()` em `conn.setState`) enquanto os subtests de timezone o mutavam. O `wg.Wait()` ao final de `gracefulServe` garante que essas goroutines terminem antes que o teste retorne, eliminando a janela de corrida. Adicionalmente, cada subtest de timezone passou a salvar e restaurar `time.Local` individualmente, tornando o isolamento independente da ordem de execução.
